### PR TITLE
ZON-5635: add teaser image updates from BC

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.26.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5635: Handle updates from Brightcove for teaser images
 
 
 4.26.3 (2020-03-09)

--- a/core/src/zeit/brightcove/convert.py
+++ b/core/src/zeit/brightcove/convert.py
@@ -328,9 +328,17 @@ def playlist_location(bcobj):
 
 
 def image_group_from_image(where, name, image):
+    # takes a local image, creates an image group with that
+    # image as master
+    # it then adds the imagegroup the `where` folder and
+    # adds the image into the image group
+    # it then returns the imagegroup from the repository
     group = zeit.content.image.imagegroup.ImageGroup()
     if image is not None:
-        image_name = 'master.' + image.format
+        if image.__name__ is None:
+            image_name = 'master.' + image.format
+        else:
+            image_name = image.__name__
         group.master_images = (('desktop', image_name),)
     where[name] = group
     if image is not None:

--- a/core/src/zeit/brightcove/tests/test_convert.py
+++ b/core/src/zeit/brightcove/tests/test_convert.py
@@ -230,7 +230,7 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
         repository = self.repository()
         local_image = zeit.content.image.testing.create_local_image('opernball.jpg')
         group = convert.image_group_from_image(repository, 'group', local_image)
-        assert group.master_image is not None
+        assert group.master_image == 'opernball.jpg'
 
     def test_image_group_from_none(self):
         repository = self.repository()

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -243,6 +243,18 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
             "thumbnail")
         assert new.stamped == 'this'
 
+    def test_update_teaser_image_still_success(self):
+        src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        bc = self.create_video()
+        bc.data['images']['poster']['src'] = src
+        imported = import_video(bc)
+        assert imported.cmsobj.cms_video_still.master_image == 'opernball.jpg'
+        new_src = "http://{0.layer[http_address]}/testdata/obama-clinton-120x120.jpg".format(self)
+        bc.data['images']['poster']['src'] = new_src
+        # importing it again triggers update:
+        reimported = import_video(bc)
+        assert reimported.cmsobj.cms_video_still.master_image == 'obama-clinton-120x120.jpg'
+
 
 class ImportPlaylistTest(zeit.brightcove.testing.FunctionalTestCase):
 

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -255,6 +255,25 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase, ImportV
         reimported = import_video(bc)
         assert reimported.cmsobj.cms_video_still.master_image == 'obama-clinton-120x120.jpg'
 
+    def test_update_teaser_image_preserves_override(self):
+        from zeit.content.image.testing import create_image_group_with_master_image
+        src = "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
+        # video is created via BC import
+        bc = self.create_video()
+        bc.data['images']['poster']['src'] = src
+        import_video(bc)
+        # editor replaces automatically created video still with custom imagegroup
+        self.repository['foo-video_still'] = create_image_group_with_master_image()
+        self.repository['video']['2017-05']['myvid'].cms_video_still = self.repository['foo-video_still']
+        assert self.repository['video']['2017-05']['myvid'].cms_video_still.master_image == 'master-image.jpg'
+        # now an update from brightcove still updates the automatically created image group:
+        new_src = "http://{0.layer[http_address]}/testdata/obama-clinton-120x120.jpg".format(self)
+        bc.data['images']['poster']['src'] = new_src
+        reimported = import_video(bc)
+        assert self.repository['video']['2017-05']['myvid-still'].master_image == 'obama-clinton-120x120.jpg'
+        # but it does not change the reference of the video to the custom imagegroup
+        assert reimported.cmsobj.cms_video_still.master_image == 'master-image.jpg'
+
 
 class ImportPlaylistTest(zeit.brightcove.testing.FunctionalTestCase):
 

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -117,6 +117,7 @@ class import_video(import_base):
         if self.bcobj.skip_import:
             return True
         self._update()
+        self._handle_images()
         if self.bcobj.state == 'ACTIVE':
             IPublish(self.cmsobj).publish(background=False)
         else:
