### PR TITLE
ZON-5241: Replace FunctionalTestSetup with plone.testing layers

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,7 @@ setup(
         'martian',
         'mock',
         'persistent',
-        'plone.testing',
+        'plone.testing[zca,zodb]',
         'pypandoc',
         'pyramid_dogpile_cache2',
         'pytest',

--- a/core/setup.py
+++ b/core/setup.py
@@ -121,7 +121,6 @@ setup(
         'zope.app.server',
         'zope.app.testing',
         'zope.app.wsgi',
-        'zope.app.zcmlfiles',
         'zope.app.zopeappgenerations',
         'zope.authentication',
         'zope.browser',

--- a/core/src/zeit/addcentral/testing.py
+++ b/core/src/zeit/addcentral/testing.py
@@ -5,16 +5,20 @@ import zeit.content.image.testing
 
 
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=(
-        zeit.content.image.testing.product_config +
-        zeit.cms.testing.cms_product_config))
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+    bases=(zeit.content.image.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(
     name='WebdriverLayer', bases=(HTTP_LAYER,))
 SELENIUM_LAYER = gocept.selenium.WebdriverSeleneseLayer(
     name='SeleniumLayer', bases=(WD_LAYER,))
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/arbeit/testing.py
+++ b/core/src/zeit/arbeit/testing.py
@@ -2,45 +2,31 @@ import plone.testing
 import zeit.cms.testing
 import zeit.cms.repository.interfaces
 import zeit.content.article.testing
-import zeit.content.cp.testing
-import zeit.push.testing
 import zope.component
-import pkg_resources
-
-product_config = """\
-<product-config zeit.arbeit>
-</product-config>
-""".format(base=pkg_resources.resource_filename(__name__, ''))
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=(
-        product_config +
-        zeit.cms.testing.cms_product_config +
-        zeit.content.article.testing.product_config +
-        zeit.content.cp.testing.product_config +
-        zeit.push.testing.product_config
-    ))
-
-
-class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
-
-    layer = ZCML_LAYER
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(
+    zeit.content.article.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
 class Layer(plone.testing.Layer):
 
-    defaultBases = (ZCML_LAYER,)
+    defaultBases = (ZOPE_LAYER,)
 
     def testSetUp(self):
-        with zeit.cms.testing.site(self['functional_setup'].getRootFolder()):
+        with zeit.cms.testing.site(self['zodbApp']):
             repository = zope.component.getUtility(
                 zeit.cms.repository.interfaces.IRepository)
             repository['arbeit'] = zeit.cms.repository.folder.Folder()
 
 LAYER = Layer()
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(LAYER,))
 
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(LAYER,))
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/brightcove/tests/test_convert.py
+++ b/core/src/zeit/brightcove/tests/test_convert.py
@@ -5,14 +5,11 @@ import mock
 import pytz
 import zeit.brightcove.testing
 import zeit.cms.tagging.testing
-import zeit.cms.testing
 import zeit.content.video.playlist
 
 
-class VideoTest(zeit.cms.testing.FunctionalTestCase,
+class VideoTest(zeit.brightcove.testing.FunctionalTestCase,
                 zeit.cms.tagging.testing.TaggingHelper):
-
-    layer = zeit.brightcove.testing.LAYER
 
     def test_converts_cms_fields_to_bc_names(self):
         cms = CMSVideo()
@@ -199,9 +196,7 @@ class VideoTest(zeit.cms.testing.FunctionalTestCase,
         self.assertTrue(cms.commentsAllowed)
 
 
-class PlaylistTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.brightcove.testing.LAYER
+class PlaylistTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def test_converts_video_list(self):
         bc = zeit.brightcove.convert.Playlist()

--- a/core/src/zeit/brightcove/tests/test_resolve.py
+++ b/core/src/zeit/brightcove/tests/test_resolve.py
@@ -2,12 +2,9 @@ import logging
 import mock
 import unittest
 import zeit.brightcove.testing
-import zeit.cms.testing
 
 
-class VideoIdResolverTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.cms.testing.ZCML_LAYER
+class VideoIdResolverTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def test_video_id_should_be_resolved_to_unique_id(self):
         with mock.patch('zeit.connector.mock.Connector.search') as search:
@@ -72,9 +69,8 @@ class QueryVideoIdTest(unittest.TestCase):
                                mock.sentinel.default))
 
 
-class BackwardCompatibleUniqueIdsTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.brightcove.testing.LAYER
+class BackwardCompatibleUniqueIdsTest(
+        zeit.brightcove.testing.FunctionalTestCase):
 
     def test_videos_should_be_resolvable(self):
         from zeit.cms.interfaces import ICMSContent

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -6,14 +6,11 @@ import pytz
 import transaction
 import zeit.brightcove.testing
 import zeit.cms.content.interfaces
-import zeit.cms.testing
 import zeit.cms.workflow.interfaces
 import zeit.content.video.video
 
 
-class ImportVideoTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.brightcove.testing.LAYER
+class ImportVideoTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def create_video(self):
         bc = zeit.brightcove.convert.Video()
@@ -152,9 +149,7 @@ class ImportVideoTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual(('William Shakespeare',), video.authors)
 
 
-class ImportPlaylistTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.brightcove.testing.LAYER
+class ImportPlaylistTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def create_playlist(self):
         bc = zeit.brightcove.convert.Playlist()
@@ -212,9 +207,7 @@ class ImportPlaylistTest(zeit.cms.testing.FunctionalTestCase):
             None, ICMSContent('http://xml.zeit.de/video/playlist/other', None))
 
 
-class ExportTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.brightcove.testing.LAYER
+class ExportTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def setUp(self):
         super(ExportTest, self).setUp()

--- a/core/src/zeit/campus/testing.py
+++ b/core/src/zeit/campus/testing.py
@@ -20,18 +20,13 @@ product_config = """\
 """.format(base=pkg_resources.resource_filename(__name__, ''))
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=(
-        product_config +
-        zeit.cms.testing.cms_product_config +
-        zeit.push.testing.product_config +
-        zeit.content.article.testing.product_config +
-        zeit.content.cp.testing.product_config +
-        zeit.content.gallery.testing.product_config +
-        zeit.content.link.testing.product_config))
-
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.content.article.testing.CONFIG_LAYER,
+    zeit.content.link.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 PUSH_LAYER = zeit.push.testing.UrbanairshipTemplateLayer(
-    name='UrbanairshipTemplateLayer', bases=(ZCML_LAYER,))
+    name='UrbanairshipTemplateLayer', bases=(ZOPE_LAYER,))
 
 
 class Layer(plone.testing.Layer):
@@ -39,7 +34,7 @@ class Layer(plone.testing.Layer):
     defaultBases = (PUSH_LAYER,)
 
     def testSetUp(self):
-        with zeit.cms.testing.site(self['functional_setup'].getRootFolder()):
+        with zeit.cms.testing.site(self['zodbApp']):
             repository = zope.component.getUtility(
                 zeit.cms.repository.interfaces.IRepository)
             campus = zeit.cms.repository.folder.Folder()
@@ -50,13 +45,18 @@ class Layer(plone.testing.Layer):
 LAYER = Layer()
 
 
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(
     name='WebdriverLayer', bases=(HTTP_LAYER,))
 SELENIUM_LAYER = gocept.selenium.WebdriverSeleneseLayer(
     name='WebdriverSeleneseLayer', bases=(WD_LAYER,))
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/campus/tests/test_article.py
+++ b/core/src/zeit/campus/tests/test_article.py
@@ -1,11 +1,8 @@
 import zeit.campus.testing
-import zeit.cms.testing
 import zope.interface.verify
 
 
-class TopicTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.campus.testing.ZCML_LAYER
+class TopicTest(zeit.campus.testing.FunctionalTestCase):
 
     def test_topic_should_adapt_content_properly(self):
         content = self.repository['testcontent']

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -16,7 +16,7 @@ HTTP_LAYER = zeit.cms.testing.HTTPLayer(
 
 
 WEBHOOK_LAYER = plone.testing.Layer(
-    bases=(zeit.cms.testing.ZCML_LAYER, HTTP_LAYER),
+    bases=(zeit.cms.testing.ZOPE_LAYER, HTTP_LAYER),
     name='WebhookLayer', module=__name__)
 
 

--- a/core/src/zeit/cms/content/tests/test_reference.py
+++ b/core/src/zeit/cms/content/tests/test_reference.py
@@ -37,9 +37,10 @@ class ReferenceFixture(object):
         zope.security.protectclass.protectSetAttribute(
             ExampleReference, 'foo', 'zope.Public')
 
-        self.zca.patch_adapter(
+        registry = zope.component.getGlobalSiteManager()
+        registry.registerAdapter(
             zeit.cms.related.related.BasicReference, name='test')
-        self.zca.patch_adapter(ExampleReference, name='test')
+        registry.registerAdapter(ExampleReference, name='test')
 
         self.repository['content'] = ExampleContentType()
         self.repository['target'] = ExampleContentType()

--- a/core/src/zeit/cms/content/tests/test_sources.py
+++ b/core/src/zeit/cms/content/tests/test_sources.py
@@ -67,7 +67,7 @@ class AddableCMSContentTypeSourceTest(zeit.cms.testing.ZeitCmsTestCase):
         class IFoo(zeit.cms.interfaces.ICMSContent):
             pass
 
-        self.zca.patch_utility(
+        zope.component.getGlobalSiteManager().registerUtility(
             IFoo, zeit.cms.content.interfaces.IAddableContent, 'IFoo')
         self.assertIn(
             IFoo,

--- a/core/src/zeit/cms/relation/tests/test_corehandlers.py
+++ b/core/src/zeit/cms/relation/tests/test_corehandlers.py
@@ -6,9 +6,7 @@ import zeit.cms.related.interfaces
 import zeit.cms.relation.corehandlers
 
 
-class CorehandlerTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.cms.testing.ZCML_LAYER
+class CorehandlerTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
         from zeit.cms.testcontenttype.testcontenttype import ExampleContentType

--- a/core/src/zeit/cms/repository/tests/test_copypastemove.py
+++ b/core/src/zeit/cms/repository/tests/test_copypastemove.py
@@ -37,7 +37,7 @@ class MoveContentBaseTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_move_event_has_correct_oldparent(self):
         move = mock.Mock()
-        self.zca.patch_handler(
+        zope.component.getGlobalSiteManager().registerHandler(
             move, (zope.lifecycleevent.interfaces.IObjectMovedEvent,))
         content = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/online/2007/01/Somalia')

--- a/core/src/zeit/cms/retractlog/tests/test_retractlog.py
+++ b/core/src/zeit/cms/retractlog/tests/test_retractlog.py
@@ -2,12 +2,9 @@ from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 from zeit.cms.workflow.interfaces import IPublishInfo
 import zeit.cms.testing
 import zeit.cms.retractlog.retractlog
-import mock
 
 
-class RetractLogTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.cms.testing.ZCML_LAYER
+class RetractLogTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_start_job_retracts_urls(self):
         self.repository['foo'] = ExampleContentType()

--- a/core/src/zeit/cms/section/testing.py
+++ b/core/src/zeit/cms/section/testing.py
@@ -8,15 +8,16 @@ import zope.interface
 
 
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
+    'ftesting.zcml', bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
 class SectionLayer(plone.testing.Layer):
 
-    defaultBases = (ZCML_LAYER,)
+    defaultBases = (ZOPE_LAYER,)
 
     def testSetUp(self):
-        with zeit.cms.testing.site(self['functional_setup'].getRootFolder()):
+        with zeit.cms.testing.site(self['zodbApp']):
             repository = zope.component.getUtility(
                 zeit.cms.repository.interfaces.IRepository)
             example = zeit.cms.repository.folder.Folder()

--- a/core/src/zeit/connector/connector.py
+++ b/core/src/zeit/connector/connector.py
@@ -786,11 +786,9 @@ class Connector(object):
         import zope.app.appsetup.product
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.connector')
-        document_store = (config or {}).get('document-store')
-        if not document_store:
-            raise ZConfig.ConfigurationError(
-                cls.long_name + " not configured properly.")
-        return cls(dict(default=document_store))
+        return cls({
+            'default': config['document-store'],
+            'search': config['document-store-search']})
 
 
 connector_factory = Connector.factory

--- a/core/src/zeit/connector/connector.txt
+++ b/core/src/zeit/connector/connector.txt
@@ -10,7 +10,7 @@ Creating a connector:
 >>> connector = zope.component.getUtility(zeit.connector.interfaces.IConnector)
 
 >>> connector
-<zeit.connector.connector.Connector object at 0x...>
+<zeit.connector.connector... object at 0x...>
 
 
 IConnector Interface

--- a/core/src/zeit/connector/ftesting-filesystem.zcml
+++ b/core/src/zeit/connector/ftesting-filesystem.zcml
@@ -1,7 +1,7 @@
 <configure
   xmlns="http://namespaces.zope.org/zope">
 
-  <include package="zope.app.zcmlfiles" />
+  <include package="zeit.cms" file="application.zcml" />
 
   <include package="zeit.connector" />
   <include package="zeit.connector" file="filesystem-connector.zcml" />

--- a/core/src/zeit/connector/ftesting-mock.zcml
+++ b/core/src/zeit/connector/ftesting-mock.zcml
@@ -1,7 +1,7 @@
 <configure
   xmlns="http://namespaces.zope.org/zope">
 
-  <include package="zope.app.zcmlfiles" />
+  <include package="zeit.cms" file="application.zcml" />
 
   <include package="zeit.connector" />
   <include package="zeit.connector" file="mock-connector.zcml" />

--- a/core/src/zeit/connector/ftesting-real.zcml
+++ b/core/src/zeit/connector/ftesting-real.zcml
@@ -1,7 +1,7 @@
 <configure
   xmlns="http://namespaces.zope.org/zope">
 
-  <include package="zope.app.zcmlfiles" />
+  <include package="zeit.cms" file="application.zcml" />
 
   <include package="zeit.connector" />
 

--- a/core/src/zeit/connector/ftesting-real.zcml
+++ b/core/src/zeit/connector/ftesting-real.zcml
@@ -4,6 +4,10 @@
   <include package="zeit.cms" file="application.zcml" />
 
   <include package="zeit.connector" />
+  <utility 
+    provides="zeit.connector.interfaces.IConnector"
+    factory="zeit.connector.connector.transaction_bound_caching_connector_factory"
+    />
 
 </configure>
 

--- a/core/src/zeit/connector/ftesting.zcml
+++ b/core/src/zeit/connector/ftesting.zcml
@@ -1,7 +1,7 @@
 <configure
   xmlns="http://namespaces.zope.org/zope">
 
-  <include package="zope.app.zcmlfiles" />
+  <include package="zeit.cms" file="application.zcml" />
 
   <include package="zeit.connector" />
   <include package="zeit.connector" file="real-connector.zcml" />

--- a/core/src/zeit/connector/test_profiling.py
+++ b/core/src/zeit/connector/test_profiling.py
@@ -1,12 +1,12 @@
 
 import unittest
 import doctest
-import zeit.connector.testing
+import zeit.cms.testing
 
 
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocFileSuite(
         'profiling.txt',
-        optionflags=zeit.connector.testing.optionflags))
+        optionflags=zeit.cms.testing.optionflags))
     return suite

--- a/core/src/zeit/connector/tests/test_cache.py
+++ b/core/src/zeit/connector/tests/test_cache.py
@@ -5,14 +5,14 @@ import ZODB
 import os
 import threading
 import transaction
+import zeit.cms.testing
 import zeit.connector.cache
 import zeit.connector.testing
-import zope.app.testing.functional
 
 
-class TestResourceCache(zope.app.testing.functional.FunctionalTestCase):
+class TestResourceCache(zeit.cms.testing.FunctionalTestCase):
 
-    layer = zeit.connector.testing.zope_connector_layer
+    layer = zeit.connector.testing.ZOPE_CONNECTOR_LAYER
 
     def setUp(self):
         super(TestResourceCache, self).setUp()

--- a/core/src/zeit/connector/tests/test_connector.py
+++ b/core/src/zeit/connector/tests/test_connector.py
@@ -19,7 +19,7 @@ class TestUnicode(zeit.connector.testing.ConnectorTest):
 
     def test_create_and_list(self):
         import zeit.connector.resource
-        rid = u'http://xml.zeit.de/%s/ünicöde' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/ünicöde' % self.testfolder
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
             StringIO.StringIO('Pop.'),
@@ -27,11 +27,11 @@ class TestUnicode(zeit.connector.testing.ConnectorTest):
         self.assertEquals(
             [(u'ünicöde', rid)],
             list(self.connector.listCollection(
-                'http://xml.zeit.de/%s/' % self.layer.testfolder)))
+                'http://xml.zeit.de/%s/' % self.testfolder)))
 
     def test_overwrite(self):
         import zeit.connector.resource
