### PR TITLE
ZON-5472: link `show_letterbox_link` to author to allow usage in zeit.web

### DIFF
--- a/core/src/zeit/content/author/author.py
+++ b/core/src/zeit/content/author/author.py
@@ -74,6 +74,11 @@ class Author(zeit.cms.content.xmlsupport.XMLContentBase):
     favourite_content = zeit.cms.content.reference.MultiResource(
         '.favourites.reference', 'related')
 
+    show_letterbox_link = zeit.cms.content.property.ObjectPathProperty(
+        '.show_letterbox_link',
+        IAuthor['show_letterbox_link'],
+        use_default=False)
+
     @property
     def exists(self):
         elastic = zope.component.getUtility(zeit.find.interfaces.ICMSSearch)


### PR DESCRIPTION
Is necessary to use the property in zeit.web..