### PR TITLE
WOMA-91: Define the WOMA ingredients XML structure

### DIFF
--- a/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
+++ b/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <ingredients>
   <chicken q="Hahn">
-    <ingredient id="brathaenchen" q="Hühnchen,Hähnchen" singular="Brathähnchen" plural="Brathähnchen">Brathähnchen</ingredient>
+    <ingredient id="brathaehnchen" q="Hühnchen,Hähnchen" singular="Brathähnchen" plural="Brathähnchen">Brathähnchen</ingredient>
     <ingredient id="chicken-nuggets" q="Hühnchen,Hähnchen" singular="Chicken Nugget" plural="Chicken Nuggets">Chicken Nuggets</ingredient>
   </chicken>
   <fish q="Fisch, Meeresfrüchte">

--- a/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
+++ b/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" ?>
 <ingredients>
   <chicken q="Hahn">
-    <ingredient id="brathaehnchen" q="Hühnchen,Hähnchen" singular="Brathähnchen" plural="Brathähnchen">Brathähnchen</ingredient>
-    <ingredient id="chicken-nuggets" q="Hühnchen,Hähnchen" singular="Chicken Nugget" plural="Chicken Nuggets">Chicken Nuggets</ingredient>
+    <ingredient id="brathaehnchen" q="Hühnchen,Hähnchen" singular="Brathähnchen" plural="Brathähnchen" />
+    <ingredient id="chicken-nuggets" q="Hühnchen,Hähnchen" singular="Chicken Nugget" plural="Chicken Nuggets" />
   </chicken>
   <fish q="Fisch, Meeresfrüchte">
-    <ingredient id="calamari" q="Tintenfisch,Kalamar" singular="Calamari" plural="Calamari">Calamari</ingredient>
-    <ingredient id="crevetten" q="Krevetten,Garnelen,Garnele" singular="Crevette" plural="Crevetten">Crevetten</ingredient>
+    <ingredient id="calamari" q="Tintenfisch,Kalamar" singular="Calamari" plural="Calamari" />
+    <ingredient id="crevetten" q="Krevetten,Garnelen,Garnele" singular="Crevette" plural="Crevetten" />
   </fish>
   <meat>
-    <ingredient id="bratenfond" q="Kraftbrühe,Fond" singular="Bratenfond" plural="Bratenfond">Bratenfond</ingredient>
-    <ingredient id="bratwurst" q="Grillwurst,Wurst" singular="Bratwurst" plural="Bratwürste">Bratwurst</ingredient>
+    <ingredient id="bratenfond" q="Kraftbrühe,Fond" singular="Bratenfond" plural="Bratenfond" />
+    <ingredient id="bratwurst" q="Grillwurst,Wurst" singular="Bratwurst" plural="Bratwürste" />
   </meat>
   <other>
-    <ingredient id="bandnudeln" q="Nudeln,Pasta" singular="Bandnudel" plural="Bandnudeln">Bandnudeln</ingredient>
-    <ingredient id="basmatireis" q="Reis,Basmati" singular="Basmatireis" plural="Basmatireis">Basmatireis</ingredient>
+    <ingredient id="bandnudeln" q="Nudeln,Pasta" singular="Bandnudel" plural="Bandnudeln" />
+    <ingredient id="basmatireis" q="Reis,Basmati" singular="Basmatireis" plural="Basmatireis" />
   </other>
   <spices>
-    <ingredient id="muskatnuss" q="" singular="Muskatnuss,Muskat" plural="Muskatnüsse">Muskatnuss</ingredient>
-    <ingredient id="natron" q="" singular="Natron" plural="Natron">Natron</ingredient>
+    <ingredient id="muskatnuss" q="" singular="Muskatnuss,Muskat" plural="Muskatnüsse" />
+    <ingredient id="natron" q="" singular="Natron" plural="Natron" />
   </spices>
   <vegetables>
-    <ingredient id="gurke" q="" singular="Gurke" plural="Gurken">Gurke</ingredient>
-    <ingredient id="tomate" q="Tomate,Tomaten" singular="Tomate" plural="Tomaten">Tomate</ingredient>
+    <ingredient id="gurke" q="" singular="Gurke" plural="Gurken" />
+    <ingredient id="tomate" q="Tomate,Tomaten" singular="Tomate" plural="Tomaten" />
   </vegetables>
   <poultry>
