### PR TITLE
ZON-5635: add teaser image as cms content

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -6,7 +6,7 @@ vivi.core changes
 -------------------
 
 - BUG-1205: Revert bugfix 4.25.15, it causes a different misbehaviour
-- ZON-5635: add teaser image as cms content: basic setup
+- ZON-5635: Add teaser images for videos as CMS content
 
 
 4.26.0 (2020-02-18)

--- a/core/src/zeit/brightcove/testing.py
+++ b/core/src/zeit/brightcove/testing.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import
+import gocept.httpserverlayer.static
 import mock
 import plone.testing
 import transaction
@@ -50,6 +51,9 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER, MOCK_API_LAYER))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
+HTTP_STATIC_LAYER = gocept.httpserverlayer.static.Layer(
+    name='HTTPStaticLayer',
+    bases=(WSGI_LAYER,))
 
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
@@ -60,6 +64,11 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
     layer = WSGI_LAYER
+
+
+class StaticBrowserTestCase(FunctionalTestCase):
+
+    layer = HTTP_STATIC_LAYER
 
 
 def update_repository(root):

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -187,6 +187,15 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         )
         shutil.copytree(image_dir, path.join(self.layer["documentroot"], "testdata"))
 
+    def test_download_teaser_image_success(self):
+        src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        bc = self.create_video()
+        bc.data['images']['thumbnail']['src'] = src
+        import_video(bc)
+        # importing the video has created an image group "next to it" for its thumbnail
+        # and has assigned it as its thumbnail
+        assert self.repository['video']['2017-05']['myvid'].cms_thumbnail == self.repository['video']['2017-05']['myvid-thumbnail']
+
     def test_download_teaser_image_error_produces_empty_group(self):
         zeit.brightcove.update.download_teaser_image(
             self.repository,

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -195,6 +195,16 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         # importing the video has created an image group "next to it" for its thumbnail
         # and has assigned it as its thumbnail
         assert self.repository['video']['2017-05']['myvid'].cms_thumbnail == self.repository['video']['2017-05']['myvid-thumbnail']
+        # the video has been published
+        self.assertEqual(
+            True,
+            zeit.cms.workflow.interfaces.IPublishInfo(
+                ICMSContent('http://xml.zeit.de/video/2017-05/myvid')).published)
+        # and so has the thumbnail
+        self.assertEqual(
+            True,
+            zeit.cms.workflow.interfaces.IPublishInfo(
+                ICMSContent('http://xml.zeit.de/video/2017-05/myvid-thumbnail')).published)
 
     def test_download_teaser_image__still_success(self):
         src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
@@ -204,6 +214,10 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         # importing the video has created an image group "next to it" for its still image
         # and has assigned it as its thumbnail
         assert self.repository['video']['2017-05']['myvid'].cms_video_still == self.repository['video']['2017-05']['myvid-still']
+        self.assertEqual(
+            True,
+            zeit.cms.workflow.interfaces.IPublishInfo(
+                ICMSContent('http://xml.zeit.de/video/2017-05/myvid-still')).published)
 
     def test_download_teaser_image_error_produces_empty_group(self):
         zeit.brightcove.update.download_teaser_image(

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -212,7 +212,6 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         bc.data['images']['poster']['src'] = src
         import_video(bc)
         # importing the video has created an image group "next to it" for its still image
-        # and has assigned it as its thumbnail
         assert self.repository['video']['2017-05']['myvid'].cms_video_still == self.repository['video']['2017-05']['myvid-still']
         self.assertEqual(
             True,

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -187,7 +187,7 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         )
         shutil.copytree(image_dir, path.join(self.layer["documentroot"], "testdata"))
 
-    def test_download_teaser_image_success(self):
+    def test_download_teaser_image__thumbnail_success(self):
         src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
         bc = self.create_video()
         bc.data['images']['thumbnail']['src'] = src
@@ -195,6 +195,15 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         # importing the video has created an image group "next to it" for its thumbnail
         # and has assigned it as its thumbnail
         assert self.repository['video']['2017-05']['myvid'].cms_thumbnail == self.repository['video']['2017-05']['myvid-thumbnail']
+
+    def test_download_teaser_image__still_success(self):
+        src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        bc = self.create_video()
+        bc.data['images']['poster']['src'] = src
+        import_video(bc)
+        # importing the video has created an image group "next to it" for its still image
+        # and has assigned it as its thumbnail
+        assert self.repository['video']['2017-05']['myvid'].cms_video_still == self.repository['video']['2017-05']['myvid-still']
 
     def test_download_teaser_image_error_produces_empty_group(self):
         zeit.brightcove.update.download_teaser_image(

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -1,6 +1,11 @@
 from datetime import datetime
+from os import path
 from zeit.brightcove.update import import_video, import_playlist
 from zeit.cms.interfaces import ICMSContent
+import pkg_resources
+import zeit.content.image.testing
+import shutil
+
 import mock
 import pytz
 import transaction
@@ -172,6 +177,15 @@ class ImportVideoTest(zeit.brightcove.testing.FunctionalTestCase):
         import_video(bc)
         video = ICMSContent('http://xml.zeit.de/video/2017-05/myvid')
         self.assertEqual(('William Shakespeare',), video.authors)
+
+
+class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportVideoTest):
+    def setUp(self):
+        super(TestDownloadTeasers, self).setUp()
+        image_dir = pkg_resources.resource_filename(
+            "zeit.content.image.browser", "testdata"
+        )
+        shutil.copytree(image_dir, path.join(self.layer["documentroot"], "testdata"))
 
     def test_download_teaser_image_error_produces_empty_group(self):
         zeit.brightcove.update.download_teaser_image(

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -119,18 +119,6 @@ class import_video(object):
                             IVideo, *list(IVideo))))
 
 
