### PR TITLE
ZON-5615: Require special permission to add embed objects

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -11,6 +11,11 @@ vivi.core changes
 
 - ZON-5603: Replace suds with zeep as our SOAP client library
 
+- ZON-5615: Require special permission to add embed objects,
+  set feature toggle `add_content_permission` to enable
+
+- ZON-5615: Removed inline code entry from rawtext module
+
 
 4.22.3 (2019-11-26)
 -------------------

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -1,4 +1,5 @@
 <features>
+  <add_content_permissions>true</add_content_permissions>
   <article_agencies>true</article_agencies>
   <article_image_animation>true</article_image_animation>
   <embed_cmp_thirdparty>true</embed_cmp_thirdparty>

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -592,8 +592,16 @@ class AddableCMSContentTypeSource(CMSContentTypeSource):
 
     def filterValue(self, context, value):
         import zeit.cms.type  # break circular import
-        return (value.queryTaggedValue('zeit.cms.addform') !=
-                zeit.cms.type.SKIP_ADD)
+        if value.queryTaggedValue(
+                'zeit.cms.addform') == zeit.cms.type.SKIP_ADD:
+            return False
+        if not FEATURE_TOGGLES.find('add_content_permissions'):
+            return True
+        permission = value.queryTaggedValue('zeit.cms.addpermission')
+        if not permission:  # most content types need no special permission
+            return True
+        return zope.security.management.getInteraction().checkPermission(
+            permission, context)
 
 
 class StorystreamReference(AllowedBase):

--- a/core/src/zeit/cms/ftesting-securitypolicy.zcml
+++ b/core/src/zeit/cms/ftesting-securitypolicy.zcml
@@ -158,6 +158,10 @@
     principal="zope.producer"
     permission="zeit.content.cp.Retract"
     />
+  <grant
+    principal="zope.producer"
+    permission="zeit.content.text.AddEmbed"
+    />
 
   <!-- SEO grants -->
 

--- a/core/src/zeit/cms/permissions.zcml
+++ b/core/src/zeit/cms/permissions.zcml
@@ -123,5 +123,11 @@
     id="zeit.cms.admin.EditSemantic"
     title="Edit semantic change and date of last semantic publish"
     />
+
+  <permission
+    id="zeit.content.text.AddEmbed"
+    title="Add Embed objects"
+    />
+
 </configure>
 

--- a/core/src/zeit/cms/type.py
+++ b/core/src/zeit/cms/type.py
@@ -33,6 +33,7 @@ class TypeDeclaration(object):
     factory = NotImplemented
     title = None
     addform = None
+    addpermission = None
     register_as_type = True
 
     def __init__(self):

--- a/core/src/zeit/cms/typegrokker.py
+++ b/core/src/zeit/cms/typegrokker.py
@@ -58,6 +58,14 @@ class TypeGrokker(martian.ClassGrokker):
                     'zeit.cms.addform'),
                 callable=annotate_interface,
                 args=(context.interface, 'zeit.cms.addform', context.addform))
+            if context.addpermission:
+                config.action(
+                    discriminator=(
+                        'annotate_interface', context.interface,
+                        'zeit.cms.addpermission'),
+                    callable=annotate_interface,
+                    args=(context.interface, 'zeit.cms.addpermission',
+                          context.addpermission))
             zope.component.zcml.interface(
                 config, context.interface, context.interface_type)
 

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -238,7 +238,7 @@ class EditRawText(
 
     legend = None
     _form_fields = zope.formlib.form.FormFields(
-        zeit.content.article.edit.interfaces.IRawText)
+        zeit.content.article.edit.interfaces.IRawText).select('text_reference')
     _omit_fields = ('__name__', '__parent__', 'xml')
     undo_description = _('edit raw text block')
 

--- a/core/src/zeit/content/cp/browser/blocks/rawtext.py
+++ b/core/src/zeit/content/cp/browser/blocks/rawtext.py
@@ -10,7 +10,7 @@ class EditProperties(
         zeit.content.cp.browser.blocks.block.EditCommon):
 
     _form_fields = zope.formlib.form.Fields(
-        zeit.content.cp.interfaces.IRawTextBlock)
+        zeit.content.cp.interfaces.IRawTextBlock).select('text_reference')
     _omit_fields = list(zeit.content.cp.interfaces.IBlock)
 
 

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
@@ -36,42 +36,13 @@ class TestRawText(zeit.content.cp.testing.BrowserTestCase):
         b.open(self.content_url)
         self.assertEqual(2, b.contents.count('type-rawtext'))
 
