### PR TITLE
ZON-5651: Make zeit.edit py3 compatible

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.25.15 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- ZON-5651: Make zeit.edit py3 compatible
 
 
 4.25.14 (2020-02-07)

--- a/core/src/zeit/edit/browser/tests/test_landing.py
+++ b/core/src/zeit/edit/browser/tests/test_landing.py
@@ -42,7 +42,7 @@ class LandingZone(zeit.edit.testing.FunctionalTestCase):
     def test_order_argument_is_required(self):
         with self.assertRaises(ValueError) as e:
             self.landing_zone()
-        self.assertEqual('Order must be specified!', e.exception.message)
+        self.assertEqual('Order must be specified!', str(e.exception))
 
     def test_json_params_validate_schema_fields_before_creation(self):
         self.request.form['order'] = 'top'

--- a/core/src/zeit/edit/browser/tests/test_landing.py
+++ b/core/src/zeit/edit/browser/tests/test_landing.py
@@ -50,7 +50,9 @@ class LandingZone(zeit.edit.testing.FunctionalTestCase):
             "example_amount": "nonnumeric"})
         with self.assertRaises(zope.interface.Invalid) as e:
             self.landing_zone()
-        self.assertIn("WrongType(u'nonnumeric'", str(e.exception))
+        exception_str = str(e.exception)
+        self.assertIn("WrongType", exception_str)
+        self.assertIn("nonnumeric", exception_str)
 
     def test_json_params_validate_invariants_before_creation(self):
         self.request.form['order'] = 'top'

--- a/core/src/zeit/edit/rule.py
+++ b/core/src/zeit/edit/rule.py
@@ -285,7 +285,7 @@ def count(context):
 
 @glob(zeit.edit.interfaces.IElement)
 def position(context):
-    return context.__parent__.keys().index(context.__name__) + 1
+    return list(context.__parent__).index(context.__name__) + 1
 
 
 @glob(zope.interface.Interface)

--- a/core/src/zeit/edit/rule.py
+++ b/core/src/zeit/edit/rule.py
@@ -146,7 +146,7 @@ class RulesManager(grok.GlobalUtility):
         rule = []
         start_line = 0
         for line_no, line in enumerate(file_rules):
-            line = six.text_type(line, 'utf-8')
+            line = six.ensure_text(line, 'utf-8')
             if line.startswith('applicable') and noop:
                 # start a new rule
                 if rule:


### PR DESCRIPTION
das waren neulich noch deutlich mehr fails, die aber wahrscheinlich inzwischen im master mitgefixt wurden. zur sicherheit bitte trotzdem nochmal lokal tests laufen lassen a la `bin/test py3  vivi/core/src/zeit/edit`. 