@@ -133,8 +134,6 @@ BC_IMG_KEYS = {
 
 def download_teaser_image(folder, bcdata, ttype='still'):
     name = '%s-%s' % (bcdata['id'], ttype)
-    if name in folder:
-        return folder[name]
     try:
         image = zeit.content.image.image.get_remote_image(
             bcdata['images'][BC_IMG_KEYS[ttype]]['src'])

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -74,12 +74,21 @@ class import_video(import_base):
         return True
 
     def _publish(self):
+
+        def publish(obj):
+            if obj is None:
+                log.info('Got None to publish')
+                return
+            if not IPublishInfo(obj).published:
+                log.info('Publishing %s' % obj)
+                IPublish(obj).publish(background=False)
+            else:
+                log.info('%s already published' % obj)
+
         if self.bcobj.state == 'ACTIVE':
-            IPublish(self.cmsobj).publish(background=False)
-            if self.cmsobj.cms_thumbnail is not None:
-                IPublish(self.cmsobj.cms_thumbnail).publish(background=False)
-            if self.cmsobj.cms_video_still is not None:
-                IPublish(self.cmsobj.cms_video_still).publish(background=False)
+            publish(self.cmsobj)
+            publish(self.cmsobj.cms_video_still)
+            publish(self.cmsobj.cms_thumbnail)
 
     def add(self):
         if self.cmsobj is not None or self.bcobj.skip_import:

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -104,10 +104,12 @@ class import_video(import_base):
             return
         cms_video_still = download_teaser_image(
             self.folder, self.bcobj.data, 'still')
-        self.cmsobj.cms_video_still = cms_video_still
+        if self.cmsobj.cms_video_still is None:
+            self.cmsobj.cms_video_still = cms_video_still
         cms_thumbnail = download_teaser_image(
             self.folder, self.bcobj.data, 'thumbnail')
-        self.cmsobj.cms_thumbnail = cms_thumbnail
+        if self.cmsobj.cms_thumbnail is None:
+            self.cmsobj.cms_thumbnail = cms_thumbnail
 
     def _commit(self):
         self.folder[self.bcobj.id] = self.cmsobj

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -100,6 +100,12 @@ class import_video(import_base):
         self._commit()
 
     def _handle_images(self):
+        # since we cannot readily distinguish whether the image has changed
+        # on BC side we *always* update the (master) image of the image group
+        # but we only set the reference *to* that imagegroup if there isn't
+        # already one in place.
+        # this allows manual overrides by the editors to take prioty during
+        # subsequent updates.
         if not FEATURE_TOGGLES.find('video_import_images'):
             return
         cms_video_still = download_teaser_image(

--- a/core/src/zeit/content/image/image.py
+++ b/core/src/zeit/content/image/image.py
@@ -1,3 +1,5 @@
+import os
+import urlparse
 from zeit.cms.i18n import MessageFactory as _
 import PIL.Image
 import lxml.objectify
@@ -172,6 +174,7 @@ def get_remote_image(url, timeout=2):
     if not response.ok:
         return
     image = LocalImage()
+    image.__name__ = os.path.basename(urlparse.urlsplit(url).path)
     with image.open('w') as fh:
         first_chunk = True
         for chunk in response.iter_content(DOWNLOAD_CHUNK_SIZE):

--- a/core/src/zeit/content/image/image.py
+++ b/core/src/zeit/content/image/image.py
@@ -1,5 +1,5 @@
 import os
-import urlparse
+import six.moves.urllib.parse
 from zeit.cms.i18n import MessageFactory as _
 import PIL.Image
 import lxml.objectify
@@ -174,7 +174,8 @@ def get_remote_image(url, timeout=2):
     if not response.ok:
         return
     image = LocalImage()
-    image.__name__ = os.path.basename(urlparse.urlsplit(url).path)
+    image.__name__ = os.path.basename(
+        six.moves.urllib.parse.urlsplit(url).path)
     with image.open('w') as fh:
         first_chunk = True
         for chunk in response.iter_content(DOWNLOAD_CHUNK_SIZE):

--- a/core/src/zeit/content/image/testing.py
+++ b/core/src/zeit/content/image/testing.py
@@ -48,6 +48,7 @@ def create_local_image(filename, path='browser/testdata/'):
         __name__, '%s%s' % (path, filename))
     fh.write(open(file_name, 'rb').read())
     fh.close()
+    image.__name__ = filename
     return image
 
 

--- a/core/src/zeit/content/image/tests/test_fetch.py
+++ b/core/src/zeit/content/image/tests/test_fetch.py
@@ -24,6 +24,7 @@ class TestImageServing(zeit.content.image.testing.StaticBrowserTestCase):
             "http://{0.layer[http_address]}/testdata/opernball.jpg".format(self)
         )
         assert local_image.mimeType == "image/jpeg"
+        assert local_image.__name__ == "opernball.jpg"
 
     def test_fetch_remote_image_fail(self):
         local_image = image.get_remote_image(

--- a/core/src/zeit/content/video/browser/video.py
+++ b/core/src/zeit/content/video/browser/video.py
@@ -26,7 +26,7 @@ class Base(zeit.push.browser.form.SocialBase,
         'commentsPremoderate', 'related', 'channels', 'lead_candidate',
         'video_still_copyright', 'has_advertisement',
         # remaining:
-        '__name__',
+        '__name__', 'cms_thumbnail', 'cms_video_still',
         'created', 'date_first_released', 'modified', 'expires',
         'thumbnail', 'video_still', 'authorships')
 
@@ -50,7 +50,7 @@ class Base(zeit.push.browser.form.SocialBase,
         CommonMetadataFormBase.auto_cp_fields,
         gocept.form.grouped.Fields(
             _('Teaser elements'),
-            ('related',),
+            ('related', 'cms_thumbnail', 'cms_video_still'),
             css_class='wide-widgets column-left'),
         gocept.form.grouped.RemainingFields(
             '', css_class='column-left'),


### PR DESCRIPTION
nun werden auch updates von brightcove verarbeitet, allerdings so, dass falls seit dem ersten update manuell eine andere bildergruppe als vorschau oder thumbnail gewaehlt wurde, diese bilder dann vorrang haben