### PR TITLE
ZON-5652: Product config always returns text, but we need an `int`

### DIFF
--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -214,7 +214,7 @@ class PublishRetractTask(object):
         """Apply method recursively on obj."""
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow')
-        DEPENDENCY_PUBLISH_LIMIT = config['dependency-publish-limit']
+        DEPENDENCY_PUBLISH_LIMIT = int(config['dependency-publish-limit'])
         stack = [obj]
         seen = set()
         result_obj = None


### PR DESCRIPTION
Nach #53 und #56 war der Rest dann einfach… 🙂 