-        rid = u'http://xml.zeit.de/%s/ünicöde' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/ünicöde' % self.testfolder
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
             StringIO.StringIO('Pop.'),
@@ -44,7 +44,7 @@ class TestUnicode(zeit.connector.testing.ConnectorTest):
 
     def test_copy(self):
         import zeit.connector.resource
-        rid = u'http://xml.zeit.de/%s/ünicöde' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/ünicöde' % self.testfolder
         new_rid = rid + u'-copied'
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
@@ -56,7 +56,7 @@ class TestUnicode(zeit.connector.testing.ConnectorTest):
 
     def test_move(self):
         import zeit.connector.resource
-        rid = u'http://xml.zeit.de/%s/ünicöde' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/ünicöde' % self.testfolder
         new_rid = rid + u'-renamed'
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
@@ -71,7 +71,7 @@ class TestEscaping(zeit.connector.testing.ConnectorTest):
 
     def test_hash(self):
         import zeit.connector.resource
-        rid = 'http://xml.zeit.de/%s/foo#bar' % self.layer.testfolder
+        rid = 'http://xml.zeit.de/%s/foo#bar' % self.testfolder
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
             StringIO.StringIO('Pop.'),
@@ -85,7 +85,7 @@ class ConflictDetectionBase(object):
     def setUp(self):
         from zeit.connector.interfaces import UUID_PROPERTY
         super(ConflictDetectionBase, self).setUp()
-        rid = u'http://xml.zeit.de/%s/conflicting' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/conflicting' % self.testfolder
         self.connector[rid] = self.get_resource('conflicting', 'Pop.')
         r_a = self.connector[rid]
         self.r_a = self.get_resource(r_a.__name__, r_a.data.read(),
@@ -150,7 +150,7 @@ class MoveConflictDetectionBase(object):
             ['target'],
             [name for name, unique_id in
              self.connector.listCollection(
-                 'http://xml.zeit.de/%s' % self.layer.testfolder) if name])
+                 'http://xml.zeit.de/%s' % self.testfolder) if name])
 
     def test_move_with_different_data_should_fail(self):
         source = self.get_resource('source', 'source-body')
@@ -162,7 +162,7 @@ class MoveConflictDetectionBase(object):
         self.assertEqual(
             ['source', 'target'],
             sorted([name for name, unique_id in self.connector.listCollection(
-                'http://xml.zeit.de/%s' % self.layer.testfolder) if name]))
+                'http://xml.zeit.de/%s' % self.testfolder) if name]))
 
     def test_move_should_fail_if_target_is_existing_directory(self):
         source = self.get_resource('source', '',
@@ -193,7 +193,7 @@ class TestResource(zeit.connector.testing.ConnectorTest):
 
     def test_properties_should_be_current(self):
         import zeit.connector.resource
-        rid = u'http://xml.zeit.de/%s/aresource' % self.layer.testfolder
+        rid = u'http://xml.zeit.de/%s/aresource' % self.testfolder
         self.connector[rid] = zeit.connector.resource.Resource(
             rid, None, 'text',
             StringIO.StringIO('Pop.'),
@@ -211,17 +211,17 @@ class TestConnectorCache(zeit.connector.testing.ConnectorTest):
     def setUp(self):
         import zeit.connector.resource
         super(TestConnectorCache, self).setUp()
-        self.rid = 'http://xml.zeit.de/%s/cache_test' % self.layer.testfolder
+        self.rid = 'http://xml.zeit.de/%s/cache_test' % self.testfolder
         self.connector[self.rid] = zeit.connector.resource.Resource(
             self.rid, None, 'text',
             StringIO.StringIO('Pop.'),
             contentType='text/plain')
         list(self.connector.listCollection(
-            'http://xml.zeit.de/%s/' % self.layer.testfolder))
+            'http://xml.zeit.de/%s/' % self.testfolder))
 
     def test_deleting_non_existing_resource_does_not_create_cache_entry(self):
         children = self.connector.child_name_cache[
-            'http://xml.zeit.de/%s/' % self.layer.testfolder]
+            'http://xml.zeit.de/%s/' % self.testfolder]
         children.remove(self.rid)
         del self.connector[self.rid]
         self.assertEqual([], list(children))
@@ -230,7 +230,7 @@ class TestConnectorCache(zeit.connector.testing.ConnectorTest):
     def test_delete_updates_cache(self):
         del self.connector[self.rid]
         children = self.connector.child_name_cache[
-            'http://xml.zeit.de/%s/' % self.layer.testfolder]
+            'http://xml.zeit.de/%s/' % self.testfolder]
         self.assertEquals([], list(children))
 
     def test_cache_time_is_not_stored_on_dav(self):
@@ -283,7 +283,7 @@ class TestConnectorCache(zeit.connector.testing.ConnectorTest):
         r = self.get_resource('res', 'Pop goes the weasel.')
         self.connector.add(r)
         list(self.connector.listCollection(
-            'http://xml.zeit.de/%s/' % self.layer.testfolder))
+            'http://xml.zeit.de/%s/' % self.testfolder))
         # Two changes: property cache and child chache
         self.assertTrue(jar._registered_objects)
         transaction.commit()
@@ -294,36 +294,36 @@ class TestConnectorCache(zeit.connector.testing.ConnectorTest):
 
     def test_invalidation_on_folder_with_non_folder_id_should_not_fail(self):
         self.connector.invalidate_cache(
-            'http://xml.zeit.de/%s' % self.layer.testfolder)
+            'http://xml.zeit.de/%s' % self.testfolder)
 
     def test_invalidation_with_redirect_should_clear_old_location_cache(self):
         del self.connector.property_cache[
-            'http://xml.zeit.de/%s/' % self.layer.testfolder]
+            'http://xml.zeit.de/%s/' % self.testfolder]
         self.connector.property_cache[
-            'http://xml.zeit.de/%s' % self.layer.testfolder] = {
+            'http://xml.zeit.de/%s' % self.testfolder] = {
             ('foo', 'bar'): 'baz'}
         self.connector.child_name_cache[
-            'http://xml.zeit.de/%s' % self.layer.testfolder] = [
+            'http://xml.zeit.de/%s' % self.testfolder] = [
             'a', 'b', 'c']
         self.connector.invalidate_cache(
-            'http://xml.zeit.de/%s' % self.layer.testfolder)
+            'http://xml.zeit.de/%s' % self.testfolder)
         self.assertEqual(
             None,
             self.connector.property_cache.get(
-                'http://xml.zeit.de/%s' % self.layer.testfolder))
+                'http://xml.zeit.de/%s' % self.testfolder))
         self.assertEqual(
             'httpd/unix-directory',
             self.connector.property_cache[
-                'http://xml.zeit.de/%s/' % self.layer.testfolder][
+                'http://xml.zeit.de/%s/' % self.testfolder][
                     ('getcontenttype', 'DAV:')])
         self.assertEqual(
             None,
             self.connector.child_name_cache.get(
-                'http://xml.zeit.de/%s' % self.layer.testfolder))
+                'http://xml.zeit.de/%s' % self.testfolder))
         self.assertEqual(
             [self.rid],
             list(self.connector.child_name_cache.get(
-                'http://xml.zeit.de/%s/' % self.layer.testfolder)))
+                'http://xml.zeit.de/%s/' % self.testfolder)))
 
 
 class TestMove(zeit.connector.testing.ConnectorTest):
@@ -333,8 +333,8 @@ class TestMove(zeit.connector.testing.ConnectorTest):
         self.connector.add(res)
         self.connector.lock(res.id, 'userid', None)
         self.connector.move(
-            res.id, 'http://xml.zeit.de/%s/bar' % self.layer.testfolder)
-        self.connector['http://xml.zeit.de/%s/bar' % self.layer.testfolder]
+            res.id, 'http://xml.zeit.de/%s/bar' % self.testfolder)
+        self.connector['http://xml.zeit.de/%s/bar' % self.testfolder]
 
     def test_move_locked_resource_should_raise(self):
         from zeit.connector.dav.interfaces import DAVLockedError
