### PR TITLE
ZON-5861: Remove marker for switching between old and new 'comments' API

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.32.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5861: Remove `commentsAPIv2` property from `ICommonMetadata`
 
 
 4.32.7 (2020-05-19)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -223,11 +223,6 @@ class ICommonMetadata(zope.interface.Interface):
         required=False,
         default=True)
 
-    commentsAPIv2 = zope.schema.Bool(
-        title=_("Use Comments APIv2"),
-        required=False,
-        default=False)
-
     commentSectionEnable = zope.schema.Bool(
         title=_("Show commentthread"),
         required=False,

--- a/core/src/zeit/cms/content/metadata.py
+++ b/core/src/zeit/cms/content/metadata.py
@@ -86,10 +86,6 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
     commentsAllowed = zeit.cms.content.dav.DAVProperty(
         ICommonMetadata['commentsAllowed'], DOCUMENT_SCHEMA_NS, 'comments')
 
-    commentsAPIv2 = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['commentsAPIv2'], DOCUMENT_SCHEMA_NS,
-        'comments_api_v2')
-
     commentSectionEnable = zeit.cms.content.dav.DAVProperty(
         ICommonMetadata['commentSectionEnable'],
         DOCUMENT_SCHEMA_NS, 'show_commentthread')

--- a/core/src/zeit/content/article/edit/browser/form.py
+++ b/core/src/zeit/content/article/edit/browser/form.py
@@ -315,7 +315,7 @@ class MetadataComments(zeit.edit.browser.form.InlineForm):
         fields = ('commentSectionEnable',)
         if self.context.commentSectionEnable:
             fields += (
-                'commentsAllowed', 'commentsPremoderate', 'commentsAPIv2')
+                'commentsAllowed', 'commentsPremoderate')
         return FormFields(ICommonMetadata).select(*fields)
 
 

--- a/core/src/zeit/content/cp/browser/form.py
+++ b/core/src/zeit/content/cp/browser/form.py
@@ -17,7 +17,7 @@ class FormBase(object):
         zope.formlib.form.FormFields(
             zeit.cms.interfaces.ICMSContent,
             zeit.cms.content.interfaces.ICommonMetadata).omit(
-            'keywords', 'commentsAPIv2') +
+            'keywords') +
         zope.formlib.form.FormFields(
             zeit.content.image.interfaces.IImages) +
         zope.formlib.form.FormFields(

--- a/core/src/zeit/locales/de/LC_MESSAGES/zeit.cms.po
+++ b/core/src/zeit/locales/de/LC_MESSAGES/zeit.cms.po
@@ -862,10 +862,6 @@ msgstr "Kommentare prämoderieren"
 msgid "Comments allowed"
 msgstr "Kommentare erlaubt"
 
-#: zeit/cms/content/interfaces.py:227
-msgid "Use Comments APIv2"
-msgstr "zeit.comment verwenden"
-
 #: zeit/cms/content/interfaces.py:232
 msgid "Show commentthread"
 msgstr "Kommentare anzeigen"

--- a/core/src/zeit/locales/zeit.cms.pot
+++ b/core/src/zeit/locales/zeit.cms.pot
@@ -903,10 +903,6 @@ msgstr ""
 msgid "Comments allowed"
 msgstr ""
 
-#: zeit/cms/content/interfaces.py:227
-msgid "Use Comments APIv2"
-msgstr ""
-
 #: zeit/cms/content/interfaces.py:232
 msgid "Show commentthread"
 msgstr ""

--- a/core/src/zeit/retresco/tests/test_convert.py
+++ b/core/src/zeit/retresco/tests/test_convert.py
@@ -72,7 +72,6 @@ class ConvertTest(zeit.retresco.testing.FunctionalTestCase):
                     'banner_content': True,
                     'color_scheme': u'Redaktion',
                     'comments': False,
-                    'comments_api_v2': False,
                     'comments_premoderate': False,
                     'copyrights': 'ZEIT online',
                     'countings': 'yes',


### PR DESCRIPTION
Hiermit wird der Support für "die Weiche"™ auch aus Vivi entfernt.  Siehe [ZON-5861](https://zeit-online.atlassian.net/browse/ZON-5861).