### PR TITLE
ZON-5635: add teaser image as cms content final

### DIFF
--- a/core/src/zeit/content/video/browser/video.py
+++ b/core/src/zeit/content/video/browser/video.py
@@ -71,7 +71,7 @@ class Thumbnail(zeit.cms.browser.view.Base):
 
     @property
     def thumbnail_url(self):
-        return self.context.thumbnail
+        return self.context.thumbnail.variant_url('thumbnail')
 
     def __call__(self):
         return self.redirect(self.thumbnail_url, trusted=True)
@@ -89,7 +89,7 @@ class Still(zeit.cms.browser.view.Base):
 
     @property
     def video_still_url(self):
-        return self.context.video_still
+        return self.context.video_still.variant_url('small')
 
     def __call__(self):
         return self.redirect(self.video_still_url, trusted=True)

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -1,5 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.content.interfaces
+import zeit.content.image.interfaces
 import zope.schema
 
 

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -13,10 +13,9 @@ class IVideoContent(zeit.cms.content.interfaces.ICommonMetadata,
 
     """
 
-    thumbnail = zope.schema.URI(
-        title=_('URI of the thumbnail'),
-        required=False,
-        readonly=True)
+    thumbnail = zope.schema.Choice(
+        source=zeit.content.image.interfaces.imageSource,
+        required=False)
 
     id_prefix = zope.schema.TextLine(
         title=_('Id prefix'),
@@ -53,10 +52,9 @@ class IVideo(IVideoContent):
         readonly=True,
         default=None)
 
-    video_still = zope.schema.URI(
-        title=_('URI of the still image'),
-        required=False,
-        readonly=True)
+    video_still = zope.schema.Choice(
+        source=zeit.content.image.interfaces.imageSource,
+        required=False)
 
     renditions = zope.schema.Tuple(
         title=_("Renditions of the Video"),

--- a/core/src/zeit/content/video/testing.py
+++ b/core/src/zeit/content/video/testing.py
@@ -83,8 +83,8 @@ def video_factory(self):
     with zeit.cms.testing.site(self.getRootFolder()):
         with zeit.cms.testing.interaction():
             video = Video()
-            video.video_still = create_image_group_with_master_image()
-            video.thumbnail = create_image_group_with_master_image()
+            video.cms_video_still = create_image_group_with_master_image()
+            video.cms_thumbnail = create_image_group_with_master_image()
             yield video
             self.repository['video'] = video
     yield self.repository['video']

--- a/core/src/zeit/content/video/testing.py
+++ b/core/src/zeit/content/video/testing.py
@@ -83,6 +83,8 @@ def video_factory(self):
     with zeit.cms.testing.site(self.getRootFolder()):
         with zeit.cms.testing.interaction():
             video = Video()
+            video.video_still = create_image_group_with_master_image()
+            video.thumbnail = create_image_group_with_master_image()
             yield video
             self.repository['video'] = video
     yield self.repository['video']

--- a/core/src/zeit/content/video/testing.py
+++ b/core/src/zeit/content/video/testing.py
@@ -79,6 +79,7 @@ def playlist_factory(self, location=''):
 
 def video_factory(self):
     from zeit.content.video.video import Video
+    from zeit.content.image.testing import create_image_group_with_master_image
     with zeit.cms.testing.site(self.getRootFolder()):
         with zeit.cms.testing.interaction():
             video = Video()

--- a/core/src/zeit/content/video/tests/test_browser.py
+++ b/core/src/zeit/content/video/tests/test_browser.py
@@ -24,7 +24,7 @@ class TestThumbnail(zeit.content.video.testing.BrowserTestCase):
         self.browser.open('http://localhost/++skin++vivi/repository/video/')
         self.browser.follow_redirects = False
         self.browser.open('@@thumbnail')
-        self.assertEqual('http://thumbnailurl',
+        self.assertEqual('http://localhost/group/thumbnail',
                          self.browser.headers.get('location'))
 
     def test_url_of_view_on_video_should_return_thumbnail_url(self):

--- a/core/src/zeit/content/video/tests/test_browser.py
+++ b/core/src/zeit/content/video/tests/test_browser.py
@@ -6,6 +6,7 @@ import zeit.push.interfaces
 import zeit.push.testing
 import zope.component
 import zope.publisher.browser
+from zeit.content.image.testing import create_image_group_with_master_image
 
 
 class TestThumbnail(zeit.content.video.testing.BrowserTestCase):
@@ -46,23 +47,23 @@ class TestThumbnail(zeit.content.video.testing.BrowserTestCase):
         url = zope.component.getMultiAdapter(
             (thumbnail_view, request),
             zope.traversing.browser.interfaces.IAbsoluteURL)()
-        self.assertEqual(url, 'http://thumbnailurl')
+        self.assertEqual(url, '/group/thumbnail')
 
     def test_view_on_playlist_should_redirect_to_playlist_thumbnail_url(self):
         factory = zeit.content.video.testing.playlist_factory(self)
         playlist = next(factory)
-        playlist.thumbnail = 'http://thumbnailurl'
+        playlist.thumbnail = create_image_group_with_master_image()
         next(factory)
         self.browser.open('http://localhost/++skin++vivi/repository/pls/')
         self.browser.follow_redirects = False
         self.browser.open('@@thumbnail')
-        self.assertEqual('http://thumbnailurl',
+        self.assertEqual('http://localhost/group/thumbnail',
                          self.browser.headers.get('location'))
 
     def test_url_of_view_on_playlist_should_return_thumbnail_url(self):
         factory = zeit.content.video.testing.playlist_factory(self)
         playlist = next(factory)
-        playlist.thumbnail = 'http://thumbnailurl'
+        playlist.thumbnail = create_image_group_with_master_image()
         playlist = next(factory)
 
         request = zope.publisher.browser.TestRequest(
@@ -72,7 +73,7 @@ class TestThumbnail(zeit.content.video.testing.BrowserTestCase):
         url = zope.component.getMultiAdapter(
             (thumbnail_view, request),
             zope.traversing.browser.interfaces.IAbsoluteURL)()
-        self.assertEqual(url, 'http://thumbnailurl')
+        self.assertEqual(url, '/group/thumbnail')
 
 
 class TestStill(zeit.content.video.testing.BrowserTestCase):
@@ -83,15 +84,13 @@ class TestStill(zeit.content.video.testing.BrowserTestCase):
             zeit.content.video.interfaces.IPlayer)
         player.get_video.return_value = {
             'renditions': (),
-            'thumbnail': None,
-            'video_still': 'http://stillurl',
         }
         next(factory)
         next(factory)
         self.browser.open('http://localhost/++skin++vivi/repository/video/')
         self.browser.follow_redirects = False
         self.browser.open('@@preview')
-        self.assertEqual('http://stillurl',
+        self.assertEqual('http://localhost/group/small',
                          self.browser.headers.get('location'))
 
     def test_url_of_preview_view_on_video_should_return_still_url(self):
@@ -99,8 +98,6 @@ class TestStill(zeit.content.video.testing.BrowserTestCase):
             zeit.content.video.interfaces.IPlayer)
         player.get_video.return_value = {
             'renditions': (),
-            'thumbnail': None,
-            'video_still': 'http://stillurl',
         }
         factory = zeit.content.video.testing.video_factory(self)
         next(factory)
@@ -113,7 +110,7 @@ class TestStill(zeit.content.video.testing.BrowserTestCase):
         url = zope.component.getMultiAdapter(
             (view, request),
             zope.traversing.browser.interfaces.IAbsoluteURL)()
-        self.assertEqual(url, 'http://stillurl')
+        self.assertEqual(url, '/group/small')
 
 
 class TestPlaylist(zeit.content.video.testing.BrowserTestCase):

--- a/core/src/zeit/content/video/tests/test_video.py
+++ b/core/src/zeit/content/video/tests/test_video.py
@@ -66,6 +66,12 @@ class TestReference(zeit.content.video.testing.TestCase):
         updater.update(node)
 
     def test_still_should_be_contained_in_xml_reference(self):
+        self.create_video(video_still='http://stillurl')
+        self.update(self.node)
+        self.assertEqual(
+            'http://stillurl', self.node['video-still'].get('src'))
+
+    def test_thumbnail_should_be_contained_in_xml_reference(self):
         self.create_video(thumbnail='http://thumbnailurl')
         self.update(self.node)
         self.assertEqual(
@@ -79,17 +85,6 @@ class TestReference(zeit.content.video.testing.TestCase):
         self.update(self.node)
         self.assertRaises(AttributeError, lambda: self.node['video-still'])
         self.assertRaises(AttributeError, lambda: self.node['thumbnail'])
-        self.create_video()
-        video = self.repository['video']
-        assert video.xml.body.video_still.xpath("@type")[0] == "JPG"
-
-    def test_thumbnail_should_be_contained_in_xml_reference(self):
-        self.create_video()
-        video = self.repository['video']
-        assert (
-            video.xml.body.thumbnail.xpath("@src")[0] ==
-            "http://xml.zeit.de/2006/DSC00109_3.JPG"
-        )
 
 
 class TestAuthorshipsProperty(zeit.content.video.testing.TestCase):

--- a/core/src/zeit/content/video/tests/test_video.py
+++ b/core/src/zeit/content/video/tests/test_video.py
@@ -60,31 +60,18 @@ class TestReference(zeit.content.video.testing.TestCase):
             zeit.content.video.interfaces.IPlayer)
         player.get_video.return_value.update(kw)
 
-    def update(self, node):
-        updater = zeit.cms.content.interfaces.IXMLReferenceUpdater(
-            self.repository['video'])
-        updater.update(node)
-
     def test_still_should_be_contained_in_xml_reference(self):
-        self.create_video(video_still='http://stillurl')
-        self.update(self.node)
-        self.assertEqual(
-            'http://stillurl', self.node['video-still'].get('src'))
+        self.create_video()
+        video = self.repository['video']
+        assert video.xml.body.video_still.xpath("@type")[0] == "jpg"
 
     def test_thumbnail_should_be_contained_in_xml_reference(self):
-        self.create_video(thumbnail='http://thumbnailurl')
-        self.update(self.node)
-        self.assertEqual(
-            'http://thumbnailurl', self.node['thumbnail'].get('src'))
-
-    def test_nodes_should_be_removed_from_reference(self):
-        self.create_video(
-            video_still='http://stillurl', thumbnail='http://thumbnailurl')
-        self.update(self.node)
-        self.create_video(video_still=None, thumbnail=None)
-        self.update(self.node)
-        self.assertRaises(AttributeError, lambda: self.node['video-still'])
-        self.assertRaises(AttributeError, lambda: self.node['thumbnail'])
+        self.create_video()
+        video = self.repository['video']
+        assert (
+            video.xml.body.thumbnail.xpath('@base-id')[0] ==
+            "http://xml.zeit.de/group/"
+        )
 
 
 class TestAuthorshipsProperty(zeit.content.video.testing.TestCase):

--- a/core/src/zeit/content/video/video.py
+++ b/core/src/zeit/content/video/video.py
@@ -75,13 +75,11 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
         high = sorted(self.renditions, key=lambda r: r.frame_width).pop()
         return getattr(high, 'url', '')
 
-    @property
-    def thumbnail(self):
-        return self._player_data['thumbnail']
+    thumbnail = zeit.cms.content.reference.SingleResource(
+        '.body.thumbnail', "image")
 
-    @property
-    def video_still(self):
-        return self._player_data['video_still']
+    video_still = zeit.cms.content.reference.SingleResource(
+        '.body.video_still', "image")
 
     @cachedproperty
     def _player_data(self):

--- a/core/src/zeit/content/video/video.py
+++ b/core/src/zeit/content/video/video.py
@@ -75,10 +75,18 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
         high = sorted(self.renditions, key=lambda r: r.frame_width).pop()
         return getattr(high, 'url', '')
 
-    thumbnail = zeit.cms.content.reference.SingleResource(
+    @property
+    def thumbnail(self):
+        return self._player_data['thumbnail']
+
+    cms_thumbnail = zeit.cms.content.reference.SingleResource(
         '.body.thumbnail', "image")
 
-    video_still = zeit.cms.content.reference.SingleResource(
+    @property
+    def video_still(self):
+        return self._player_data['video_still']
+
+    cms_video_still = zeit.cms.content.reference.SingleResource(
         '.body.video_still', "image")
 
     @cachedproperty


### PR DESCRIPTION
Nach den Vorarbeiten werden nun die thumbnails und teaser als attribute am video objekt gesetzt. allerdings verwenden wir dafuer zusaetzliche feldnamen (`cms_thumbnail` und `cms_video_still`) damit der Code BBB mit existierenden videos bleibt