-    def test_rawtext_is_edited(self):
-        b = self.browser
-        b.getLink('Edit block properties', index=0).click()
-        b.getControl('Raw text', index=1).value = '<rawcode_text>'
-        b.getControl('Apply').click()
-        b.open(self.content_url)
-        self.assertEllipsis('...(inline)...', b.contents)
-        b.getLink('Edit block properties', index=0).click()
-        self.assertEqual(
-            '<rawcode_text>', b.getControl('Raw text', index=1).value.strip())
-
-    def test_rawtext_is_referenced(self):
+    def test_rawtext_can_be_referenced(self):
         b = self.browser
         b.getLink('Edit block properties', index=0).click()
         b.getControl('Raw text reference').value = self.plaintext.uniqueId
         b.getControl('Apply').click()
         b.open(self.content_url)
         self.assertEllipsis('...http://xml.zeit.de/plaintext...', b.contents)
-
-    def test_rawtext_reference_should_be_preferred(self):
-        b = self.browser
-        b.getLink('Edit block properties', index=0).click()
-        b.getControl('Raw text', index=1).value = '<rawcode_text>'
-        b.getControl('Raw text reference').value = self.plaintext.uniqueId
-        b.getControl('Apply').click()
-        b.open(self.content_url)
-        self.assertEllipsis('...http://xml.zeit.de/plaintext...', b.contents)
-
-    def test_rawtext_should_display_default_if_empty(self):
-        b = self.browser
-        b.getLink('Edit block properties', index=0).click()
-        b.getControl('Raw text', index=1).value = ''
-        b.getControl('Raw text reference').value = ''
-        b.getControl('Apply').click()
-        b.open(self.content_url)
-        self.assertEllipsis('...(inline)...', b.contents)
 
     def test_rawtext_should_store_parameters(self):
         embed = zeit.content.text.embed.Embed()
@@ -90,26 +61,3 @@ class TestRawText(zeit.content.cp.testing.BrowserTestCase):
         b.open(self.content_url)
         b.getLink('Edit block properties', index=0).click()
         self.assertEqual('p1', b.getControl('One').value)
-
-    def test_rawtext_stores_consent_info(self):
-        b = self.browser
-        b.getLink('Edit block properties', index=0).click()
-        b.getControl('Contains thirdparty code').displayValue = ['yes']
-        b.getControl('Add Vendors').click()
-        b.getControl('Add Vendors').click()
-        b.getControl(name='form.thirdparty_vendors.0.').displayValue = [
-            'Twitter']
-        b.getControl(name='form.thirdparty_vendors.1.').displayValue = [
-            'YouTube']
-        b.getControl('Apply').click()
-
-        b.open(self.content_url)
-        b.getLink('Edit block properties', index=0).click()
-        self.assertEqual(
-            ['yes'], b.getControl('Contains thirdparty code').displayValue)
-        self.assertEqual(
-            ['Twitter'],
-            b.getControl(name='form.thirdparty_vendors.0.').displayValue)
-        self.assertEqual(
-            ['YouTube'],
-            b.getControl(name='form.thirdparty_vendors.1.').displayValue)

--- a/core/src/zeit/content/modules/rawtext.py
+++ b/core/src/zeit/content/modules/rawtext.py
@@ -25,11 +25,13 @@ class RawText(zeit.edit.block.Element):
 
     text_reference = zeit.cms.content.reference.SingleResource(
         '.text_reference', 'related')
+    # BBB inline code cannot be entered in vivi UI since ZON-5615,
+    # only kept for old content objects so zeit.web can still render them.
     text = zeit.cms.content.property.ObjectPathProperty(
         '.text', zeit.content.modules.interfaces.IRawText['text'])
 
     @property
-    def raw_code(self):
+    def raw_code(self):  # BBB See RawText.text above
         if self.text_reference:
             return self.text_reference.text
         if self.text:
@@ -155,10 +157,6 @@ class EmbedParameterForm(object):
         self.form_fields = zope.formlib.form.FormFields(
             ICSS, zeit.cms.content.interfaces.IMemo) + self._form_fields.omit(
                 *self._omit_fields)
