### PR TITLE
IR-66: Retry webhook on errors

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- IR-66: Retry webhook on errors
 
 
 4.4.0 (2019-06-20)

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -1,9 +1,11 @@
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.sources import Product
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
+import celery.exceptions
 import lxml.objectify
 import mock
 import plone.testing
+import requests.exceptions
 import zeit.cms.checkout.webhook
 import zeit.cms.testing
 
@@ -66,6 +68,18 @@ class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
         with checked_out(self.repository['testcontent']):
             pass
         self.assertEqual([], self.layer['request_handler'].requests)
+
+    def test_retry_on_technical_error(self):
+        self.layer['request_handler'].response_code = [503, 200]
+        with self.assertRaises(celery.exceptions.Retry):
+            with checked_out(self.repository['testcontent']):
+                pass
+
+    def test_no_retry_on_semantic_error(self):
+        self.layer['request_handler'].response_code = [400, 200]
+        with self.assertRaises(requests.exceptions.HTTPError):
+            with checked_out(self.repository['testcontent']):
+                pass
 
 
 class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -33,7 +33,7 @@ class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
         self.patch.start()
         source = zeit.cms.checkout.webhook.HOOKS.factory
         # XXX Have to pass the instance because of zc.factory init shenanigans.
-        source.getValues.invalidate(source)
+        source._values.invalidate(source)
 
     def tearDown(self):
         self.patch.stop()

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -1,6 +1,7 @@
 from zeit.cms.application import CONFIG_CACHE
 from zeit.cms.content.interfaces import ICommonMetadata
 from zeit.cms.interfaces import ITypeDeclaration
+import collections
 import grokcore.component as grok
 import logging
 import requests
@@ -20,7 +21,8 @@ def notify_after_checkin(context, event):
     if event.publishing:
         return
     # XXX Work around redis/ZODB race condition, see BUG-796.
-    notify_webhooks.apply_async((context.uniqueId,), countdown=5)
+    for hook in HOOKS:
+        notify_webhook.apply_async((context.uniqueId, hook.url), countdown=5)
 
 
 @grok.subscribe(zope.lifecycleevent.IObjectAddedEvent)
@@ -33,17 +35,21 @@ def notify_after_add(event):
     if zeit.cms.workingcopy.interfaces.IWorkingcopy.providedBy(
             event.newParent):
         return
-    notify_webhooks.delay(context.uniqueId)
+    for hook in HOOKS:
+        notify_webhook.delay(context.uniqueId, hook.url)
 
 
 @zeit.cms.celery.task(queuename='webhook')
-def notify_webhooks(uniqueId):
+def notify_webhook(uniqueId, url):
     content = zeit.cms.interfaces.ICMSContent(uniqueId, None)
     if content is None:
         log.warning('Could not resolve %s, ignoring.', uniqueId)
         return
-    for hook in HOOKS:
-        hook(content)
+    hook = HOOKS.factory.find(url)
+    if hook is None:
+        log.warning('Hook configuration for %s has vanished, ignoring.', url)
+        return
+    hook(content)
 
 
 class Hook(object):
@@ -92,15 +98,21 @@ class HookSource(zeit.cms.content.sources.SimpleXMLSource):
     config_url = 'checkin-webhook-config'
 
     @CONFIG_CACHE.cache_on_arguments()
-    def getValues(self):
-        result = []
+    def _values(self):
+        result = collections.OrderedDict()
         tree = self._get_tree()
         for node in tree.iterchildren('webhook'):
             hook = Hook(node.get('url'))
             for exclude in node.xpath('exclude/*'):
                 hook.add_exclude(exclude.tag, exclude.text)
-            result.append(hook)
+            result[hook.url] = hook
         return result
+
+    def getValues(self):
+        return self._values().values()
+
+    def find(self, url):
+        return self._values().get(url)
 
 
 HOOKS = HookSource()

--- a/core/src/zeit/cms/testing.py
+++ b/core/src/zeit/cms/testing.py
@@ -221,6 +221,9 @@ def celery_ping():
 
 class RecordingRequestHandler(gocept.httpserverlayer.custom.RequestHandler):
 
+    response_code = 200
+    response_body = '{}'
+
     def do_GET(self):
         length = int(self.headers.get('content-length', 0))
         self.requests.append(dict(
@@ -228,9 +231,17 @@ class RecordingRequestHandler(gocept.httpserverlayer.custom.RequestHandler):
             path=self.path,
             body=self.rfile.read(length) if length else None,
         ))
-        self.send_response(self.response_code)
+        if isinstance(self.response_code, int):
+            status = self.response_code
+        else:
+            status = self.response_code.pop(0)
+        if isinstance(self.response_body, basestring):
+            body = self.response_body
+        else:
+            body = self.response_body.pop(0)
+        self.send_response(status)
         self.end_headers()
-        self.wfile.write(self.response_body)
+        self.wfile.write(body)
 
     do_POST = do_GET
     do_PUT = do_GET


### PR DESCRIPTION
This ensures nothing is lost while we restart the contenthub processes (including the HTTP API) for a config update.