@@ -346,8 +346,7 @@ class TestMove(zeit.connector.testing.ConnectorTest):
         try:
             self.assertRaises(
                 DAVLockedError, lambda: self.connector.move(
-                    res.id,
-                    'http://xml.zeit.de/%s/bar' % self.layer.testfolder))
+                    res.id, 'http://xml.zeit.de/%s/bar' % self.testfolder))
         finally:
             self.connector.unlock(res.id, token)
 
@@ -356,12 +355,12 @@ class TestMove(zeit.connector.testing.ConnectorTest):
         self.connector.add(res)
         self.connector.lock(res.id, 'userid', None)
         self.connector.copy(
-            res.id, 'http://xml.zeit.de/%s/bar' % self.layer.testfolder)
-        self.connector['http://xml.zeit.de/%s/bar' % self.layer.testfolder]
+            res.id, 'http://xml.zeit.de/%s/bar' % self.testfolder)
+        self.connector['http://xml.zeit.de/%s/bar' % self.testfolder]
 
     def test_move_collection_moves_all_members(self):
         coll = zeit.connector.resource.Resource(
-            'http://xml.zeit.de/%s/foo' % self.layer.testfolder,
+            'http://xml.zeit.de/%s/foo' % self.testfolder,
             'foo', 'collection', StringIO.StringIO(''))
         self.connector.add(coll)
         res = self.get_resource('foo/one', 'body')
@@ -370,12 +369,12 @@ class TestMove(zeit.connector.testing.ConnectorTest):
         self.connector.add(res)
         self.assertEqual(['one', 'two'], sorted([
             x[0] for x in self.connector.listCollection(
-                'http://xml.zeit.de/%s/foo' % self.layer.testfolder)]))
+                'http://xml.zeit.de/%s/foo' % self.testfolder)]))
         self.connector.move(
-            coll.id, 'http://xml.zeit.de/%s/bar' % self.layer.testfolder)
+            coll.id, 'http://xml.zeit.de/%s/bar' % self.testfolder)
         self.assertEqual(['one', 'two'], sorted([
             x[0] for x in self.connector.listCollection(
-                'http://xml.zeit.de/%s/bar' % self.layer.testfolder)]))
+                'http://xml.zeit.de/%s/bar' % self.testfolder)]))
 
 
 class TestSearch(zeit.connector.testing.ConnectorTest):

--- a/core/src/zeit/connector/tests/test_doctest.py
+++ b/core/src/zeit/connector/tests/test_doctest.py
@@ -1,6 +1,6 @@
-import doctest
 import pytest
 import unittest
+import zeit.cms.testing
 import zeit.connector.connector
 import zeit.connector.testing
 
@@ -8,53 +8,25 @@ import zeit.connector.testing
 def test_suite():
     suite = unittest.TestSuite()
 
-    real = zeit.connector.testing.FunctionalDocFileSuite(
-        'connector.txt',
-        'locking.txt',
-        'resource.txt',
-        'search-ft.txt',
-        'uuid.txt',
-    )
-    real.level = 2
-    mark_doctest_suite(real, pytest.mark.slow)
-    suite.addTest(real)
-
     mock = zeit.connector.testing.FunctionalDocFileSuite(
         'mock.txt',
         'uuid.txt',
-        layer=zeit.connector.testing.mock_connector_layer,
+        layer=zeit.connector.testing.MOCK_CONNECTOR_LAYER,
     )
     suite.addTest(mock)
-
-    long_running = zeit.connector.testing.FunctionalDocFileSuite(
-        'longrunning.txt',
-        'stressing.txt',
-    )
-    long_running.level = 3
-    mark_doctest_suite(long_running, pytest.mark.slow)
-    suite.addTest(long_running)
 
     functional = zeit.connector.testing.FunctionalDocFileSuite(
         'cache.txt',
         'functional.txt',
         'invalidator.txt',
         'invalidation-events.txt',
-        layer=zeit.connector.testing.zope_connector_layer,
+        layer=zeit.connector.testing.ZOPE_CONNECTOR_LAYER,
     )
+    zeit.connector.testing.mark_doctest_suite(functional, pytest.mark.slow)
     suite.addTest(functional)
 
-    suite.addTest(doctest.DocTestSuite(zeit.connector.connector))
-    suite.addTest(doctest.DocFileSuite(
+    suite.addTest(zeit.cms.testing.DocFileSuite(
         'search.txt',
-        optionflags=zeit.connector.testing.optionflags,
         package='zeit.connector'))
 
     return suite
-
-
-def mark_doctest_suite(suite, mark):
-    # Imitate pytest magic, see _pytest.python.transfer_markers
-    for test in suite:
-        func = test.runTest.im_func
-        mark(func)
-        test.runTest = func.__get__(test)

--- a/core/src/zeit/connector/tests/test_doctest2.py
+++ b/core/src/zeit/connector/tests/test_doctest2.py
@@ -1,0 +1,22 @@
+import pytest
+import zeit.cms.testing
+import zeit.connector.connector
+import zeit.connector.testing
+
+
+def test_suite():
+    # Need to put this into a separate file, otherwise gocept.pytestlayers
+    # does not tear down other layers before running this.
+    suite = zeit.connector.testing.FunctionalDocFileSuite(
+        'connector.txt',
+        'locking.txt',
+        'resource.txt',
+        'search-ft.txt',
+        'uuid.txt',
+
+        'longrunning.txt',
+        'stressing.txt',
+        layer=zeit.connector.testing.REAL_CONNECTOR_LAYER,
+    )
+    zeit.connector.testing.mark_doctest_suite(suite, pytest.mark.slow)
+    return suite

--- a/core/src/zeit/connector/tests/test_zopeconnector.py
+++ b/core/src/zeit/connector/tests/test_zopeconnector.py
@@ -3,12 +3,7 @@ import zeit.connector.testing
 
 class TestMoveRollback(zeit.connector.testing.ConnectorTest):
 
-    layer = zeit.connector.testing.zope_connector_layer
-
-    def setUp(self):
-        import zope.component.hooks
-        zope.component.hooks.setSite(self.layer.setup.getRootFolder())
-        super(TestMoveRollback, self).setUp()
+    layer = zeit.connector.testing.ZOPE_CONNECTOR_LAYER
 
     def test_move_should_revert_on_abort(self):
         import transaction
@@ -21,7 +16,7 @@ class TestMoveRollback(zeit.connector.testing.ConnectorTest):
             ['source'],
             [name for name, unique_id in
              self.connector.listCollection(
-                 'http://xml.zeit.de/%s' % self.layer.testfolder) if name])
+                 'http://xml.zeit.de/%s' % self.testfolder) if name])
 
     def test_move_should_not_revert_on_commit(self):
         import transaction
@@ -34,7 +29,7 @@ class TestMoveRollback(zeit.connector.testing.ConnectorTest):
             ['target'],
             [name for name, unique_id in
              self.connector.listCollection(
-                 'http://xml.zeit.de/%s' % self.layer.testfolder) if name])
+                 'http://xml.zeit.de/%s' % self.testfolder) if name])
 
     def test_move_should_not_try_to_revert_on_error(self):
         import transaction
@@ -53,6 +48,6 @@ class TestMoveRollback(zeit.connector.testing.ConnectorTest):
         transaction.abort()
         self.assertEqual(
             ['target'],
-            [name for name, unique_id in
-             self.connector.listCollection('http://xml.zeit.de/testing')
+            [name for name, unique_id in self.connector.listCollection(
+                'http://xml.zeit.de/%s' % self.testfolder)
              if name])

--- a/core/src/zeit/connector/zopeconnector.py
+++ b/core/src/zeit/connector/zopeconnector.py
@@ -96,23 +96,9 @@ def connectorFactory():
     import zope.app.appsetup.product
     config = zope.app.appsetup.product.getProductConfiguration(
         'zeit.connector')
-    if config:
-        root = config.get('document-store')
-        if not root:
-            raise ZConfig.ConfigurationError(
-                "WebDAV server not configured properly.")
-        search_root = config.get('document-store-search')
-    else:
-        root = os.environ.get('connector-url')
-        search_root = os.environ.get('search-connector-url')
-
-    if not root:
-        raise ZConfig.ConfigurationError(
-            "zope.conf has no product config for zeit.connector.")
-
-    return ZopeConnector(dict(
-        default=root,
-        search=search_root))
+    return ZopeConnector({
+        'default': config['document-store'],
+        'search': config['document-store-search']})
 
 
 class DataManager(object):

--- a/core/src/zeit/content/advertisement/testing.py
+++ b/core/src/zeit/content/advertisement/testing.py
@@ -1,10 +1,15 @@
 import zeit.cms.testing
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=zeit.cms.testing.cms_product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', bases=(
+    zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/advertisement/tests/test_advertisement.py
+++ b/core/src/zeit/content/advertisement/tests/test_advertisement.py
@@ -1,10 +1,7 @@
-import zeit.cms.testing
 import zeit.content.advertisement.testing
 
 
-class AdvertisementTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.advertisement.testing.ZCML_LAYER
+class AdvertisementTest(zeit.content.advertisement.testing.FunctionalTestCase):
 
     def test_image_of_advertisement_can_be_retrieved_via_IImages(self):
         from zeit.content.advertisement.advertisement import Advertisement

--- a/core/src/zeit/content/article/browser/tests/test_breaking.py
+++ b/core/src/zeit/content/article/browser/tests/test_breaking.py
@@ -15,7 +15,8 @@ class TestAdding(zeit.content.article.testing.BrowserTestCase):
     def setUp(self):
         super(TestAdding, self).setUp()
         domain = zope.i18n.translationdomain.TranslationDomain('zeit.cms')
-        self.zca.patch_utility(domain, name='zeit.cms')
+        zope.component.getGlobalSiteManager().registerUtility(
+            domain, name='zeit.cms')
         self.catalog = zeit.cms.testing.TestCatalog()
         domain.addCatalog(self.catalog)
 

--- a/core/src/zeit/content/article/testing.py
+++ b/core/src/zeit/content/article/testing.py
@@ -6,14 +6,9 @@ import re
 import zeit.cms.tagging.interfaces
 import zeit.cms.tagging.testing
 import zeit.cms.testing
-import zeit.content.author.testing
-import zeit.content.cp.testing
 import zeit.content.gallery.testing
-import zeit.content.image.testing
-import zeit.content.modules.testing
 import zeit.content.volume.testing
 import zeit.push.testing
-import zeit.workflow.testing
 import zope.component
 
 
@@ -43,22 +38,13 @@ checker = zeit.cms.testing.OutputChecker([
 checker.transformers[0:0] = zeit.cms.testing.checker.transformers
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=(
-        product_config +
-        zeit.workflow.testing.product_config +
-        zeit.content.cp.testing.product_config +
-        zeit.content.image.testing.product_config +
-        zeit.content.modules.testing.product_config +
-        zeit.content.gallery.testing.product_config +
-        zeit.content.author.testing.product_config +
-        zeit.content.volume.testing.product_config +
-        zeit.push.testing.product_config +
-        zeit.cms.testing.cms_product_config))
-
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.content.gallery.testing.CONFIG_LAYER,
+    zeit.content.volume.testing.CONFIG_LAYER))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 PUSH_LAYER = zeit.push.testing.UrbanairshipTemplateLayer(
-    name='UrbanairshipTemplateLayer', bases=(ZCML_LAYER,))
+    name='UrbanairshipTemplateLayer', bases=(ZOPE_LAYER,))
 
 
 class ArticleLayer(plone.testing.Layer):

--- a/core/src/zeit/content/author/testing.py
+++ b/core/src/zeit/content/author/testing.py
@@ -14,18 +14,22 @@ product_config = """
 </product-config>
 """.format(fixtures=pkg_resources.resource_filename(__name__, '.'))
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=zeit.cms.testing.cms_product_config +
-    zeit.workflow.testing.product_config +
-    zeit.find.testing.product_config +
-    product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.workflow.testing.CONFIG_LAYER,
+    zeit.find.testing.CONFIG_LAYER))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 def FunctionalDocFileSuite(*args, **kw):
-    kw.setdefault('layer', ZCML_LAYER)
+    kw.setdefault('layer', ZOPE_LAYER)
     return zeit.cms.testing.FunctionalDocFileSuite(*args, **kw)
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = WSGI_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/author/tests/test_author.py
+++ b/core/src/zeit/content/author/tests/test_author.py
@@ -9,7 +9,6 @@ import mock
 import requests_mock
 import urllib
 import zeit.cms.interfaces
-import zeit.cms.testing
 import zeit.content.author.author
 import zeit.content.author.testing
 import zeit.find.interfaces
@@ -19,9 +18,7 @@ import zope.event
 NONZERO = 3
 
 