-        if FEATURE_TOGGLES.find('embed_cmp_thirdparty'):
-            self.form_fields += zope.formlib.form.FormFields(
-                zeit.cmp.interfaces.IConsentInfo).select(
-                    'has_thirdparty', 'thirdparty_vendors')
 
         memo = self.form_fields['memo']
         memo.custom_widget = RestructuredTextDisplayWidget
@@ -198,6 +196,7 @@ class RawDisplayWidget(zope.formlib.widget.DisplayWidget):
         return self._data
 
 
+# BBB See RawText.text above
 @grok.implementer(zeit.cmp.interfaces.IConsentInfo)
 class ConsentInfo(zeit.cms.grok.TrustedAdapter,
                   zeit.cms.content.xmlsupport.Persistent,

--- a/core/src/zeit/content/text/browser/configure.zcml
+++ b/core/src/zeit/content/text/browser/configure.zcml
@@ -68,7 +68,7 @@
   <browser:page
     for="zeit.cms.repository.interfaces.IFolder"
     name="zeit.content.text.embed.Add"
-    permission="zeit.AddContent"
+    permission="zeit.content.text.AddEmbed"
     class=".embed.Add"
     menu="zeit-add-menu" title="Embed"
     />

--- a/core/src/zeit/content/text/browser/tests/test_embed.py
+++ b/core/src/zeit/content/text/browser/tests/test_embed.py
@@ -5,6 +5,8 @@ import zeit.content.text.testing
 
 class EmbedBrowserTest(zeit.content.text.testing.BrowserTestCase):
 
+    login_as = 'producer:producerpw'
+
     def test_add_embed(self):
         b = self.browser
         b.open('http://localhost/++skin++cms/repository/2006')

--- a/core/src/zeit/content/text/browser/tests/test_embed.py
+++ b/core/src/zeit/content/text/browser/tests/test_embed.py
@@ -26,6 +26,16 @@ class EmbedBrowserTest(zeit.content.text.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         self.assertEllipsis('...<pre>changed</pre>...', b.contents)
 
+    def test_special_permission_is_required_to_add_embed_via_addcentral(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/@@addcentral')
+        self.assertIn('Embed', b.getControl('Type').displayOptions)
+
+        b = zeit.cms.testing.Browser(self.layer['wsgi_app'])
+        b.login('user', 'userpw')
+        b.open('http://localhost/++skin++vivi/@@addcentral')
+        self.assertNotIn('Embed', b.getControl('Type').displayOptions)
+
     def test_edit_cmp_fields(self):
         embed = zeit.content.text.embed.Embed()
         embed.text = u''

--- a/core/src/zeit/content/text/embed.py
+++ b/core/src/zeit/content/text/embed.py
@@ -71,3 +71,4 @@ class EmbedType(zeit.content.text.text.TextType):
     title = _('Embed')
     factory = Embed
     addform = 'zeit.content.text.embed.Add'
+    addpermission = 'zeit.content.text.AddEmbed'

--- a/core/src/zeit/content/text/ftesting.zcml
+++ b/core/src/zeit/content/text/ftesting.zcml
@@ -10,5 +10,6 @@
   <include package="zeit.content.text.browser" />
 
   <include package="zeit.cmp" />
+  <include package="zeit.addcentral" />
 
 </configure>

--- a/core/src/zeit/securitypolicy/security.zcml
+++ b/core/src/zeit/securitypolicy/security.zcml
@@ -179,6 +179,10 @@
     role="zeit.Producer"
     permission="zeit.vgwort.RetryReport"
     />
+  <grant
+    role="zeit.Producer"
+    permission="zeit.content.text.AddEmbed"
+    />
 
 
   <!-- CvD grants -->


### PR DESCRIPTION
Changelog-Eintrag:
```
- ZON-5615: Require special permission to add embed objects,
  set feature toggle `add_content_permission` to enable
- ZON-5615: Removed inline code entry from rawtext module  
```

Aus historischen Gründen gibt es zwei UI-Möglichkeiten, Content-Objekte anzulegen, direkt im Ordner oder über das "Hinzufügen"-Formular in der linken Spalte. Deshalb muss die neue Permission auch an zwei Stellen geprüft werden.