-class migrate_video(import_video):
-
-    """ subclass with slimmer init to act as helper
-    for migration code
-    """
-
-    def __init__(self, bcobj, cmsobj, ):
-        self.bcobj = bcobj
-        self.cmsobj = cmsobj
-        self.folder = self.cmsobj.__parent__
-
-
 BC_IMG_KEYS = {
     'still': 'poster',
     'thumbnail': 'thumbnail'

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -54,6 +54,10 @@ class import_video(object):
         self._add()
         if self.bcobj.state == 'ACTIVE':
             IPublish(self.cmsobj).publish(background=False)
+            if self.cmsobj.cms_thumbnail is not None:
+                IPublish(self.cmsobj.cms_thumbnail).publish(background=False)
+            if self.cmsobj.cms_video_still is not None:
+                IPublish(self.cmsobj.cms_video_still).publish(background=False)
         return True
 
     def _add(self):

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -68,7 +68,8 @@ class import_video(object):
         cmsobj.cms_video_still = cms_video_still
         cms_thumbnail = download_teaser_image(folder, self.bcobj.data, 'thumbnail')
         cmsobj.cms_thumbnail = cms_thumbnail
-        self.cmsobj = folder[self.bcobj.id] = cmsobj
+        folder[self.bcobj.id] = cmsobj
+        self.cmsobj = folder[self.bcobj.id]
 
     def update(self):
         if self.bcobj.skip_import:

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -184,6 +184,7 @@ class import_playlist(import_video):
         self.bcobj = bcobj
         self.cmsobj = zeit.cms.interfaces.ICMSContent(
             self.bcobj.uniqueId, None)
+        self.folder = self.cmsobj.__parent__
         log.debug('CMS object resolved: %r', self.cmsobj)
         success = self.add() or self.update()
         if not success:

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -66,7 +66,7 @@ class import_video(object):
         zope.event.notify(zope.lifecycleevent.ObjectCopiedEvent(cmsobj, None))
         folder[self.bcobj.id] = cmsobj
         download_teaser_image(folder, self.bcobj.data, 'still')
-        download_teaser_image(folder, self.bcobj.data, 'thumbnail')
+        folder[self.bcobj.id].cms_thumbnail = download_teaser_image(folder, self.bcobj.data, 'thumbnail')
         self.cmsobj = folder[self.bcobj.id]
 
     def update(self):

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -72,10 +72,10 @@ class import_video(object):
         # preserved.
         zope.event.notify(zope.lifecycleevent.ObjectCopiedEvent(cmsobj, None))
         self.cmsobj = cmsobj
-        self._handle_teasers()
+        self._handle_images()
         self._commit()
 
-    def _handle_teasers(self):
+    def _handle_images(self):
         cms_video_still = download_teaser_image(
             self.folder, self.bcobj.data, 'still')
         self.cmsobj.cms_video_still = cms_video_still

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -64,10 +64,10 @@ class import_video(object):
         # Special case of ObjectCreatedEvent, so that e.g. ISemanticChange is
         # preserved.
         zope.event.notify(zope.lifecycleevent.ObjectCopiedEvent(cmsobj, None))
-        folder[self.bcobj.id] = cmsobj
         download_teaser_image(folder, self.bcobj.data, 'still')
-        folder[self.bcobj.id].cms_thumbnail = download_teaser_image(folder, self.bcobj.data, 'thumbnail')
-        self.cmsobj = folder[self.bcobj.id]
+        cms_thumbnail = download_teaser_image(folder, self.bcobj.data, 'thumbnail')
+        cmsobj.cms_thumbnail = cms_thumbnail
+        self.cmsobj = folder[self.bcobj.id] = cmsobj
 
     def update(self):
         if self.bcobj.skip_import:

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -64,7 +64,8 @@ class import_video(object):
         # Special case of ObjectCreatedEvent, so that e.g. ISemanticChange is
         # preserved.
         zope.event.notify(zope.lifecycleevent.ObjectCopiedEvent(cmsobj, None))
-        download_teaser_image(folder, self.bcobj.data, 'still')
+        cms_video_still = download_teaser_image(folder, self.bcobj.data, 'still')
+        cmsobj.cms_video_still = cms_video_still
         cms_thumbnail = download_teaser_image(folder, self.bcobj.data, 'thumbnail')
         cmsobj.cms_thumbnail = cms_thumbnail
         self.cmsobj = folder[self.bcobj.id] = cmsobj

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -1,5 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.content.interfaces
+import zeit.content.image.interfaces
 import zope.schema
 
 
@@ -16,6 +17,10 @@ class IVideoContent(zeit.cms.content.interfaces.ICommonMetadata,
         title=_('URI of the thumbnail'),
         required=False,
         readonly=True)
+
+    cms_thumbnail = zope.schema.Choice(
+        source=zeit.content.image.interfaces.imageSource,
+        required=False)
 
     id_prefix = zope.schema.TextLine(
         title=_('Id prefix'),

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -13,15 +13,6 @@ class IVideoContent(zeit.cms.content.interfaces.ICommonMetadata,
 
     """
 
-    thumbnail = zope.schema.URI(
-        title=_('URI of the thumbnail'),
-        required=False,
-        readonly=True)
-
-    cms_thumbnail = zope.schema.Choice(
-        source=zeit.content.image.interfaces.imageSource,
-        required=False)
-
     id_prefix = zope.schema.TextLine(
         title=_('Id prefix'),
         required=True,
@@ -56,6 +47,15 @@ class IVideo(IVideoContent):
         required=False,
         readonly=True,
         default=None)
+
+    thumbnail = zope.schema.URI(
+        title=_('URI of the thumbnail'),
+        required=False,
+        readonly=True)
+
+    cms_thumbnail = zope.schema.Choice(
+        source=zeit.content.image.interfaces.imageSource,
+        required=False)
 
     video_still = zope.schema.URI(
         title=_('URI of the still image'),

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -62,6 +62,10 @@ class IVideo(IVideoContent):
         required=False,
         readonly=True)
 
+    cms_video_still = zope.schema.Choice(
+        source=zeit.content.image.interfaces.imageSource,
+        required=False)
+
     renditions = zope.schema.Tuple(
         title=_("Renditions of the Video"),
         required=False,

--- a/core/src/zeit/content/video/playlist.py
+++ b/core/src/zeit/content/video/playlist.py
@@ -18,11 +18,6 @@ class Playlist(zeit.cms.content.metadata.CommonMetadata):
     default_template = pkg_resources.resource_string(
         __name__, 'playlist-template.xml').decode('utf-8')
 
-    zeit.cms.content.dav.mapProperties(
-        zeit.content.video.interfaces.IPlaylist,
-        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        ('thumbnail',))
-
     videos = zeit.cms.content.reference.MultiResource(
         '.body.videos.video', 'related')
 

--- a/core/src/zeit/content/video/testing.py
+++ b/core/src/zeit/content/video/testing.py
@@ -79,9 +79,12 @@ def playlist_factory(self, location=''):
 
 def video_factory(self):
     from zeit.content.video.video import Video
+    from zeit.content.image.testing import create_image_group_with_master_image
     with zeit.cms.testing.site(self.getRootFolder()):
         with zeit.cms.testing.interaction():
             video = Video()
+            video.cms_video_still = create_image_group_with_master_image()
+            video.cms_thumbnail = create_image_group_with_master_image()
             yield video
             self.repository['video'] = video
     yield self.repository['video']

--- a/core/src/zeit/content/video/tests/test_browser.py
+++ b/core/src/zeit/content/video/tests/test_browser.py
@@ -48,32 +48,6 @@ class TestThumbnail(zeit.content.video.testing.BrowserTestCase):
             zope.traversing.browser.interfaces.IAbsoluteURL)()
         self.assertEqual(url, 'http://thumbnailurl')
 
-    def test_view_on_playlist_should_redirect_to_playlist_thumbnail_url(self):
-        factory = zeit.content.video.testing.playlist_factory(self)
-        playlist = next(factory)
-        playlist.thumbnail = 'http://thumbnailurl'
-        next(factory)
-        self.browser.open('http://localhost/++skin++vivi/repository/pls/')
-        self.browser.follow_redirects = False
-        self.browser.open('@@thumbnail')
-        self.assertEqual('http://thumbnailurl',
-                         self.browser.headers.get('location'))
-
-    def test_url_of_view_on_playlist_should_return_thumbnail_url(self):
-        factory = zeit.content.video.testing.playlist_factory(self)
-        playlist = next(factory)
-        playlist.thumbnail = 'http://thumbnailurl'
-        playlist = next(factory)
-
-        request = zope.publisher.browser.TestRequest(
-            skin=zeit.cms.browser.interfaces.ICMSLayer)
-        thumbnail_view = zope.component.getMultiAdapter(
-            (playlist, request), name='thumbnail')
-        url = zope.component.getMultiAdapter(
-            (thumbnail_view, request),
-            zope.traversing.browser.interfaces.IAbsoluteURL)()
-        self.assertEqual(url, 'http://thumbnailurl')
-
 
 class TestStill(zeit.content.video.testing.BrowserTestCase):
 

--- a/core/src/zeit/content/video/video.py
+++ b/core/src/zeit/content/video/video.py
@@ -79,9 +79,15 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
     def thumbnail(self):
         return self._player_data['thumbnail']
 
+    cms_thumbnail = zeit.cms.content.reference.SingleResource(
+        '.body.thumbnail', "image")
+
     @property
     def video_still(self):
         return self._player_data['video_still']
+
+    cms_video_still = zeit.cms.content.reference.SingleResource(
+        '.body.video_still', "image")
 
     @cachedproperty
     def _player_data(self):


### PR DESCRIPTION
Dieser PR tut im wesentlichen drei dinge:

- erzeugt beim video import anhand der brightcove daten bildergruppen fuer die teaser bilder
- setzt neue attribute am video objekt, die jeweils eine dieser bildergruppen referenzieren
- macht den bestehenden brightcove importer goutierbar fuer das migrationskript