### PR TITLE
STO-49: Support setting a default filename for source config files

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -11,6 +11,8 @@ vivi.core changes
 
 - WOMA-104: Add subheading to recipe list
 
+- STO-49: Support setting a default filename for source config files
+
 
 4.33.3 (2020-06-09)
 -------------------

--- a/core/setup.py
+++ b/core/setup.py
@@ -10,7 +10,7 @@ else:
 
 setup(
     name='vivi.core',
-    version='4.33.4.dev0',
+    version='4.34.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/core/src/zeit/campus/interfaces.py
+++ b/core/src/zeit/campus/interfaces.py
@@ -89,6 +89,7 @@ class StudyCourseSource(
 
     product_configuration = 'zeit.campus'
     config_url = 'article-stoa-source'
+    default_filename = 'article-stoa.xml'
     attribute = 'id'
 
     @CONFIG_CACHE.cache_on_arguments()

--- a/core/src/zeit/cmp/interfaces.py
+++ b/core/src/zeit/cmp/interfaces.py
@@ -11,6 +11,7 @@ class VendorSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.cmp'
     config_url = 'vendors'
+    default_filename = 'cmp-vendors.xml'
     attribute = 'id'
 
     class source_class(zc.sourcefactory.source.FactoredContextualSource):

--- a/core/src/zeit/cms/browser/manual.py
+++ b/core/src/zeit/cms/browser/manual.py
@@ -12,6 +12,7 @@ class LinkSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.cms'
     config_url = 'source-manual'
+    default_filename = 'vivi-handbuch.xml'
     attribute = 'id'
 
 

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -120,6 +120,7 @@ class Hook(object):
 class HookSource(zeit.cms.content.sources.SimpleXMLSource):
 
     config_url = 'checkin-webhook-config'
+    default_filename = 'checkin-webhooks.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -33,11 +33,19 @@ class CachedXMLBase(object):
 
     product_configuration = 'zeit.cms'
     config_url = NotImplemented
+    default_filename = NotImplemented
 
     def _get_tree(self):
-        cms_config = zope.app.appsetup.product.getProductConfiguration(
-            self.product_configuration)
-        url = cms_config[self.config_url]
+        config = zope.app.appsetup.product.getProductConfiguration(
+            self.product_configuration) or {}
+        try:
+            url = config[self.config_url]
+        except KeyError:
+            if self.default_filename is NotImplemented:
+                raise
+            config = zope.app.appsetup.product.getProductConfiguration(
+                'zeit.cms')
+            url = '%s/%s' % (config['config-base-url'], self.default_filename)
         return self._get_tree_from_url(url)
 
     @CONFIG_CACHE.cache_on_arguments()
@@ -248,6 +256,7 @@ class FolderItemSource(zc.sourcefactory.basic.BasicSourceFactory):
 class RessortSource(XMLSource):
 
     config_url = 'source-ressorts'
+    default_filename = 'ressorts.xml'
     attribute = 'name'
     title_xpath = '/ressorts/ressort'
 
@@ -329,8 +338,9 @@ class MasterSlaveSource(XMLSource):
 
 class SubRessortSource(MasterSlaveSource):
 
-    config_url = 'source-ressorts'
-    attribute = 'name'
+    config_url = RessortSource.config_url
+    default_filename = RessortSource.default_filename
+    attribute = RessortSource.attribute
     slave_tag = 'subnavigation'
     master_node_xpath = '/ressorts/ressort'
     master_value_key = 'ressort'
@@ -348,6 +358,7 @@ class SubRessortSource(MasterSlaveSource):
 class ChannelSource(XMLSource):
 
     config_url = 'source-channels'
+    default_filename = 'channels.xml'
     attribute = 'name'
     title_xpath = '/ressorts/ressort'
 
@@ -358,6 +369,7 @@ class ChannelSource(XMLSource):
 class SubChannelSource(MasterSlaveSource):
 
     config_url = ChannelSource.config_url
+    default_filename = ChannelSource.default_filename
     attribute = ChannelSource.attribute
     slave_tag = 'subnavigation'
     master_node_xpath = '/ressorts/ressort'
@@ -391,6 +403,7 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
 
     product_configuration = 'zeit.cms'
     config_url = 'feature-toggle-source'
+    default_filename = 'vivi-feature-toggle.xml'
 
     class source_class(zc.sourcefactory.source.FactoredContextualSource):
 
@@ -455,6 +468,7 @@ class Serie(AllowedBase):
 class SerieSource(ObjectSource, SimpleContextualXMLSource):
 
     config_url = 'source-serie'
+    default_filename = 'series.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -511,6 +525,7 @@ class Product(AllowedBase):
 class ProductSource(ObjectSource, SimpleContextualXMLSource):
 
     config_url = 'source-products'
+    default_filename = 'products.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -626,6 +641,7 @@ class StorystreamReference(AllowedBase):
 class StorystreamSource(ObjectSource, XMLSource):
 
     config_url = 'source-storystreams'
+    default_filename = 'storystreams.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -640,6 +656,7 @@ class StorystreamSource(ObjectSource, XMLSource):
 class AccessSource(XMLSource):
 
     config_url = 'source-access'
+    default_filename = 'access.xml'
     attribute = 'id'
 
     def translate_to_c1(self, value):
@@ -657,6 +674,7 @@ class PrintRessortSource(XMLSource):
 
     product_configuration = 'zeit.cms'
     config_url = 'source-printressorts'
+    default_filename = 'print-ressorts.xml'
     attribute = 'id'
 
 

--- a/core/src/zeit/cms/retractlog/interfaces.py
+++ b/core/src/zeit/cms/retractlog/interfaces.py
@@ -39,6 +39,7 @@ class RetractLogConfig(zeit.cms.content.sources.CachedXMLBase):
 
     product_configuration = 'zeit.cms'
     config_url = 'config-retractlog'
+    default_filename = 'retractlog.xml'
 
     @property
     def limit(self):

--- a/core/src/zeit/content/article/edit/body.py
+++ b/core/src/zeit/content/article/edit/body.py
@@ -148,6 +148,7 @@ class ModuleSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'module-source'
+    default_filename = 'article-modules.xml'
     attribute = 'id'
 
 

--- a/core/src/zeit/content/article/edit/header.py
+++ b/core/src/zeit/content/article/edit/header.py
@@ -96,6 +96,7 @@ class ModuleSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'header-module-source'
+    default_filename = 'article-header-modules.xml'
     attribute = 'id'
 
     # For consistency with the zeit.content.cp config files.

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -112,6 +112,7 @@ class VideoLayoutSource(BodyAwareXMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'video-layout-source'
+    default_filename = 'article-video-layouts.xml'
     attribute = 'id'
 
 
@@ -204,6 +205,7 @@ class InfoboxLayoutSource(BodyAwareXMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'infobox-layout-source'
+    default_filename = 'article-infobox-layouts.xml'
     attribute = 'id'
 
 
@@ -312,6 +314,7 @@ class AvailableBlockLayoutSource(zeit.cms.content.sources.XMLSource):
 class CitationLayoutSource(AvailableBlockLayoutSource):
 
     config_url = 'citation-layout-source'
+    default_filename = 'article-citation-layouts.xml'
 
 
 CITATION_LAYOUT_SOURCE = CitationLayoutSource()
@@ -324,6 +327,7 @@ class BoxLayoutSource(AvailableBlockLayoutSource):
     # and maybe get rid of the superclass
 
     config_url = 'box-layout-source'
+    default_filename = 'article-box-layouts.xml'
 
 
 BOX_LAYOUT_SOURCE = BoxLayoutSource()
@@ -496,6 +500,7 @@ class PuzzleSource(zeit.cms.content.sources.ObjectSource,
 
     product_configuration = 'zeit.content.article'
     config_url = 'puzzleforms-source'
+    default_filename = 'puzzleforms.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -9,12 +9,14 @@ class BookRecensionCategories(zeit.cms.content.sources.SimpleXMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'book-recension-categories'
+    default_filename = 'article-recension-categories.xml'
 
 
 class GenreSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'genre-url'
+    default_filename = 'article-genres.xml'
     attribute = 'name'
 
     class source_class(zc.sourcefactory.source.FactoredContextualSource):
@@ -39,6 +41,7 @@ class ArticleTemplateSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'template-source'
+    default_filename = 'article-templates.xml'
     attribute = 'name'
     title_xpath = '/templates/template'
 
@@ -124,6 +127,7 @@ class ArticleHeaderSource(zeit.cms.content.sources.MasterSlaveSource):
 
     product_configuration = ArticleTemplateSource.product_configuration
     config_url = ArticleTemplateSource.config_url
+    default_filename = ArticleTemplateSource.default_filename
     attribute = 'name'
     slave_tag = 'header'
     master_node_xpath = '/templates/template'
@@ -143,6 +147,7 @@ class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'image-display-mode-source'
+    default_filename = 'article-image-display-modes.xml'
     attribute = 'id'
     title_xpath = '/display-modes/display-mode'
 
@@ -159,6 +164,7 @@ class LegacyDisplayModeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'legacy-display-mode-source'
+    default_filename = 'article-legacy-display-modes.xml'
 
     def getValues(self, context):
         tree = self._get_tree()
@@ -173,6 +179,7 @@ class ImageVariantNameSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'image-variant-name-source'
+    default_filename = 'article-image-variant-names.xml'
     attribute = 'id'
     title_xpath = '/variant-names/variant-name'
 
@@ -231,6 +238,7 @@ class LegacyVariantNameSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
     config_url = 'legacy-variant-name-source'
+    default_filename = 'article-legacy-variant-names.xml'
 
     def getValues(self, context):
         tree = self._get_tree()

--- a/core/src/zeit/content/author/interfaces.py
+++ b/core/src/zeit/content/author/interfaces.py
@@ -178,6 +178,7 @@ class BiographyQuestionSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.author'
     config_url = 'biography-questions'
+    default_filename = 'author-biography-questions.xml'
     attribute = 'id'
 
 
@@ -198,6 +199,7 @@ class RoleSource(zeit.cms.content.sources.SimpleContextualXMLSource):
 
     product_configuration = 'zeit.content.author'
     config_url = 'roles'
+    default_filename = 'author-roles.xml'
 
 
 ROLE_SOURCE = RoleSource()

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -283,6 +283,7 @@ class AutomaticFeedSource(zeit.cms.content.sources.ObjectSource,
 
     product_configuration = 'zeit.content.cp'
     config_url = 'cp-automatic-feed-source'
+    default_filename = 'cp-automatic-feeds.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):

--- a/core/src/zeit/content/cp/layout.py
+++ b/core/src/zeit/content/cp/layout.py
@@ -126,6 +126,7 @@ class TeaserBlockLayoutSource(
 
     product_configuration = 'zeit.content.cp'
     config_url = 'block-layout-source'
+    default_filename = 'cp-layouts.xml'
     attribute = 'id'
 
     @CONFIG_CACHE.cache_on_arguments()
@@ -161,6 +162,7 @@ class RegionConfigSource(ObjectSource, zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.cp'
     config_url = 'region-config-source'
+    default_filename = 'cp-regions.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -187,6 +189,7 @@ class AreaConfigSource(ObjectSource, zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.cp'
     config_url = 'area-config-source'
+    default_filename = 'cp-areas.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -209,6 +212,7 @@ class ModuleConfigSource(ObjectSource, zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.cp'
     config_url = 'module-config-source'
+    default_filename = 'cp-modules.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):

--- a/core/src/zeit/content/cp/source.py
+++ b/core/src/zeit/content/cp/source.py
@@ -7,6 +7,7 @@ class CPTypeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.cp'
     config_url = 'cp-types-url'
+    default_filename = 'cp-types.xml'
     attribute = 'name'
 
 
@@ -14,6 +15,7 @@ class CPExtraSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.cp'
     config_url = 'cp-extra-url'
+    default_filename = 'cp-extras.xml'
     attribute = 'id'
 
     def isAvailable(self, node, context):

--- a/core/src/zeit/content/gallery/source.py
+++ b/core/src/zeit/content/gallery/source.py
@@ -7,6 +7,7 @@ class GalleryTypeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.gallery'
     config_url = 'gallery-types-url'
+    default_filename = 'gallery-types.xml'
     attribute = 'name'
 
 

--- a/core/src/zeit/content/image/interfaces.py
+++ b/core/src/zeit/content/image/interfaces.py
@@ -34,6 +34,7 @@ class CopyrightCompanySource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.image'
     config_url = 'copyright-company-source'
+    default_filename = 'image-copyright-company.xml'
 
     def getValues(self, context):
         tree = self._get_tree()
@@ -192,6 +193,7 @@ class DisplayTypeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.image'
     config_url = 'display-type-source'
+    default_filename = 'image-display-types.xml'
     attribute = 'id'
 
 
@@ -199,6 +201,7 @@ class ViewportSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.image'
     config_url = 'viewport-source'
+    default_filename = 'image-viewports.xml'
     attribute = 'id'
 
 

--- a/core/src/zeit/content/image/variant.py
+++ b/core/src/zeit/content/image/variant.py
@@ -174,6 +174,7 @@ class VariantSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.image'
     config_url = 'variant-source'
+    default_filename = 'image-variants.xml'
 
     def getTitle(self, context, value):
         return value.id

--- a/core/src/zeit/content/link/sources.py
+++ b/core/src/zeit/content/link/sources.py
@@ -17,6 +17,7 @@ def unicode_or_none(value):
 class BlogSource(zeit.cms.content.sources.SimpleContextualXMLSource):
     product_configuration = 'zeit.content.link'
     config_url = 'source-blogs'
+    default_filename = 'link-blogs.xml'
 
     def getValues(self, context):
         tree = self._get_tree()

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -41,6 +41,7 @@ class EmbedProviderSource(zeit.cms.content.sources.SimpleXMLSource):
 
     product_configuration = 'zeit.content.modules'
     config_url = 'embed-provider-source'
+    default_filename = 'embed-providers.xml'
 
 
 EMBED_PROVIDER_SOURCE = EmbedProviderSource()
@@ -109,6 +110,7 @@ class NewsletterSource(zeit.cms.content.sources.ObjectSource,
 
     product_configuration = 'zeit.content.modules'
     config_url = 'newsletter-source'
+    default_filename = 'newsletter.xml'
 
     @CONFIG_CACHE.cache_on_arguments()
     def _values(self):
@@ -161,6 +163,7 @@ class SubjectSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.modules'
     config_url = 'subject-source'
+    default_filename = 'mail-subjects.xml'
     attribute = 'id'
 
 
@@ -215,6 +218,7 @@ class RecipeMetadataSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.modules'
     config_url = 'recipe-metadata-source'
+    default_filename = 'recipe-metadata.xml'
 
     def __init__(self, xpath):
         super(RecipeMetadataSource, self).__init__()

--- a/core/src/zeit/content/modules/jobticker.py
+++ b/core/src/zeit/content/modules/jobticker.py
@@ -42,6 +42,7 @@ class FeedSource(zeit.cms.content.sources.ObjectSource,
 
     product_configuration = 'zeit.content.modules'
     config_url = 'jobticker-source'
+    default_filename = 'jobboxticker.xml'
 
     def __init__(self, content_iface):
         self.content_iface = content_iface

--- a/core/src/zeit/content/volume/interfaces.py
+++ b/core/src/zeit/content/volume/interfaces.py
@@ -144,6 +144,7 @@ class VolumeCoverSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.volume'
     config_url = 'volume-cover-source'
+    default_filename = 'volume-covers.xml'
     attribute = 'id'
 
 
@@ -154,6 +155,7 @@ class AccessControlConfig(zeit.cms.content.sources.CachedXMLBase):
 
     product_configuration = 'zeit.content.volume'
     config_url = 'access-control-config'
+    default_filename = 'volume_access_configuration.xml'
 
     @property
     def min_cr(self):

--- a/core/src/zeit/imp/source.py
+++ b/core/src/zeit/imp/source.py
@@ -12,6 +12,7 @@ class ScaleSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.imp'
     config_url = 'scale-source'
+    default_filename = 'scales.xml'
 
     def getValues(self, context):
         xml = self._get_tree()
@@ -34,6 +35,7 @@ class ColorSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.imp'
     config_url = 'color-source'
+    default_filename = 'imp-colors.xml'
 
     def getValues(self, context):
         xml = self._get_tree()

--- a/core/src/zeit/magazin/sources.py
+++ b/core/src/zeit/magazin/sources.py
@@ -5,4 +5,5 @@ class ArticleRelatedLayoutSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.magazin'
     config_url = 'article-related-layout-source'
+    default_filename = 'article-related-layouts.xml'
     attribute = 'id'

--- a/core/src/zeit/push/interfaces.py
+++ b/core/src/zeit/push/interfaces.py
@@ -262,6 +262,7 @@ class MobileButtonsSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.push'
     config_url = 'mobile-buttons'
+    default_filename = 'push-mobile-buttons.xml'
     attribute = 'id'
 
 


### PR DESCRIPTION
We no longer require an explicit path/url to be configured, but rather default to a central `config-base-url` setting if no explicit value is configured. This should vastly reduce the amount of boilerplate configuration needed (e.g. to differentiate between staging and production), since for most cases only the base-url has to be overridden now.