-    <ingredient id="haenchenkeule" q="Hühnchen,Hähnchen" singular="Hänchenkeule" plural="Hänchenkeulen">Hähnchenkeule</ingredient>
-    <ingredient id="truthahnbrust" q="Truthahn,Pute" singular="Truthahnbrust" plural="Truthahnbrüste">Truthahnbrust</ingredient>
+    <ingredient id="haenchenkeule" q="Hühnchen,Hähnchen" singular="Hänchenkeule" plural="Hänchenkeulen" />
+    <ingredient id="truthahnbrust" q="Truthahn,Pute" singular="Truthahnbrust" plural="Truthahnbrüste" />
   </poultry>
   <fruits>
-    <ingredient id="physalis" q="Physalis" singular="Physalis" plural="Physalis">Physalis</ingredient>
-    <ingredient id="pomeranze" q="Bitterorange,Pomeranze" singular="Pomeranze" plural="Pomeranzen">Pomeranze</ingredient>
+    <ingredient id="physalis" q="Physalis" singular="Physalis" plural="Physalis" />
+    <ingredient id="pomeranze" q="Bitterorange,Pomeranze" singular="Pomeranze" plural="Pomeranzen" />
   </fruits>
 </ingredients>

--- a/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
+++ b/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<ingredients>
+  <chicken q="Hahn">
+    <ingredient id="brathaenchen" q="Hühnchen,Hähnchen" singular="Brathähnchen" plural="Brathähnchen">Brathähnchen</ingredient>
+    <ingredient id="chicken-nuggets" q="Hühnchen,Hähnchen" singular="Chicken Nugget" plural="Chicken Nuggets">Chicken Nuggets</ingredient>
+  </chicken>
+  <fish q="Fisch, Meeresfrüchte">
+    <ingredient id="calamari" q="Tintenfisch,Kalamar" singular="Calamari" plural="Calamari">Calamari</ingredient>
+    <ingredient id="crevetten" q="Krevetten,Garnelen,Garnele" singular="Crevette" plural="Crevetten">Crevetten</ingredient>
+  </fish>
+  <meat>
+    <ingredient id="bratenfond" q="Kraftbrühe,Fond" singular="Bratenfond" plural="Bratenfond">Bratenfond</ingredient>
+    <ingredient id="bratwurst" q="Grillwurst,Wurst" singular="Bratwurst" plural="Bratwürste">Bratwurst</ingredient>
+  </meat>
+  <other>
+    <ingredient id="bandnudeln" q="Nudeln,Pasta" singular="Bandnudel" plural="Bandnudeln">Bandnudeln</ingredient>
+    <ingredient id="basmatireis" q="Reis,Basmati" singular="Basmatireis" plural="Basmatireis">Basmatireis</ingredient>
+  </other>
+  <spices>
+    <ingredient id="muskatnuss" q="" singular="Muskatnuss,Muskat" plural="Muskatnüsse">Muskatnuss</ingredient>
+    <ingredient id="natron" q="" singular="Natron" plural="Natron">Natron</ingredient>
+  </spices>
+  <vegetables>
+    <ingredient id="gurke" q="" singular="Gurke" plural="Gurken">Gurke</ingredient>
+    <ingredient id="tomate" q="Tomate,Tomaten" singular="Tomate" plural="Tomaten">Tomate</ingredient>
+  </vegetables>
+  <poultry>
+    <ingredient id="haenchenkeule" q="Hühnchen,Hähnchen" singular="Hänchenkeule" plural="Hänchenkeulen">Hähnchenkeule</ingredient>
+    <ingredient id="truthahnbrust" q="Truthahn,Pute" singular="Truthahnbrust" plural="Truthahnbrüste">Truthahnbrust</ingredient>
+  </poultry>
+  <fruits>
+    <ingredient id="physalis" q="Physalis" singular="Physalis" plural="Physalis">Physalis</ingredient>
+    <ingredient id="pomeranze" q="Bitterorange,Pomeranze" singular="Pomeranze" plural="Pomeranzen">Pomeranze</ingredient>
+  </fruits>
+</ingredients>


### PR DESCRIPTION
Nach diversen Absprachen sind wir soweit, dass wir die Struktur für das Zutaten XML fixiert haben. Wir speichern dieses Im Vivi im Modul zeit.wochenmarkt innerhalb der Tests. Das Modul wird erst mit der WOMA-65 Eingang ins Vivi finden. Nichtsdestotrotz, kann diese Datei in ihrer endgültigen Form schon gemerged werden.
![](https://media.giphy.com/media/xT8qAXTeSkNcxyWiBi/giphy-downsized.gif)