### PR TITLE
FIX: replace ``pytest_server_fixtures`` with ``gocept.httpserverlayer…

### DIFF
--- a/core/src/zeit/content/image/testing.py
+++ b/core/src/zeit/content/image/testing.py
@@ -1,4 +1,5 @@
 import gocept.httpserverlayer.wsgi
+import gocept.httpserverlayer.static
 import gocept.selenium
 import os.path
 import pkg_resources
@@ -30,6 +31,10 @@ ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = gocept.httpserverlayer.wsgi.Layer(
     name='HTTPLayer', bases=(WSGI_LAYER,))
+HTTP_STATIC_LAYER = gocept.httpserverlayer.static.Layer(
+    name='HTTPStaticLayer',
+    bases=(HTTP_LAYER,))
+
 WD_LAYER = gocept.selenium.WebdriverLayer(
     name='WebdriverLayer', bases=(HTTP_LAYER,))
 WEBDRIVER_LAYER = gocept.selenium.WebdriverSeleneseLayer(
@@ -88,6 +93,11 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
     layer = WSGI_LAYER
+
+
+class StaticBrowserTestCase(zeit.cms.testing.BrowserTestCase):
+
+    layer = HTTP_STATIC_LAYER
 
 
 class SeleniumTestCase(zeit.cms.testing.SeleniumTestCase):

--- a/core/src/zeit/content/image/tests/test_fetch.py
+++ b/core/src/zeit/content/image/tests/test_fetch.py
@@ -1,34 +1,36 @@
-import pytest
+import pkg_resources
+import zeit.content.image.testing
 import shutil
+import requests
 from os import path
-from pytest_server_fixtures.http import SimpleHTTPTestServer
 from zeit.content.image import image
 
 
-@pytest.yield_fixture
-def image_server():
-    image_dir = path.abspath(path.join(path.dirname(__file__), '..', 'browser', 'testdata'))
-    with SimpleHTTPTestServer() as s:
-        shutil.copytree(image_dir, path.join(s.document_root, "testdata"))
-        s.start()
-        yield s
+class TestImageServing(zeit.content.image.testing.StaticBrowserTestCase):
+    def setUp(self):
+        image_dir = pkg_resources.resource_filename(
+            "zeit.content.image.browser", "testdata"
+        )
+        shutil.copytree(image_dir, path.join(self.layer["documentroot"], "testdata"))
 
+    def test_image_server(self):
+        response = requests.get(
+            "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        )
+        assert response.status_code == 200
 
-def test_image_server(image_server):
-    response = image_server.get('/testdata/opernball.jpg')
-    assert response.status_code == 200
+    def test_fetch_remote_image(self):
+        local_image = image.get_remote_image(
+            "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        )
+        assert local_image.mimeType == "image/jpeg"
 
+    def test_fetch_remote_image_fail(self):
+        local_image = image.get_remote_image(
+            "http://{0.layer[http_address]}/testdata/nosuchimage.jpg".format(self)
+        )
+        assert local_image is None
 
-def test_fetch_remote_image(image_server):
-    local_image = image.get_remote_image('%s/testdata/opernball.jpg' % image_server.uri)
-    assert local_image.mimeType == 'image/jpeg'
-
-
-def test_fetch_remote_image_fail(image_server):
-    local_image = image.get_remote_image('%s/testdata/nosuchimage.jpg' % image_server.uri)
-    assert local_image is None
-
-
-def test_fetch_remote_image_fail_url(image_server):
-    local_image = image.get_remote_image('nosuchhost')
-    assert local_image is None
+    def test_fetch_remote_image_fail_url(self):
+        local_image = image.get_remote_image("nosuchhost")
+        assert local_image is None


### PR DESCRIPTION
….static``

since the former was a) not working properly under py3 and b) usees a
forks instead of threads