### PR TITLE
PERF: Determine image mime type only on demand, not always upfront on resolve

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -9,6 +9,8 @@ vivi.core changes
 
 - IR-77: Add `setup_timebased_jobs` xmlrpc method
 
+- PERF: Determine image mime type only on demand, not always upfront on resolve
+
 
 4.0.5 (2019-05-22)
 ------------------

--- a/core/src/zeit/content/gallery/workflow.txt
+++ b/core/src/zeit/content/gallery/workflow.txt
@@ -18,7 +18,6 @@ gallery:
 ...                         'browser', 'testdata', '01.jpg')
 ...     test_data = open(filename, 'rb').read()
 >>> image.open('w').write(open(filename).read())
->>> image.mimeType = 'image/jpeg'
 >>> folder['01.jpg'] = image
 >>> image = folder['01.jpg']
 

--- a/core/src/zeit/content/image/README.txt
+++ b/core/src/zeit/content/image/README.txt
@@ -78,14 +78,6 @@ The local image also has the title:
 >>> metadata.title
 u'my title'
 
-The repository image factory returns None when the image cannot be identified:
-
->>> import zeit.content.image.image
->>> connector = zope.component.getUtility(zeit.connector.interfaces.IConnector)
->>> zeit.content.image.image.ImageType().content(
-...     connector['http://xml.zeit.de/online/2007/01/Somalia']) is None
-True
-
 There is also a view for the metadata:
 
 >>> zope.component.getMultiAdapter((image, object()), name='metadata')

--- a/core/src/zeit/content/image/image.py
+++ b/core/src/zeit/content/image/image.py
@@ -11,22 +11,10 @@ import zeit.cms.workingcopy.interfaces
 import zeit.content.image.interfaces
 import zeit.workflow.interfaces
 import zeit.workflow.timebased
-import zope.app.container.contained
 import zope.app.container.interfaces
-import zope.app.file.image
 import zope.component
 import zope.interface
 import zope.security.proxy
-
-
-class Image(zope.app.file.image.Image,
-            zope.app.container.contained.Contained):
-    """Image contains exactly one image."""
-
-    zope.interface.implements(zeit.content.image.interfaces.IImage)
-    uniqueId = None
-
-    # XXX keep image class for migration
 
 
 class BaseImage(object):

--- a/core/src/zeit/content/image/image.py
+++ b/core/src/zeit/content/image/image.py
@@ -12,12 +12,34 @@ import zeit.content.image.interfaces
 import zeit.workflow.interfaces
 import zeit.workflow.timebased
 import zope.app.container.interfaces
+import zope.cachedescriptors.property
 import zope.component
 import zope.interface
 import zope.security.proxy
 
 
+class FakeWriteableCachedProperty(zope.cachedescriptors.property.Lazy):
+
+    def __set__(self, inst, value):
+        pass
+
+
 class BaseImage(object):
+
+    def __init__(self, uniqueId=None):
+        super(BaseImage, self).__init__(uniqueId, mimeType='')
+
+    # Not writeable since we always calculate it, but our superclasses want to.
+    @FakeWriteableCachedProperty
+    def mimeType(self):
+        data = self.open()
+        head = data.read(200)
+        data.close()
+        with magic.Magic(flags=magic.MAGIC_MIME_TYPE) as m:
+            file_type = m.id_buffer(head)
+        if not file_type.startswith('image/'):
+            return ''
+        return file_type
 
     def getImageSize(self):
         return PIL.Image.open(self.open()).size
@@ -27,7 +49,7 @@ class BaseImage(object):
         try:
             width, height = self.getImageSize()
             return float(width) / float(height)
-        except:
+        except Exception:
             return None
 
     @property
@@ -73,7 +95,7 @@ class TemporaryImage(LocalImage):
 @zope.component.adapter(RepositoryImage)
 @zope.interface.implementer(zeit.cms.workingcopy.interfaces.ILocalContent)
 def localimage_factory(context):