-class AuthorTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class AuthorTest(zeit.content.author.testing.FunctionalTestCase):
 
     def test_author_exists(self):
         author = zeit.content.author.author.Author()
@@ -41,9 +38,7 @@ class AuthorTest(zeit.cms.testing.FunctionalTestCase):
             self.assertTrue(author.exists)
 
 
-class FreetextCopyTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class FreetextCopyTest(zeit.content.author.testing.FunctionalTestCase):
 
     def setUp(self):
         super(FreetextCopyTest, self).setUp()
@@ -91,9 +86,7 @@ class FreetextCopyTest(zeit.cms.testing.FunctionalTestCase):
             ('',), self.repository['online']['testcontent'].authors)
 
 
-class BiographyQuestionsTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class BiographyQuestionsTest(zeit.content.author.testing.FunctionalTestCase):
 
     def test_provides_dict_access_to_xml_nodes(self):
         author = zeit.content.author.author.Author()
@@ -128,9 +121,7 @@ class BiographyQuestionsTest(zeit.cms.testing.FunctionalTestCase):
             'Das treibt mich an', author.bio_questions['drive'].title)
 
 
-class SSOIdConnectTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class SSOIdConnectTest(zeit.content.author.testing.FunctionalTestCase):
 
     def setUp(self):
         super(SSOIdConnectTest, self).setUp()

--- a/core/src/zeit/content/author/tests/test_reference.py
+++ b/core/src/zeit/content/author/tests/test_reference.py
@@ -3,16 +3,14 @@ import gocept.testing.mock
 import lxml.etree
 import mock
 import zeit.cms.content.interfaces
-import zeit.cms.testing
 import zeit.content.article.edit.author
 import zeit.content.author.author
 import zeit.content.author.testing
 import zope.component
 
 
-class AuthorshipXMLReferenceUpdater(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class AuthorshipXMLReferenceUpdater(
+        zeit.content.author.testing.FunctionalTestCase):
 
     def setUp(self):
         super(AuthorshipXMLReferenceUpdater, self).setUp()
@@ -108,9 +106,7 @@ class AuthorshipXMLReferenceUpdater(zeit.cms.testing.FunctionalTestCase):
                 updater.update(content.xml, suppress_errors=True)
 
 
-class RelatedReferenceTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.author.testing.ZCML_LAYER
+class RelatedReferenceTest(zeit.content.author.testing.FunctionalTestCase):
 
     def setUp(self):
         super(RelatedReferenceTest, self).setUp()

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_mail.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_mail.py
@@ -1,11 +1,9 @@
-import zeit.cms.testing
 import zeit.content.cp
 import zeit.content.cp.centerpage
+import zeit.content.cp.testing
 
 
-class TestMail(zeit.cms.testing.BrowserTestCase):
-
-    layer = zeit.content.cp.testing.WSGI_LAYER
+class TestMail(zeit.content.cp.testing.BrowserTestCase):
 
     def setUp(self):
         super(TestMail, self).setUp()

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
@@ -5,7 +5,6 @@ import mock
 import transaction
 import unittest
 import zeit.cms.browser.interfaces
-import zeit.cms.testing
 import zeit.content.cp.browser.testing
 import zeit.content.cp.centerpage
 import zeit.content.cp.testing
@@ -128,9 +127,7 @@ class CommonEditTest(zeit.content.cp.testing.BrowserTestCase):
         self.assertEqual('foo', b.getControl('Title').value)
 
 
-class FunctionalTeaserDisplayTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.cp.testing.ZCML_LAYER
+class FunctionalTeaserDisplayTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def setUp(self):
         super(FunctionalTeaserDisplayTest, self).setUp()

--- a/core/src/zeit/content/cp/rule.txt
+++ b/core/src/zeit/content/cp/rule.txt
@@ -12,7 +12,6 @@ XXX this is supposed to be user documentation. writeme
 >>> import zope.app.appsetup.product
 >>> config = zope.app.appsetup.product.getProductConfiguration(
 ...     'zeit.edit')
->>> old_rules_url = config['rules-url']
 >>> config['rules-url'] = 'file://%s' % rules_filename
 
 >>> def create_rules(rules_str):
@@ -135,4 +134,3 @@ Clean up
 
 >>> import os
 >>> os.remove(rules_filename)
->>> config['rules-url'] = old_rules_url

--- a/core/src/zeit/content/cp/tests/test_automatic.py
+++ b/core/src/zeit/content/cp/tests/test_automatic.py
@@ -417,8 +417,8 @@ class AutomaticAreaTopicpageTest(zeit.content.cp.testing.FunctionalTestCase):
         super(AutomaticAreaTopicpageTest, self).setUp()
         self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
         self.tms = mock.Mock()
-        self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS,
-                               registry=zope.component.getSiteManager())
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.tms, zeit.retresco.interfaces.ITMS)
 
     def test_passes_id_to_tms(self):
         lead = self.repository['cp']['lead']
@@ -597,8 +597,8 @@ class HideDupesTest(zeit.content.cp.testing.FunctionalTestCase):
         self.area.automatic_type = 'topicpage'
         self.area.referenced_topicpage = 'mytopic'
         tms = mock.Mock()
