### PR TITLE
Remove old function call for outdated fanstatic alpha

### DIFF
--- a/core/src/zeit/cms/browser/resources.py
+++ b/core/src/zeit/cms/browser/resources.py
@@ -19,7 +19,7 @@ backend = Group([])
 
 def register(resource):
     depends = backend.depends.union(
-        set(fanstatic.core.normalize_groups([resource])))
+        set([resource]))
     for dep in depends:
         backend.resources.update(dep.resources)
 


### PR DESCRIPTION
needs: https://github.com/ZeitOnline/vivi-deployment/pull/81

JENKINS_BATOU_BRANCH=migrate-gocept-jasmine