-    local = LocalImage(context.uniqueId, context.mimeType)
+    local = LocalImage(context.uniqueId)
     local.__name__ = context.__name__
     zeit.cms.interfaces.IWebDAVProperties(local).update(
         zeit.cms.interfaces.IWebDAVProperties(context))
@@ -110,13 +132,7 @@ class ImageType(zeit.cms.type.TypeDeclaration):
     factory = RepositoryImage
 
     def content(self, resource):
-        head = resource.data.read(200)
-        resource.data.close()
-        with magic.Magic(flags=magic.MAGIC_MIME_TYPE) as m:
-            file_type = m.id_buffer(head)
-        if not file_type.startswith('image/'):
-            return None
-        return self.factory(resource.id, file_type)
+        return self.factory(resource.id)
 
     def resource_body(self, content):
         return zope.security.proxy.removeSecurityProxy(content.open('r'))

--- a/core/src/zeit/content/image/testing.py
+++ b/core/src/zeit/content/image/testing.py
@@ -38,12 +38,7 @@ WEBDRIVER_LAYER = gocept.selenium.WebdriverSeleneseLayer(
 
 
 def create_local_image(filename, path='browser/testdata/'):
-    filetype = filename.rsplit('.', 1)[-1].lower()
-    if filetype == 'jpg':
-        image = zeit.content.image.image.LocalImage(mimeType='image/jpeg')
-    else:
-        image = zeit.content.image.image.LocalImage(
-            mimeType="image/{}".format(filetype))
+    image = zeit.content.image.image.LocalImage()
     fh = image.open('w')
     file_name = pkg_resources.resource_filename(
         __name__, '%s%s' % (path, filename))
@@ -81,7 +76,6 @@ def create_image_group_with_master_image(file_name=None):
     group.master_images = (('desktop', u'master-image' + extension),)
     repository['group'] = group
     image = zeit.content.image.image.LocalImage()
-    image.mimeType = mimetypes.types_map[extension]
     image.open('w').write(fh.read())
     repository['group'][group.master_image] = image
     return repository['group']

--- a/core/src/zeit/content/image/tests/test_image.py
+++ b/core/src/zeit/content/image/tests/test_image.py
@@ -52,7 +52,6 @@ class TestImageXMLReference(zeit.cms.testing.FunctionalTestCase):
     def test_master_image_without_filename_extension_sets_mime_as_type(self):
         fh = self.repository['2006']['DSC00109_2.JPG'].open()
         image = zeit.content.image.image.LocalImage()
-        image.mimeType = 'image/jpeg'
         image.open('w').write(fh.read())
         self.repository['example-image'] = image
         ref = zope.component.getAdapter(

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -27,7 +27,6 @@ class CreateVariantImageTest(zeit.cms.testing.FunctionalTestCase):
 
     def create_image(self, pil_image):
         image = zeit.content.image.image.LocalImage()
-        image.mimeType = 'image/png'
         pil_image.save(image.open('w'), 'PNG')
         return image
 

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -172,9 +172,6 @@ class ImageTransform(object):
         image = zeit.content.image.image.TemporaryImage()
         if not format:
             format = self.context.format
-            image.mimeType = self.context.mimeType
-        else:
-            image.mimeType = 'image/' + format.lower()  # XXX crude heuristic.
         # XXX Maybe encoder setting should be made configurable.
         if format in ('JPG', 'JPEG'):
             options = {'progressive': True, 'quality': 85, 'optimize': True}


### PR DESCRIPTION
This saves a lot of unnecessary effort, e.g. when we only resolve an object to read its workflow properties or some such, and are not interested in its intrinsic properties at all. Also, while we only have read the first few bytes for the identification, zeit.connector always has to read the whole body, which then uses quite a bit of RAM.

Since be8134d we don't set the mime type explicitly anyway, and only use detection, so we don't lose any functionality here. We do lose the  safetybelt of "don't even resolve it if it's not an image/ mime type", but the only situation where that could be relevant is data corruption, and then an exception later on is fine as well, I think.