### PR TITLE
OPS-1133: Modify DAV cache conflict resolution rules to avoid deleting cache entries

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,11 @@ vivi.core changes
 4.21.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- OPS-1133: Modify DAV cache conflict resolution rules
+  to avoid deleting cache entries (doing that was definitely correct,
+  but it caused thundering herd issues e.g. for often-used folders)
+  Set feature toggle `dav_cache_delete_on_conflict` to revert to the previous
+  behaviour.
 
 
 4.21.4 (2019-11-13)

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -8,8 +8,8 @@ vivi.core changes
 - OPS-1133: Modify DAV cache conflict resolution rules
   to avoid deleting cache entries (doing that was definitely correct,
   but it caused thundering herd issues e.g. for often-used folders)
-  Set feature toggle `dav_cache_delete_on_conflict` to revert to the previous
-  behaviour.
+  Set feature toggle `dav_cache_delete_property_on_conflict` (or `childname`)
+  to revert to the previous behaviour.
 
 
 4.21.4 (2019-11-13)

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -141,16 +141,6 @@ def configure_dogpile_cache(event):
     settings = {
         'dogpile_cache.regions': config['cache-regions']
     }
-    if config.get('cache-redis-url', '').strip():
-        import zeit.connector.cache
-        settings['dogpile_cache.regions'] += ', dav'
-        pyramid_dogpile_cache2.CACHE_REGIONS[
-            'dav'] = zeit.connector.cache.DAV_CACHE
-
-        settings.update({
-            'dogpile_cache.dav.backend': 'dogpile.cache.redis',
-            'dogpile_cache.dav.arguments.url': config['cache-redis-url'],
-        })
     for region in re.split(r'\s*,\s*', config['cache-regions']):
         settings['dogpile_cache.%s.backend' % region] = 'dogpile.cache.memory'
         settings['dogpile_cache.%s.expiration_time' % region] = config[

--- a/core/src/zeit/connector/cache.py
+++ b/core/src/zeit/connector/cache.py
@@ -1,11 +1,9 @@
-from dogpile.cache.api import NO_VALUE
 from gocept.cache.method import Memoize as memoize
 import BTrees
 import UserDict
 import ZODB.POSException
 import ZODB.blob
 import cStringIO
-import dogpile.cache
 import gocept.lxml.objectify
 import logging
 import lxml.objectify
@@ -528,49 +526,3 @@ class FeatureToggles(object):
 
 
 FEATURE_TOGGLES = FeatureToggles()
-
-
-# Don't use pyramid_dogpile_cache2.get_region, we want no key mangling here.
-DAV_CACHE = dogpile.cache.make_region('dav')
-
-
-class DogpileCache(object):
-
-    prefix = NotImplemented
-
-    def _key(self, key):
-        return key.replace(
-            zeit.cms.interfaces.ID_NAMESPACE, u'%s:' % self.prefix, 1)
-
-    def __getitem__(self, key):
-        value = self.get(key, NO_VALUE)
-        if value is NO_VALUE:
-            raise KeyError(key)
-        return value
-
-    def get(self, key, default=None):
-        value = DAV_CACHE.get(self._key(key))
-        return value if value is not NO_VALUE else default
-
-    def __setitem__(self, key, value):
-        DAV_CACHE.set(self._key(key), value)
-
-    def __delitem__(self, key):
-        DAV_CACHE.delete(self._key(key))
-
-    def __contains__(self, key):
-        return self.get(key, NO_VALUE) is not NO_VALUE
-
-
-class PropertyDogpileCache(DogpileCache):
-
-    zope.interface.implements(zeit.connector.interfaces.IPropertyCache)
-
-    prefix = 'prop'
-
-
-class ChildNameDogpileCache(DogpileCache):
-
-    zope.interface.implements(zeit.connector.interfaces.IChildNameCache)
-
-    prefix = 'child'

--- a/core/src/zeit/connector/cache.py
+++ b/core/src/zeit/connector/cache.py
@@ -1,17 +1,21 @@
 from dogpile.cache.api import NO_VALUE
+from gocept.cache.method import Memoize as memoize
 import BTrees
 import UserDict
 import ZODB.POSException
 import ZODB.blob
 import cStringIO
 import dogpile.cache
+import gocept.lxml.objectify
 import logging
+import lxml.objectify
+import os
 import persistent
 import persistent.mapping
-import pyramid_dogpile_cache2
 import tempfile
 import time
 import transaction
+import urllib2
 import zc.set
 import zeit.connector.interfaces
 import zope.interface
@@ -384,6 +388,11 @@ class Properties(persistent.mapping.PersistentMapping):
 
     # NOTE: By default, conflict resolution is performed by the ZEO *server*!
     def _p_resolveConflict(self, old, commited, newstate):
+        if not FEATURE_TOGGLES.find('dav_cache_delete_on_conflict'):
+            log.info('Overwriting %s with %s after ConflictError',
+                     commited, newstate)
+            return newstate
+
         if not (old.keys() ==
                 commited.keys() ==
                 newstate.keys() ==
@@ -398,6 +407,7 @@ class Properties(persistent.mapping.PersistentMapping):
         if newstate_data == commited_data:
             return newstate
         # Completely invalidate cache entry when we cannot resolve.
+        log.info('Emptying %s due to ConflictError', newstate)
         old['data'] = {zeit.connector.interfaces.DeleteProperty: None}
         return old
 
@@ -442,6 +452,9 @@ class ChildNames(zc.set.Set):
     def _p_resolveConflict(self, old, commited, newstate):
         if commited == newstate:
             return commited
+        if not FEATURE_TOGGLES.find('dav_cache_delete_on_conflict'):
+            raise ZODB.POSException.ConflictError()
+        log.info('Emptying %s due to ConflictError', newstate)
         old['_data'] = set([zeit.connector.interfaces.DeleteProperty])
         return old
 
@@ -487,6 +500,34 @@ class AlwaysEmptyDict(UserDict.DictMixin):
 
     def keys(self):
         return ()
+
+
+# Copy&paste from zeit.cms.content.sources to make it work in a ZEO environment
+# where we have no dogpile setup, no product config, etc.pp.
+class FeatureToggles(object):
+
+    config_url = 'ZEIT_VIVI_FEATURE_TOGGLE_SOURCE'
+
+    def find(self, name):
+        try:
+            return bool(getattr(self._get_tree(), name, False))
+        except TypeError:
+            return False
+
+    @memoize(300, ignore_self=True)
+    def _get_tree(self):
+        if self.config_url not in os.environ:
+            return lxml.objectify.XML('<empty/>')
+        return self._get_tree_from_url(os.environ[self.config_url])
+
+    def _get_tree_from_url(self, url):
+        __traceback_info__ = (url, )
+        log.debug('Getting %s' % url)
+        response = urllib2.urlopen(url)
+        return gocept.lxml.objectify.fromfile(response)
+
+
+FEATURE_TOGGLES = FeatureToggles()
 
 
 # Don't use pyramid_dogpile_cache2.get_region, we want no key mangling here.

--- a/core/src/zeit/connector/cache.py
+++ b/core/src/zeit/connector/cache.py
@@ -386,7 +386,7 @@ class Properties(persistent.mapping.PersistentMapping):
 
     # NOTE: By default, conflict resolution is performed by the ZEO *server*!
     def _p_resolveConflict(self, old, commited, newstate):
-        if not FEATURE_TOGGLES.find('dav_cache_delete_on_conflict'):
+        if not FEATURE_TOGGLES.find('dav_cache_delete_property_on_conflict'):
             log.info('Overwriting %s with %s after ConflictError',
                      commited, newstate)
             return newstate
@@ -450,7 +450,7 @@ class ChildNames(zc.set.Set):
     def _p_resolveConflict(self, old, commited, newstate):
         if commited == newstate:
             return commited
-        if not FEATURE_TOGGLES.find('dav_cache_delete_on_conflict'):
+        if not FEATURE_TOGGLES.find('dav_cache_delete_childname_on_conflict'):
             raise ZODB.POSException.ConflictError()
         log.info('Emptying %s due to ConflictError', newstate)
         old['_data'] = set([zeit.connector.interfaces.DeleteProperty])


### PR DESCRIPTION
Deleting was definitely correct, but it caused thundering herd issues e.g. for often-used folders. We now switch to a simple "last request wins" for properties (which hopefully does not wrongly overwrite previous changed -- since concurrent accesses to the same object should be locked anyway). For childnames we go back to ConflictError/retry (since deleting would cause the folder properties to be deleted as well, to make the cache consistent), and hope that folder childnames to not conflict often.