-        self.zca.patch_utility(tms, zeit.retresco.interfaces.ITMS,
-                               registry=zope.component.getSiteManager())
+        zope.component.getGlobalSiteManager().registerUtility(
+            tms, zeit.retresco.interfaces.ITMS)
         tms.get_topicpage_documents.return_value = zeit.cms.interfaces.Result([
             {'url': '/t1', 'doc_type': 'testcontenttype'},
             {'url': '/t2', 'doc_type': 'testcontenttype'},
@@ -616,8 +616,8 @@ class HideDupesTest(zeit.content.cp.testing.FunctionalTestCase):
         self.area.automatic_type = 'topicpage'
         self.area.referenced_topicpage = 'mytopic'
         tms = mock.Mock()
-        self.zca.patch_utility(tms, zeit.retresco.interfaces.ITMS,
-                               registry=zope.component.getSiteManager())
+        zope.component.getGlobalSiteManager().registerUtility(
+            tms, zeit.retresco.interfaces.ITMS)
         tms.get_topicpage_documents.return_value = zeit.cms.interfaces.Result([
             {'url': '/t1', 'doc_type': 'testcontenttype'},
             {'url': '/t2', 'doc_type': 'testcontenttype'},
@@ -643,8 +643,8 @@ class HideDupesTest(zeit.content.cp.testing.FunctionalTestCase):
         a2.referenced_topicpage = 'tms-id'
         a3.referenced_topicpage = 'tms-id'
         tms = mock.Mock()
-        self.zca.patch_utility(tms, zeit.retresco.interfaces.ITMS,
-                               registry=zope.component.getSiteManager())
+        zope.component.getGlobalSiteManager().registerUtility(
+            tms, zeit.retresco.interfaces.ITMS)
         results = zeit.cms.interfaces.Result()
         for n in range(30):
             url = 'teaser-{}'.format(n)
@@ -746,8 +746,8 @@ class HideDupesTest(zeit.content.cp.testing.FunctionalTestCase):
         area = self.create_automatic_area(self.cp)
         area.start = 0          # TODO: are we sure this is _always_ set?
         tms = mock.Mock()
-        self.zca.patch_utility(tms, zeit.retresco.interfaces.ITMS,
-                               registry=zope.component.getSiteManager())
+        zope.component.getGlobalSiteManager().registerUtility(
+            tms, zeit.retresco.interfaces.ITMS)
         results = zeit.cms.interfaces.Result([])
         results.hits = 42
         tms.get_topicpage_documents.return_value = results

--- a/core/src/zeit/content/cp/tests/test_doctest.py
+++ b/core/src/zeit/content/cp/tests/test_doctest.py
@@ -1,13 +1,10 @@
-import unittest
 import zeit.content.cp
 import zeit.content.cp.testing
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(zeit.content.cp.testing.FunctionalDocFileSuite(
+    return zeit.content.cp.testing.FunctionalDocFileSuite(
         'README.txt',
         'cmscontentiterable.txt',
         'rule.txt',
-        package=zeit.content.cp))
-    return suite
+        package=zeit.content.cp)

--- a/core/src/zeit/content/cp/tests/test_interfaces.py
+++ b/core/src/zeit/content/cp/tests/test_interfaces.py
@@ -1,7 +1,6 @@
 import gocept.testing.assertion
 import mock
 import unittest
-import zeit.cms.testing
 import zeit.content.cp.interfaces
 import zeit.content.cp.testing
 
@@ -47,9 +46,7 @@ class AreaValidationTest(
         self.assertIn('No JSON object could be decoded', str(err.exception))
 
 
-class TopicpageFilterSourceTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.cp.testing.ZCML_LAYER
+class TopicpageFilterSourceTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def test_parses_filter_json(self):
         self.assertEqual(

--- a/core/src/zeit/content/cp/tests/test_rule.py
+++ b/core/src/zeit/content/cp/tests/test_rule.py
@@ -98,10 +98,6 @@ class RulesManagerTest(zeit.content.cp.testing.FunctionalTestCase):
         self.rm = zope.component.getUtility(
             zeit.edit.interfaces.IRulesManager)
 
-    def tearDown(self):
-        self._set_rules('example_rules.py')
-        super(RulesManagerTest, self).tearDown()
-
     def _set_rules(self, filename):
         zope.app.appsetup.product._configs['zeit.edit']['rules-url'] = (
             'file://' + pkg_resources.resource_filename(

--- a/core/src/zeit/content/cp/tests/test_source.py
+++ b/core/src/zeit/content/cp/tests/test_source.py
@@ -7,9 +7,7 @@ import zeit.content.cp.testing
 
 class CPSourceTest(
         zeit.cms.content.tests.test_contentsource.ContentSourceBase,
-        zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.cp.testing.ZCML_LAYER
+        zeit.content.cp.testing.FunctionalTestCase):
 
     source = zeit.content.cp.source.centerPageSource
     expected_types = ['centerpage-2009']

--- a/core/src/zeit/content/dynamicfolder/testing.py
+++ b/core/src/zeit/content/dynamicfolder/testing.py
@@ -8,22 +8,20 @@ import zeit.cms.repository.folder
 import zeit.cms.repository.interfaces
 import zeit.cms.testing
 import zeit.content.cp.testing
-import zeit.workflow.testing
 import zope.component
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', product_config=(
-    zeit.cms.testing.cms_product_config +
-    zeit.workflow.testing.product_config +
-    zeit.content.cp.testing.product_config))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(
+    zeit.content.cp.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
 class DynamicLayer(plone.testing.Layer):
 
-    defaultBases = (ZCML_LAYER,)
+    defaultBases = (ZOPE_LAYER,)
 
     def testSetUp(self):
-        with zeit.cms.testing.site(self['functional_setup'].getRootFolder()):
+        with zeit.cms.testing.site(self['zodbApp']):
             repository = zope.component.getUtility(
                 zeit.cms.repository.interfaces.IRepository)
 
@@ -41,16 +39,13 @@ class DynamicLayer(plone.testing.Layer):
             transaction.commit()
 
 
-DYNAMIC_LAYER = DynamicLayer()
+LAYER = DynamicLayer()
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(LAYER,))
 
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 
-    layer = DYNAMIC_LAYER
-
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(DYNAMIC_LAYER,))
+    layer = LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/gallery/tests/test_doctest.py
+++ b/core/src/zeit/content/gallery/tests/test_doctest.py
@@ -9,7 +9,7 @@ def test_suite():
         'README.txt',
         'reference.txt',
         package='zeit.content.gallery',
-        layer=zeit.content.gallery.testing.ZCML_LAYER))
+        layer=zeit.content.gallery.testing.ZOPE_LAYER))
     suite.addTest(zeit.cms.testing.FunctionalDocFileSuite(
         'workflow.txt',
         package='zeit.content.gallery',

--- a/core/src/zeit/content/gallery/tests/test_gallery.py
+++ b/core/src/zeit/content/gallery/tests/test_gallery.py
@@ -1,6 +1,5 @@
 import transaction
 import unittest
-import zeit.cms.testing
 import zeit.content.gallery.gallery
 import zope.component
 
@@ -24,9 +23,7 @@ class TestHTMLContent(unittest.TestCase):
         self.assertEqual(1, len(gallery.xml.body.findall('text')))
 
 
-class TestEntryMetadata(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.gallery.testing.ZCML_LAYER
+class TestEntryMetadata(zeit.content.gallery.testing.FunctionalTestCase):
 
     def setUp(self):
         super(TestEntryMetadata, self).setUp()
@@ -58,9 +55,7 @@ class TestEntryMetadata(zeit.cms.testing.FunctionalTestCase):
         assert metadata.title == u'Beautiful title'
 
 
-class TestEntryImages(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.gallery.testing.ZCML_LAYER
+class TestEntryImages(zeit.content.gallery.testing.FunctionalTestCase):
 
     def test_gallery_entry_should_adapt_to_IImages(self):
         entry = zeit.content.gallery.gallery.GalleryEntry()
@@ -70,9 +65,7 @@ class TestEntryImages(zeit.cms.testing.FunctionalTestCase):
         assert images.image is entry.image
 
 
-class TestVisibleEntryCount(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.gallery.testing.ZCML_LAYER
+class TestVisibleEntryCount(zeit.content.gallery.testing.FunctionalTestCase):
 
     def setUp(self):
         super(TestVisibleEntryCount, self).setUp()

--- a/core/src/zeit/content/gallery/tests/test_imp.py
+++ b/core/src/zeit/content/gallery/tests/test_imp.py
@@ -1,14 +1,11 @@
 import PIL
 import transaction
-import zeit.cms.testing
 import zeit.content.gallery.gallery
 import zeit.content.image.interfaces
 import zeit.imp.interfaces
 
 
-class TestGalleryStorer(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.gallery.testing.ZCML_LAYER
+class TestGalleryStorer(zeit.content.gallery.testing.FunctionalTestCase):
 
     def setUp(self):
         super(TestGalleryStorer, self).setUp()

--- a/core/src/zeit/content/gallery/tests/test_interfaces.py
+++ b/core/src/zeit/content/gallery/tests/test_interfaces.py
@@ -1,15 +1,12 @@
 from zeit.cms.testing import copy_inherited_functions
 import zeit.cms.content.tests.test_contentsource
-import zeit.cms.testing
 import zeit.content.gallery.interfaces
 import zeit.content.gallery.testing
 
 
 class TestGallerySource(
-    zeit.cms.content.tests.test_contentsource.ContentSourceBase,
-    zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.gallery.testing.ZCML_LAYER
+        zeit.cms.content.tests.test_contentsource.ContentSourceBase,
+        zeit.content.gallery.testing.FunctionalTestCase):
 
     source = zeit.content.gallery.interfaces.gallerySource
     expected_types = ['gallery']

--- a/core/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -195,9 +195,7 @@ class ImageGroupBrowserTest(
             '...Unsupported image type...', self.browser.contents)
 
 
-class ImageGroupWebdriverTest(zeit.cms.testing.SeleniumTestCase):
-
-    layer = zeit.content.image.testing.WEBDRIVER_LAYER
+class ImageGroupWebdriverTest(zeit.content.image.testing.SeleniumTestCase):
 
     def setUp(self):
         super(ImageGroupWebdriverTest, self).setUp()
@@ -247,9 +245,7 @@ class ImageGroupWebdriverTest(zeit.cms.testing.SeleniumTestCase):
         sel.assertVisible(freetext)
 
 
-class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ThumbnailTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         from zeit.content.image.browser.imagegroup import Thumbnail

--- a/core/src/zeit/content/image/browser/tests/test_variant.py
+++ b/core/src/zeit/content/image/browser/tests/test_variant.py
@@ -153,9 +153,8 @@ class VariantJsonAPI(zeit.cms.testing.FunctionalTestCase):
             self.request('delete', '/repository/group/variants/cinema-small')
 
 
-class VariantIntegrationTest(zeit.cms.testing.SeleniumTestCase):
+class VariantIntegrationTest(zeit.content.image.testing.SeleniumTestCase):
 
-    layer = zeit.content.image.testing.WEBDRIVER_LAYER
     window_width = 1300  # The "Variants" tab needs to fit in and be clickable.
 
     def setUp(self):

--- a/core/src/zeit/content/image/testing.py
+++ b/core/src/zeit/content/image/testing.py
@@ -20,13 +20,11 @@ product_config = """
 """.format(here=pkg_resources.resource_filename(__name__, '.'))
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=(
-        product_config +
-        zeit.cms.testing.cms_product_config +
-        zeit.workflow.testing.product_config))
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(ZCML_LAYER,))
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.workflow.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(
@@ -77,6 +75,11 @@ def create_image_group_with_master_image(file_name=None):
     image.open('w').write(fh.read())
     repository['group'][group.master_image] = image
     return repository['group']
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/image/tests/test_doctest.py
+++ b/core/src/zeit/content/image/tests/test_doctest.py
@@ -10,4 +10,4 @@ def test_suite():
         'transform.txt',
         'masterimage.txt',
         package='zeit.content.image',
-        layer=zeit.content.image.testing.ZCML_LAYER)
+        layer=zeit.content.image.testing.ZOPE_LAYER)

--- a/core/src/zeit/content/image/tests/test_image.py
+++ b/core/src/zeit/content/image/tests/test_image.py
@@ -2,14 +2,12 @@ from zeit.cms.checkout.helper import checked_out
 from zeit.content.image.testing import create_image_group, create_local_image
 import zeit.cms.checkout.interfaces
 import zeit.cms.interfaces
-import zeit.cms.testing
 import zeit.content.image.testing
 import zope.component
 
 
-class TestImageMetadataAcquisition(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class TestImageMetadataAcquisition(
+        zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(TestImageMetadataAcquisition, self).setUp()
@@ -45,9 +43,7 @@ class TestImageMetadataAcquisition(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual(None, metadata.title)
 
 
-class TestImageXMLReference(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class TestImageXMLReference(zeit.content.image.testing.FunctionalTestCase):
 
     def test_master_image_without_filename_extension_sets_mime_as_type(self):
         fh = self.repository['2006']['DSC00109_2.JPG'].open()
@@ -60,9 +56,7 @@ class TestImageXMLReference(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual('jpeg', ref.get('type'))
 
 
-class TestImageMIMEType(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class TestImageMIMEType(zeit.content.image.testing.FunctionalTestCase):
 
     def test_ignores_stored_dav_mime_type(self):
         self.repository['image'] = create_local_image('opernball.jpg')

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -5,15 +5,12 @@ from zope.publisher.interfaces import NotFound
 import PIL
 import mock
 import zeit.cms.repository.interfaces
-import zeit.cms.testing
 import zeit.content.image.testing
 import zope.event
 import zope.lifecycleevent
 
 
-class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(ImageGroupTest, self).setUp()
@@ -244,9 +241,7 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual('WEBP', image.format)
 
 
-class ExternalIDTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ExternalIDTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(ExternalIDTest, self).setUp()
@@ -277,9 +272,7 @@ class ExternalIDTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual(None, self.search('wartsnurab.jpg'))
 
 
-class ThumbnailsTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ThumbnailsTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         from ..imagegroup import Thumbnails

--- a/core/src/zeit/content/image/tests/test_imagereference.py
+++ b/core/src/zeit/content/image/tests/test_imagereference.py
@@ -6,15 +6,12 @@ from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 from zeit.content.image.interfaces import IImageMetadata
 import lxml.etree
 import mock
-import zeit.cms.testing
 import zeit.content.image.interfaces
 import zeit.content.image.testing
 import zope.copypastemove.interfaces
 
 
-class ImageAssetTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ImageAssetTest(zeit.content.image.testing.FunctionalTestCase):
 
     def test_IImages_accepts_IImage_for_backwards_compatibility(self):
         with self.assertNothingRaised():
@@ -22,9 +19,7 @@ class ImageAssetTest(zeit.cms.testing.FunctionalTestCase):
                 ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG'))
 
 
-class ImageReferenceTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ImageReferenceTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(ImageReferenceTest, self).setUp()
@@ -117,9 +112,7 @@ class ImageReferenceTest(zeit.cms.testing.FunctionalTestCase):
             '//head/image[@fill_color="F00F00"]')) == 1
 
 
-class MoveReferencesTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class MoveReferencesTest(zeit.content.image.testing.FunctionalTestCase):
 
     def test_moving_image_updates_uniqueId_in_referencing_obj(self):
         # This is basically the same test as zeit.cms.redirect.tests.test_move,

--- a/core/src/zeit/content/image/tests/test_metadata.py
+++ b/core/src/zeit/content/image/tests/test_metadata.py
@@ -2,15 +2,12 @@ from zeit.cms.content.interfaces import IXMLReference
 from zeit.cms.interfaces import ICMSContent
 from zeit.content.image.interfaces import IImageMetadata
 import lxml.etree
-import zeit.cms.testing
 import zeit.content.image.testing
 import zeit.content.image.metadata
 import zope.component
 
 
-class ImageMetadataTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class ImageMetadataTest(zeit.content.image.testing.FunctionalTestCase):
 
     def set_copyright(self, value):
         image = ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -3,14 +3,11 @@ from zeit.content.image.variant import Variant
 import PIL.Image
 import PIL.ImageDraw
 import pkg_resources
-import zeit.cms.testing
 import zeit.content.image.interfaces
 import zeit.content.image.testing
 
 
-class CreateVariantImageTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(CreateVariantImageTest, self).setUp()

--- a/core/src/zeit/content/image/tests/test_variant.py
+++ b/core/src/zeit/content/image/tests/test_variant.py
@@ -1,13 +1,10 @@
 from zeit.content.image.interfaces import IVariants
 import sys
-import zeit.cms.testing
 import zeit.content.image.testing
 import zope.interface.verify
 
 
-class VariantTraversal(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class VariantTraversal(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(VariantTraversal, self).setUp()
@@ -70,9 +67,7 @@ class VariantTraversal(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual(180, variant.max_height)
 
 
-class VariantProperties(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.image.testing.ZCML_LAYER
+class VariantProperties(zeit.content.image.testing.FunctionalTestCase):
 
     def setUp(self):
         super(VariantProperties, self).setUp()

--- a/core/src/zeit/content/infobox/tests.py
+++ b/core/src/zeit/content/infobox/tests.py
@@ -6,19 +6,16 @@ import zeit.cms.testing
 import zeit.content.infobox.interfaces
 
 
-InfoboxLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
-
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(InfoboxLayer,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 class InfoboxSourceTest(
         zeit.cms.content.tests.test_contentsource.ContentSourceBase,
         zeit.cms.testing.FunctionalTestCase):
 
-    layer = InfoboxLayer
+    layer = ZOPE_LAYER
 
     source = zeit.content.infobox.interfaces.infoboxSource
     expected_types = ['infobox']
@@ -29,7 +26,7 @@ class InfoboxSourceTest(
 
 class ReferenceTest(zeit.cms.testing.FunctionalTestCase):
 
-    layer = InfoboxLayer
+    layer = ZOPE_LAYER
 
     def test_should_have_security_declarations(self):
         from zeit.content.infobox.reference import InfoboxReference
@@ -51,7 +48,7 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
-        layer=InfoboxLayer))
+        layer=ZOPE_LAYER))
     suite.addTest(unittest.makeSuite(InfoboxSourceTest))
     suite.addTest(unittest.makeSuite(ReferenceTest))
     return suite

--- a/core/src/zeit/content/link/testing.py
+++ b/core/src/zeit/content/link/testing.py
@@ -6,23 +6,24 @@ import zeit.push.testing
 
 product_config = """
 <product-config zeit.content.link>
-    source-blogs file://%s
+    source-blogs file://{base}/blog_source.xml
 </product-config>
-""" % pkg_resources.resource_filename(__name__, 'blog_source.xml')
+""".format(base=pkg_resources.resource_filename(__name__, ''))
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=(zeit.cms.testing.cms_product_config +
-                    zeit.push.testing.product_config +
-                    product_config))
-
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.push.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 PUSH_LAYER = zeit.push.testing.UrbanairshipTemplateLayer(
-    name='UrbanairshipTemplateLayer', bases=(ZCML_LAYER,))
+    name='UrbanairshipTemplateLayer', bases=(ZOPE_LAYER,))
+LAYER = plone.testing.Layer(bases=(PUSH_LAYER,), name='Layer')
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(LAYER,))
 
-LAYER = plone.testing.Layer(bases=(PUSH_LAYER,), name='LinkLayer')
 
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(LAYER,))
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/link/tests/test_doctest.py
+++ b/core/src/zeit/content/link/tests/test_doctest.py
@@ -5,4 +5,4 @@ def test_suite():
     return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.content.link',
-        layer=zeit.content.link.testing.ZCML_LAYER)
+        layer=zeit.content.link.testing.LAYER)

--- a/core/src/zeit/content/link/tests/test_push.py
+++ b/core/src/zeit/content/link/tests/test_push.py
@@ -1,13 +1,10 @@
-import zeit.cms.testing
 import zeit.content.link.link
 import zeit.content.link.testing
 import zeit.push.interfaces
 import zope.component
 
 
-class PushURLTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.link.testing.ZCML_LAYER
+class PushURLTest(zeit.content.link.testing.FunctionalTestCase):
 
     def test_push_uses_url_of_target_instead_of_link_object(self):
         link = zeit.content.link.link.Link()

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -10,7 +10,12 @@ product_config = """\
 """.format(base=pkg_resources.resource_filename(__name__, '.'))
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=zeit.cms.testing.cms_product_config +
-    product_config)
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
+    product_config, bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER

--- a/core/src/zeit/content/modules/tests/test_rawtext.py
+++ b/core/src/zeit/content/modules/tests/test_rawtext.py
@@ -2,15 +2,12 @@ from zeit.cms.checkout.helper import checked_out
 import lxml.etree
 import lxml.objectify
 import mock
-import zeit.cms.testing
 import zeit.content.modules.rawtext
 import zeit.content.modules.testing
 import zeit.content.text.embed
 
 
-class EmbedParameters(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.modules.testing.ZCML_LAYER
+class EmbedParameters(zeit.content.modules.testing.FunctionalTestCase):
 
     def setUp(self):
         super(EmbedParameters, self).setUp()
@@ -79,9 +76,7 @@ class EmbedParameters(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual('10.000', self.module.params['p1'])
 
 
-class EmbedCSS(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.modules.testing.ZCML_LAYER
+class EmbedCSS(zeit.content.modules.testing.FunctionalTestCase):
 
     def setUp(self):
         super(EmbedCSS, self).setUp()

--- a/core/src/zeit/content/portraitbox/tests.py
+++ b/core/src/zeit/content/portraitbox/tests.py
@@ -6,18 +6,16 @@ import zeit.cms.testing
 import zeit.content.portraitbox.interfaces
 
 
-PortraitboxLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(PortraitboxLayer,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 class PortraitboxSourceTest(
         zeit.cms.content.tests.test_contentsource.ContentSourceBase,
         zeit.cms.testing.FunctionalTestCase):
 
-    layer = PortraitboxLayer
+    layer = ZOPE_LAYER
 
     source = zeit.content.portraitbox.interfaces.portraitboxSource
     expected_types = ['portraitbox']
@@ -28,7 +26,7 @@ class PortraitboxSourceTest(
 
 class ReferenceTest(zeit.cms.testing.FunctionalTestCase):
 
-    layer = PortraitboxLayer
+    layer = ZOPE_LAYER
 
     def test_should_have_security_declarations(self):
         from zeit.content.portraitbox.reference import PortraitboxReference
@@ -50,7 +48,7 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
-        layer=PortraitboxLayer))
+        layer=ZOPE_LAYER))
     suite.addTest(unittest.makeSuite(PortraitboxSourceTest))
     suite.addTest(unittest.makeSuite(ReferenceTest))
     return suite

--- a/core/src/zeit/content/rawxml/tests.py
+++ b/core/src/zeit/content/rawxml/tests.py
@@ -1,14 +1,12 @@
 import zeit.cms.testing
 
 
-RawXMLLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(RawXMLLayer,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 def test_suite():
     return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
-        layer=RawXMLLayer)
+        layer=ZOPE_LAYER)

--- a/core/src/zeit/content/text/browser/tests/test_doctest.py
+++ b/core/src/zeit/content/text/browser/tests/test_doctest.py
@@ -1,12 +1,9 @@
-import unittest
 import zeit.cms.testing
 import zeit.content.text.testing
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(zeit.cms.testing.FunctionalDocFileSuite(
+    return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.content.text.browser',
-        layer=zeit.content.text.testing.WSGI_LAYER))
-    return suite
+        layer=zeit.content.text.testing.WSGI_LAYER)

--- a/core/src/zeit/content/text/testing.py
+++ b/core/src/zeit/content/text/testing.py
@@ -1,11 +1,14 @@
 import zeit.cms.testing
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(ZCML_LAYER,))
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = WSGI_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/content/text/tests/test_doctest.py
+++ b/core/src/zeit/content/text/tests/test_doctest.py
@@ -6,4 +6,4 @@ def test_suite():
     return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.content.text',
-        layer=zeit.content.text.testing.ZCML_LAYER)
+        layer=zeit.content.text.testing.ZOPE_LAYER)

--- a/core/src/zeit/content/text/tests/test_embed.py
+++ b/core/src/zeit/content/text/tests/test_embed.py
@@ -1,12 +1,9 @@
-import zeit.cms.testing
 import zeit.content.text.embed
 import zeit.content.text.testing
 import zope.schema
 
 
-class EmbedParameters(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.text.testing.ZCML_LAYER
+class EmbedParameters(zeit.content.text.testing.FunctionalTestCase):
 
     def create(self, params):
         result = zeit.content.text.embed.Embed()

--- a/core/src/zeit/content/text/tests/test_jinja.py
+++ b/core/src/zeit/content/text/tests/test_jinja.py
@@ -1,11 +1,8 @@
-import zeit.cms.testing
 import zeit.content.text.jinja
 import zeit.content.text.testing
 
 
-class PythonScriptTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.text.testing.ZCML_LAYER
+class PythonScriptTest(zeit.content.text.testing.FunctionalTestCase):
 
     def create(self, text):
         result = zeit.content.text.jinja.JinjaTemplate()

--- a/core/src/zeit/content/text/tests/test_python.py
+++ b/core/src/zeit/content/text/tests/test_python.py
@@ -1,10 +1,7 @@
-import zeit.cms.testing
 import zeit.content.text.testing
 
 
-class PythonScriptTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.content.text.testing.ZCML_LAYER
+class PythonScriptTest(zeit.content.text.testing.FunctionalTestCase):
 
     def create(self, text):
         py = zeit.content.text.python.PythonScript()

--- a/core/src/zeit/content/video/testing.py
+++ b/core/src/zeit/content/video/testing.py
@@ -1,25 +1,19 @@
-import doctest
 import mock
 import plone.testing
 import zeit.cms.repository.folder
 import zeit.cms.testing
 import zeit.find.testing
 import zeit.push.testing
-import zeit.workflow.testing
 import zope.component
 import zope.interface
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=(
-        zeit.find.testing.product_config +
-        zeit.push.testing.product_config +
-        zeit.cms.testing.cms_product_config +
-        zeit.workflow.testing.product_config))
-
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(
+    zeit.find.testing.CONFIG_LAYER,
+    zeit.push.testing.CONFIG_LAYER))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 PUSH_LAYER = zeit.push.testing.UrbanairshipTemplateLayer(
-    name='UrbanairshipTemplateLayer', bases=(ZCML_LAYER,))
+    name='UrbanairshipTemplateLayer', bases=(ZOPE_LAYER,))
 
 
 class PlayerMockLayer(plone.testing.Layer):
@@ -47,9 +41,7 @@ PLAYER_MOCK_LAYER = PlayerMockLayer()
 LAYER = plone.testing.Layer(
     bases=(PUSH_LAYER, PLAYER_MOCK_LAYER),
     name='Layer', module=__name__)
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(LAYER,))
 
 
 class TestCase(zeit.cms.testing.FunctionalTestCase):

--- a/core/src/zeit/content/volume/browser/tests/test_admin.py
+++ b/core/src/zeit/content/volume/browser/tests/test_admin.py
@@ -7,6 +7,7 @@ import zeit.cms.interfaces
 import zeit.content.volume.testing
 import zeit.find.interfaces
 import zeit.workflow.testing
+import zope.component
 
 
 class VolumeAdminBrowserTest(zeit.content.volume.testing.BrowserTestCase):
@@ -15,7 +16,8 @@ class VolumeAdminBrowserTest(zeit.content.volume.testing.BrowserTestCase):
 
     def setUp(self):
         self.elastic = mock.Mock()
-        self.zca.patch_utility(self.elastic, zeit.find.interfaces.ICMSSearch)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.elastic, zeit.find.interfaces.ICMSSearch)
         super(VolumeAdminBrowserTest, self).setUp()
         volume = Volume()
         volume.year = 2015
@@ -118,7 +120,8 @@ class PublishAllContent(zeit.content.volume.testing.SeleniumTestCase):
         super(PublishAllContent, self).setUp()
         elastic = mock.Mock()
         elastic.search.return_value = zeit.cms.interfaces.Result()
-        self.zca.patch_utility(elastic, zeit.find.interfaces.ICMSSearch)
+        zope.component.getGlobalSiteManager().registerUtility(
+            elastic, zeit.find.interfaces.ICMSSearch)
         volume = Volume()
         volume.year = 2015
         volume.volume = 1

--- a/core/src/zeit/content/volume/tests/test_volume.py
+++ b/core/src/zeit/content/volume/tests/test_volume.py
@@ -19,6 +19,7 @@ import zeit.content.volume.testing
 import zeit.content.volume.volume
 import zeit.find.interfaces
 import zope.app.appsetup.product
+import zope.component
 
 
 class TestVolumeCovers(zeit.content.volume.testing.FunctionalTestCase):
@@ -202,9 +203,10 @@ class TestVolumeQueries(zeit.content.volume.testing.FunctionalTestCase):
         self.create_volume(2015, 1)
         self.create_volume(2015, 2)
         self.elastic = mock.Mock()
-        self.zca.patch_utility(
+        zope.component.getGlobalSiteManager().registerUtility(
             self.elastic, zeit.retresco.interfaces.IElasticsearch)
-        self.zca.patch_utility(self.elastic, zeit.find.interfaces.ICMSSearch)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.elastic, zeit.find.interfaces.ICMSSearch)
 
     def create_volume(self, year, name):
         volume = Volume()

--- a/core/src/zeit/edit/testing.py
+++ b/core/src/zeit/edit/testing.py
@@ -4,11 +4,10 @@ import zeit.cms.testing
 import zeit.workflow.testing
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=zeit.cms.testing.cms_product_config +
-    zeit.workflow.testing.product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(
+    zeit.workflow.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(
@@ -19,7 +18,7 @@ WEBDRIVER_LAYER = gocept.selenium.WebdriverSeleneseLayer(
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 
-    layer = ZCML_LAYER
+    layer = ZOPE_LAYER
 
 
 class SeleniumTestCase(zeit.cms.testing.SeleniumTestCase):

--- a/core/src/zeit/edit/tests/test_container.py
+++ b/core/src/zeit/edit/tests/test_container.py
@@ -89,7 +89,7 @@ class ContainerTest(zeit.edit.testing.FunctionalTestCase):
 
     def test_moving_item_between_containers_sends_event(self):
         check_move = mock.Mock()
-        self.zca.patch_handler(
+        zope.component.getGlobalSiteManager().registerHandler(
             check_move, (zeit.edit.interfaces.IBlock,
                          zope.lifecycleevent.IObjectMovedEvent))
         block = self.container.create_item('block')

--- a/core/src/zeit/find/testing.py
+++ b/core/src/zeit/find/testing.py
@@ -16,14 +16,15 @@ product_config = """\
 """
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml',
-    product_config=zeit.cms.testing.cms_product_config + product_config)
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.cms.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
 class Layer(plone.testing.Layer):
 
-    defaultBases = (ZCML_LAYER,)
+    defaultBases = (ZOPE_LAYER,)
 
     def setUp(self):
         self.search = zope.component.getUtility(

--- a/core/src/zeit/ghost/testing.py
+++ b/core/src/zeit/ghost/testing.py
@@ -1,5 +1,10 @@
 import zeit.cms.testing
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
+
+
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER

--- a/core/src/zeit/ghost/tests/test_doctest.py
+++ b/core/src/zeit/ghost/tests/test_doctest.py
@@ -6,4 +6,4 @@ def test_suite():
     return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.ghost',
-        layer=zeit.ghost.testing.ZCML_LAYER)
+        layer=zeit.ghost.testing.ZOPE_LAYER)

--- a/core/src/zeit/ghost/tests/test_ghost.py
+++ b/core/src/zeit/ghost/tests/test_ghost.py
@@ -3,14 +3,11 @@ from zeit.cms.checkout.interfaces import ICheckoutManager
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import mock
 import zeit.cms.checkout.interfaces
-import zeit.cms.testing
 import zeit.ghost.ghost
 import zeit.ghost.testing
 
 
-class GhostbusterTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.ghost.testing.ZCML_LAYER
+class GhostbusterTest(zeit.ghost.testing.FunctionalTestCase):
 
     def test_removes_excessive_ghosts_on_checkout(self):
         self.repository['ghost-origin'] = ExampleContentType()

--- a/core/src/zeit/imp/browser/tests/test_doctest.py
+++ b/core/src/zeit/imp/browser/tests/test_doctest.py
@@ -1,12 +1,9 @@
-import unittest
 import zeit.cms.testing
 import zeit.imp.tests
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(zeit.cms.testing.FunctionalDocFileSuite(
+    return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.imp.browser',
-        layer=zeit.imp.tests.WSGI_LAYER))
-    return suite
+        layer=zeit.imp.tests.WSGI_LAYER)

--- a/core/src/zeit/imp/browser/tests/test_selenium.py
+++ b/core/src/zeit/imp/browser/tests/test_selenium.py
@@ -9,7 +9,7 @@ import zeit.imp.tests
 
 
 WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(zeit.imp.tests.imp_layer,))
+    name='WSGILayer', bases=(zeit.imp.tests.ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(

--- a/core/src/zeit/imp/tests.py
+++ b/core/src/zeit/imp/tests.py
@@ -12,20 +12,17 @@ import zope.interface.verify
 
 product_config = """
 <product-config zeit.imp>
-    scale-source file://%s
-    color-source file://%s
+    scale-source file://{base}/scales.xml
+    color-source file://{base}/colors.xml
 </product-config>
-""" % (
-    pkg_resources.resource_filename(__name__, 'scales.xml'),
-    pkg_resources.resource_filename(__name__, 'colors.xml'))
+""".format(base=pkg_resources.resource_filename(__name__, ''))
 
 
-imp_layer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config +
-    zeit.content.image.testing.product_config +
-    product_config)
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(imp_layer,))
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
+    product_config, bases=(zeit.content.image.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
@@ -110,7 +107,7 @@ class TestLayerMask(unittest.TestCase):
 
 class TestSources(zeit.cms.testing.FunctionalTestCase):
 
-    layer = imp_layer
+    layer = ZOPE_LAYER
 
     def test_scale_source(self):
         source = zeit.imp.source.ScaleSource()(None)
@@ -136,7 +133,7 @@ class TestSources(zeit.cms.testing.FunctionalTestCase):
 
 class TestCrop(zeit.cms.testing.FunctionalTestCase):
 
-    layer = imp_layer
+    layer = ZOPE_LAYER
 
     def setUp(self):
         super(TestCrop, self).setUp()

--- a/core/src/zeit/invalidate/ftesting.zcml
+++ b/core/src/zeit/invalidate/ftesting.zcml
@@ -1,12 +1,7 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
-  <include package="zope.app.zcmlfiles" />
+  <include package="zeit.cms" file="application.zcml" />
   <include package="zope.securitypolicy" />
-  <include package="zope.securitypolicy" file="meta.zcml" />
-  <include package="zope.login" />
-  <include package="zope.password" />
-  <include package="zope.authentication" />
-
   <securityPolicy
     component="zope.securitypolicy.zopepolicy.ZopeSecurityPolicy" />
 

--- a/core/src/zeit/invalidate/tests.py
+++ b/core/src/zeit/invalidate/tests.py
@@ -1,8 +1,9 @@
 import zeit.cms.testing
 
 
-LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml')
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer()
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 def test_suite():

--- a/core/src/zeit/newsletter/testing.py
+++ b/core/src/zeit/newsletter/testing.py
@@ -18,20 +18,11 @@ product_config = """\
 </product-config>
 """
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', product_config=(
-    zeit.cms.testing.cms_product_config +
-    zeit.workflow.testing.product_config +
-    product_config))
-
-
-class TestLayer(plone.testing.Layer):
-
-    defaultBases = (ZCML_LAYER, PLAYER_MOCK_LAYER)
-
-TEST_LAYER = TestLayer()
-
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.workflow.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER, PLAYER_MOCK_LAYER))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
 WD_LAYER = gocept.selenium.WebdriverLayer(
@@ -55,7 +46,7 @@ BROWSER_LAYER = TestBrowserLayer()
 
 class TestCase(zeit.cms.testing.FunctionalTestCase):
 
-    layer = TEST_LAYER
+    layer = ZOPE_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):

--- a/core/src/zeit/newsletter/tests/test_newsletter.py
+++ b/core/src/zeit/newsletter/tests/test_newsletter.py
@@ -116,8 +116,9 @@ class SendTest(zeit.newsletter.testing.TestCase):
         self.newsletter = self.repository['mynl']['newsletter']
         self.newsletter.subject = 'thesubject'
 
-        self.renderer = self.zca.patch_utility(
-            mock.Mock(), zeit.newsletter.interfaces.IRenderer)
+        self.renderer = mock.Mock()
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.renderer, zeit.newsletter.interfaces.IRenderer)
         self.renderer.return_value = dict(
             html=mock.sentinel.html, text=mock.sentinel.text)
 
@@ -125,17 +126,17 @@ class SendTest(zeit.newsletter.testing.TestCase):
         self.optivo.reset()
 
     def test_send_uses_renderer_and_calls_optivo(self):
-            self.newsletter.send()
-            self.assertEqual(
-                ('send', 12345, 'recipientlist', 'thesubject',
-                 mock.sentinel.html, mock.sentinel.text), self.optivo.calls[0])
+        self.newsletter.send()
+        self.assertEqual(
+            ('send', 12345, 'recipientlist', 'thesubject',
+             mock.sentinel.html, mock.sentinel.text), self.optivo.calls[0])
 
     def test_send_test_passes_recipient_to_optivo(self):
-            self.newsletter.send_test('test@example.com')
-            self.assertEqual(
-                ('test', 12345, 'recipientlist_test',
-                 'test@example.com', '[test] thesubject',
-                 mock.sentinel.html, mock.sentinel.text), self.optivo.calls[0])
+        self.newsletter.send_test('test@example.com')
+        self.assertEqual(
+            ('test', 12345, 'recipientlist_test',
+             'test@example.com', '[test] thesubject',
+             mock.sentinel.html, mock.sentinel.text), self.optivo.calls[0])
 
     def test_send_updates_timestamp_even_when_error(self):
         with checked_out(self.newsletter) as co:

--- a/core/src/zeit/objectlog/ftesting.zcml
+++ b/core/src/zeit/objectlog/ftesting.zcml
@@ -3,12 +3,7 @@
    xmlns:meta="http://namespaces.zope.org/meta"
    i18n_domain="zope">
 
-  <include package="zope.app.zcmlfiles" />
-  <include package="zope.app.zcmlfiles" file="ftesting.zcml" />
-
-  <include package="zope.app.keyreference" />
-  <include package="zc.sourcefactory" />
-
+  <include package="zeit.cms" file="application.zcml" />
   <include package="zeit.objectlog" />
 
   <principal

--- a/core/src/zeit/objectlog/testing.py
+++ b/core/src/zeit/objectlog/testing.py
@@ -1,18 +1,14 @@
-import os
 import persistent
-import re
 import zeit.cms.testing
-import zope.app.testing.functional
 
 
-ObjectLogLayer = zope.app.testing.functional.ZCMLLayer(
-    os.path.join(os.path.dirname(__file__), 'ftesting.zcml'),
-    __name__, 'ObjectLogLayer', allow_teardown=True)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer()
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
-FORMATTED_DATE_REGEX = re.compile(r'\d{4} \d{1,2} \d{1,2}  \d\d:\d\d:\d\d')
-checker = zeit.cms.testing.OutputChecker([
-    (FORMATTED_DATE_REGEX, '<formatted date>')])
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
+
+    layer = ZOPE_LAYER
 
 
 class Content(persistent.Persistent):

--- a/core/src/zeit/objectlog/tests/test_doctest.py
+++ b/core/src/zeit/objectlog/tests/test_doctest.py
@@ -1,14 +1,9 @@
-import doctest
+import zeit.cms.testing
 import zeit.objectlog.testing
-import zope.app.testing.functional
 
 
 def test_suite():
-    suite = zope.app.testing.functional.FunctionalDocFileSuite(
+    return zeit.cms.testing.FunctionalDocFileSuite(
         'README.txt',
         package='zeit.objectlog',
-        optionflags=(doctest.ELLIPSIS |
-                     doctest.REPORT_NDIFF | doctest.NORMALIZE_WHITESPACE),
-        checker=zeit.objectlog.testing.checker)
-    suite.layer = zeit.objectlog.testing.ObjectLogLayer
-    return suite
+        layer=zeit.objectlog.testing.ZOPE_LAYER)

--- a/core/src/zeit/objectlog/tests/test_objectlog.py
+++ b/core/src/zeit/objectlog/tests/test_objectlog.py
@@ -1,32 +1,17 @@
 from datetime import datetime
 import transaction
-import zeit.cms.testing
 import zeit.objectlog.interfaces
 import zeit.objectlog.testing
-import zope.app.testing.functional
 import zope.component
-import zope.component.hooks
-import zope.publisher.browser
-import zope.security.management
-import zope.security.testing
 
 
-class ObjectLog(zope.app.testing.functional.FunctionalTestCase):
-
-    layer = zeit.objectlog.testing.ObjectLogLayer
+class ObjectLog(zeit.objectlog.testing.FunctionalTestCase):
 
     def setUp(self):
         super(ObjectLog, self).setUp()
-        zope.component.hooks.setSite(self.getRootFolder())
-        zeit.cms.testing.create_interaction()
         self.content = zeit.objectlog.testing.Content()
         self.getRootFolder()['content'] = self.content
         transaction.commit()
-
-    def tearDown(self):
-        zope.component.hooks.setSite(None)
-        zope.security.management.endInteraction()
-        super(ObjectLog, self).tearDown()
 
     def test_timestamp_can_be_overridden(self):
         log = zeit.objectlog.interfaces.ILog(self.content)

--- a/core/src/zeit/push/tests/test_workflow.py
+++ b/core/src/zeit/push/tests/test_workflow.py
@@ -6,6 +6,7 @@ import lxml.etree
 import mock
 import zeit.cms.content.interfaces
 import zeit.push.testing
+import zope.component
 
 
 class PushServiceProperties(zeit.push.testing.TestCase):
@@ -34,7 +35,7 @@ class SendingNotifications(zeit.push.testing.TestCase):
     def setUp(self):
         super(SendingNotifications, self).setUp()
         self.notifier = mock.Mock()
-        self.zca.patch_adapter(
+        zope.component.getGlobalSiteManager().registerAdapter(
             self.notifier, (zeit.cms.content.interfaces.ICommonMetadata,),
             zeit.push.interfaces.IMessage, name='mypush')
         # getAdapter instantiates factory, which causes one call

--- a/core/src/zeit/retresco/tests/test_search.py
+++ b/core/src/zeit/retresco/tests/test_search.py
@@ -9,7 +9,7 @@ import zope.component
 class TestElasticsearch(unittest.TestCase):
     """Testing ..search.Elasticsearch."""
 
-    layer = zeit.retresco.testing.MOCK_ZCML_LAYER
+    layer = zeit.retresco.testing.MOCK_LAYER
 
     query = {
         "query": {

--- a/core/src/zeit/retresco/tests/test_update.py
+++ b/core/src/zeit/retresco/tests/test_update.py
@@ -20,7 +20,8 @@ class UpdateTest(zeit.retresco.testing.FunctionalTestCase):
         self.tms = mock.Mock()
         self.tms.enrich.return_value = {}
         self.tms.generate_keyword_list.return_value = []
-        self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.tms, zeit.retresco.interfaces.ITMS)
 
     def test_creating_content_should_index(self):
         self.repository['t1'] = ExampleContentType()
@@ -161,7 +162,8 @@ class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
     def setUp(self):
         super(UpdatePublishTest, self).setUp()
         self.tms = mock.Mock()
-        self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.tms, zeit.retresco.interfaces.ITMS)
 
     def test_publish_should_index_with_published_true(self):
         published = []
@@ -244,7 +246,8 @@ class RetryTest(zeit.retresco.testing.FunctionalTestCase):
 
         self.tms = mock.Mock()
         self.tms.enrich.return_value = {}
-        self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.tms, zeit.retresco.interfaces.ITMS)
 
         self.retry_patch = mock.patch(
             'zeit.cms.celery.Task.default_retry_delay', new=None)

--- a/core/src/zeit/retresco/xmlrpc/tests/test_update.py
+++ b/core/src/zeit/retresco/xmlrpc/tests/test_update.py
@@ -6,6 +6,7 @@ import mock
 import zeit.cms.interfaces
 import zeit.cms.webtest
 import zeit.retresco.testing
+import zope.component
 
 
 class XMLRPCTest(zeit.retresco.testing.BrowserTestCase):
@@ -19,7 +20,8 @@ class XMLRPCTest(zeit.retresco.testing.BrowserTestCase):
         self.tms = mock.Mock()
         self.tms.enrich.return_value = {}
         self.tms.generate_keyword_list.return_value = []
-        self.zca.patch_utility(self.tms, zeit.retresco.interfaces.ITMS)
+        zope.component.getGlobalSiteManager().registerUtility(
+            self.tms, zeit.retresco.interfaces.ITMS)
 
         self.log = StringIO.StringIO()
         self.log_handler = logging.StreamHandler(self.log)

--- a/core/src/zeit/securitypolicy/ftesting.zcml
+++ b/core/src/zeit/securitypolicy/ftesting.zcml
@@ -3,10 +3,12 @@
   i18n_domain="zeit.cms">
 
   <include package="zeit.cms" file="application.zcml" />
+  <!-- generic @@contents views -->
+  <include package="zope.app.container.browser.tests" />
+
   <include package="zeit.cms" />
   <include package="zeit.connector" file="mock-connector.zcml" />
   <include package="zeit.push" />
-  <include package="zope.app.zcmlfiles" file="ftesting.zcml" />
 
   <include package="zeit.securitypolicy" />
 

--- a/core/src/zeit/seo/tests.py
+++ b/core/src/zeit/seo/tests.py
@@ -2,9 +2,9 @@ import unittest
 import zeit.cms.testing
 
 
-SEOLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=zeit.cms.testing.cms_product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(SEOLayer,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 def test_suite():

--- a/core/src/zeit/sourcepoint/testing.py
+++ b/core/src/zeit/sourcepoint/testing.py
@@ -12,17 +12,18 @@ product_config = """\
 </product-config>
 """
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'testing.zcml', product_config=product_config +
-    zeit.cms.testing.cms_product_config)
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.cms.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer('testing.zcml', bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 
 
 class Layer(plone.testing.Layer):
 
-    defaultBases = (ZCML_LAYER,)
+    defaultBases = (ZOPE_LAYER,)
 
     def testSetUp(self):
-        with zeit.cms.testing.site(self['functional_setup'].getRootFolder()):
+        with zeit.cms.testing.site(self['zodbApp']):
             repository = zope.component.getUtility(
                 zeit.cms.repository.interfaces.IRepository)
             repository['sourcepoint'] = zeit.cms.repository.folder.Folder()

--- a/core/src/zeit/vgwort/testing.py
+++ b/core/src/zeit/vgwort/testing.py
@@ -27,10 +27,12 @@ product_config = """
 )
 
 
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+    zeit.cms.testing.CONFIG_LAYER,))
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
-    'ftesting-mock.zcml',
-    product_config=zeit.cms.testing.cms_product_config + product_config)
-WSGI_LAYER = zeit.cms.testing.WSGILayer(name='WSGILayer', bases=(ZCML_LAYER,))
+    'ftesting-mock.zcml', bases=(CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 class XMLRPCLayer(plone.testing.Layer):
@@ -46,14 +48,14 @@ class XMLRPCLayer(plone.testing.Layer):
 
 XMLRPC_LAYER = XMLRPCLayer()
 
-SOAPLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting-soap.zcml', name='SOAPLayer',
-    product_config=zeit.cms.testing.cms_product_config + product_config)
+SOAP_ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
+    'ftesting-soap.zcml', bases=(CONFIG_LAYER,))
+SOAP_LAYER = zeit.cms.testing.ZopeLayer(bases=(SOAP_ZCML_LAYER,))
 
 
 class TestCase(zeit.cms.testing.FunctionalTestCase):
 
-    layer = ZCML_LAYER
+    layer = ZOPE_LAYER
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
@@ -65,7 +67,7 @@ class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 class EndToEndTestCase(zeit.cms.testing.FunctionalTestCase,
                        unittest.TestCase):
 
-    layer = SOAPLayer
+    layer = SOAP_LAYER
     level = 2
 
     def setUp(self):
@@ -74,7 +76,7 @@ class EndToEndTestCase(zeit.cms.testing.FunctionalTestCase,
             zeit.vgwort.interfaces.IMessageService)
         try:
             service.call('qualityControl')
-        except:
+        except Exception as e:
             self.skipTest('vgwort test system is down')
 
 

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -23,9 +23,7 @@ import zope.component
 import zope.i18n
 
 
-class PublishTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class PublishTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_object_already_checked_out_should_raise(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
@@ -67,9 +65,7 @@ class RelatedDependency(object):
         return relateds.related
 
 
-class PublicationDependencies(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class PublicationDependencies(zeit.workflow.testing.FunctionalTestCase):
 
     def setUp(self):
         super(PublicationDependencies, self).setUp()
@@ -142,9 +138,7 @@ class PublicationDependencies(zeit.cms.testing.FunctionalTestCase):
                     if IPublishInfo(x).date_last_published > BEFORE_PUBLISH]))
 
 
-class SynchronousPublishTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class SynchronousPublishTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_publish_and_retract_in_same_process(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
@@ -170,9 +164,7 @@ class SynchronousPublishTest(zeit.cms.testing.FunctionalTestCase):
         self.assertTrue(info.published)
 
 
-class PublishPriorityTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class PublishPriorityTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_determines_priority_via_adapter(self):
         content = self.repository['testcontent']
@@ -329,9 +321,7 @@ class PublishErrorEndToEndTest(zeit.cms.testing.FunctionalTestCase):
             [zope.i18n.interpolate(m, m.mapping) for m in get_object_log(c2)])
 
 
-class MultiPublishRetractTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class MultiPublishRetractTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_publishes_and_retracts_multiple_objects_in_single_script_call(
             self):
@@ -390,7 +380,7 @@ class MultiPublishRetractTest(zeit.cms.testing.FunctionalTestCase):
             calls.append(context.uniqueId)
             if context.uniqueId == c1.uniqueId:
                 raise RuntimeError('provoked')
-        self.zca.patch_handler(
+        zope.component.getGlobalSiteManager().registerHandler(
             after_publish,
             (zeit.cms.interfaces.ICMSContent,
              zeit.cms.workflow.interfaces.IPublishedEvent))

--- a/core/src/zeit/workflow/tests/test_publishinfo.py
+++ b/core/src/zeit/workflow/tests/test_publishinfo.py
@@ -1,13 +1,10 @@
 from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
-import zeit.cms.testing
 import zeit.workflow.testing
 import zope.copypastemove.interfaces
 import zope.interface.verify
 
 
-class PublishInfoTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class PublishInfoTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_last_published_by_takes_last_entry_from_objectlog(self):
         content = self.repository['testcontent']
@@ -23,9 +20,7 @@ class PublishInfoTest(zeit.cms.testing.FunctionalTestCase):
         zope.interface.verify.verifyObject(IPublishInfo, info)
 
 
-class WorkflowCopyTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class WorkflowCopyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_publishinfo_is_reset_for_copied_objects(self):
         content = self.repository['testcontent']

--- a/core/src/zeit/workflow/tests/test_timebased.py
+++ b/core/src/zeit/workflow/tests/test_timebased.py
@@ -16,9 +16,7 @@ import zope.component
 import zope.i18n
 
 
-class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class TimeBasedWorkflowTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_add_job_calls_apply_async_on_commit_with_eta_for_future_execution(
             self):
@@ -54,9 +52,7 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
                 apply_async.call_args[0][0][0][0])
 
 
-class PrintImportSchedulingTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class PrintImportSchedulingTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_should_schedule_job_when_no_jobid_present(self):
         content = self.repository['testcontent']

--- a/core/src/zeit/workflow/tests/test_workflow.py
+++ b/core/src/zeit/workflow/tests/test_workflow.py
@@ -6,7 +6,6 @@ import zeit.cms.repository.folder
 import zeit.cms.repository.interfaces
 import zeit.cms.repository.unknown
 import zeit.cms.testcontenttype.interfaces
-import zeit.cms.testing
 import zeit.cms.workflow.interfaces
 import zeit.workflow.asset
 import zeit.workflow.testing
@@ -14,9 +13,7 @@ import zope.annotation.interfaces
 import zope.interface
 
 
-class AssetWorkflowTests(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class AssetWorkflowTests(zeit.workflow.testing.FunctionalTestCase):
 
     def setUp(self):
         super(AssetWorkflowTests, self).setUp()
@@ -56,9 +53,7 @@ class AssetWorkflowTests(zeit.cms.testing.FunctionalTestCase):
         assert not workflow.published
 
 
-class ContentWorkflowTest(zeit.cms.testing.FunctionalTestCase):
-
-    layer = zeit.workflow.testing.LAYER
+class ContentWorkflowTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_content_in_blacklisted_folder_should_not_publish(self):
         self.repository['blacklist'] = zeit.cms.repository.folder.Folder()

--- a/core/src/zeit/wysiwyg/testing.py
+++ b/core/src/zeit/wysiwyg/testing.py
@@ -9,18 +9,15 @@ import zope.component
 import zope.interface
 
 
-WYSIWYGLayer = zeit.cms.testing.ZCMLLayer(
-    'ftesting.zcml', product_config=(
-        zeit.content.image.testing.product_config +
-        zeit.cms.testing.cms_product_config))
-
-WSGI_LAYER = zeit.cms.testing.WSGILayer(
-    name='WSGILayer', bases=(WYSIWYGLayer,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(
+    zeit.content.image.testing.CONFIG_LAYER,))
+ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
-class WYSIWYGTestCase(zeit.cms.testing.FunctionalTestCase):
+class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 
-    layer = WYSIWYGLayer
+    layer = ZOPE_LAYER
 
 
 class HTMLContent(zeit.wysiwyg.html.HTMLContentBase):

--- a/core/src/zeit/wysiwyg/tests/test_doctests.py
+++ b/core/src/zeit/wysiwyg/tests/test_doctests.py
@@ -7,4 +7,4 @@ def test_suite():
         'html.txt',
         'reference.txt',
         package='zeit.wysiwyg',
-        layer=zeit.wysiwyg.testing.WYSIWYGLayer)
+        layer=zeit.wysiwyg.testing.ZOPE_LAYER)

--- a/core/src/zeit/wysiwyg/tests/test_html.py
+++ b/core/src/zeit/wysiwyg/tests/test_html.py
@@ -6,7 +6,7 @@ import zeit.wysiwyg.html
 import zeit.wysiwyg.testing
 
 
-class VideoExpiresTest(zeit.wysiwyg.testing.WYSIWYGTestCase):
+class VideoExpiresTest(zeit.wysiwyg.testing.FunctionalTestCase):
 
     def setUp(self):
         super(VideoExpiresTest, self).setUp()
@@ -49,7 +49,7 @@ class VideoExpiresTest(zeit.wysiwyg.testing.WYSIWYGTestCase):
             self.step._expires(VIDEO1, VIDEO2, None))
 
 
-class VideoStepTest(zeit.wysiwyg.testing.WYSIWYGTestCase):
+class VideoStepTest(zeit.wysiwyg.testing.FunctionalTestCase):
 
     def test_empty_hrefs_should_not_break_conversion(self):
         source = """\
@@ -82,7 +82,7 @@ class VideoStepTest(zeit.wysiwyg.testing.WYSIWYGTestCase):
 """, lxml.etree.tostring(article.xml, pretty_print=True))
 
 
-class TopLevelTest(zeit.wysiwyg.testing.WYSIWYGTestCase):
+class TopLevelTest(zeit.wysiwyg.testing.FunctionalTestCase):
 
     def test_regression_conversion_to_p_copes_with_non_element_nodes(self):
         source = '<article><body></body></article>'


### PR DESCRIPTION
* Split everything that FTS did (product config, zcml, zodb, etc.) into individual layers, for better readibility and composeability
* For these components I would have liked to use the test layers provided by zope.component, zope.app.appsetup etc., but they don't fit with plone.testing.Layer very well, and also don't always _quite_ do what I want, so I implemented them myself (not that much code anyway)
* Functional tests now have to use ZOPE_LAYER instead of ZCML_LAYER, we use this to uniformly use per-module FunctionalTestCase base classes
* Replace gocept.zcapatch with plone.testing pushGlobalRegistry() and then directly using registerUtility() and friends. Note however you'll probably want to use getGlobalSiteManager(), to avoid pickling issues that the (set-by-default in tests) local site manager would cause
* zeit.connector now uses zeit.cms for testing infrastructure (this was a no-go in pre-monorepo days, but only testing it's fine now)