### PR TITLE
MAINT: Read ingredient name from property instead of parsing the xml

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.34.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- MAINT: Read ingredient name from property instead of parsing the xml
 
 
 4.34.0 (2020-06-18)

--- a/core/src/zeit/content/modules/ftesting.zcml
+++ b/core/src/zeit/content/modules/ftesting.zcml
@@ -8,5 +8,6 @@
 
   <include package="zeit.content.modules" />
   <include package="zeit.content.text" />
+  <include package="zeit.wochenmarkt" />
 
 </configure>

--- a/core/src/zeit/content/modules/recipelist.py
+++ b/core/src/zeit/content/modules/recipelist.py
@@ -1,6 +1,7 @@
-import collections
 from lxml.objectify import E
+import collections
 import zeit.content.modules.interfaces
+import zeit.wochenmarkt.interfaces
 import zope.interface
 
 
@@ -14,9 +15,12 @@ class Ingredient(object):
 
     @classmethod
     def from_xml(cls, node):
+        code = node.get('code')
+        name = zope.component.getUtility(
+            zeit.wochenmarkt.interfaces.IIngredientsWhitelist).get(code).name
         return cls(
-            node.get('code'),
-            node.get('label'),
+            code,
+            name,
             node.get('amount'),
             node.get('unit'))
 
@@ -68,7 +72,6 @@ class RecipeList(zeit.edit.block.Element):
             self.xml.append(
                 E.ingredient(
                     code=item.code,
-                    label=item.label,
                     amount=item.amount,
                     unit=item.unit))
 

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -6,6 +6,7 @@ import zeit.cms.testing
 import zeit.content.modules
 import zeit.content.text.text
 import zeit.wochenmarkt.ingredients
+import zeit.wochenmarkt.testing
 
 
 product_config = """\
@@ -19,8 +20,9 @@ product_config = """\
 """.format(base=pkg_resources.resource_filename(__name__, '.'))
 
 
-CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
-    product_config, bases=(zeit.cmp.testing.CONFIG_LAYER,))
+CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
+        zeit.cmp.testing.CONFIG_LAYER,
+        zeit.wochenmarkt.testing.CONFIG_LAYER))
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -48,8 +48,7 @@ class RecipeListTest(
         milk = ingredients['milk']
         self.module.ingredients = [banana, milk]
         self.assertEllipsis(
-            '<ingredient... amount="2" code="banana" '
-            'label="_banana" unit="g"/>',
+            '<ingredient... amount="2" code="banana" unit="g"/>',
             lxml.etree.tostring(
                 self.module.xml.ingredient,
                 encoding=six.text_type))

--- a/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
+++ b/core/src/zeit/wochenmarkt/tests/fixtures/ingredients.xml
@@ -15,6 +15,7 @@
   <other>
     <ingredient id="bandnudeln" q="Nudeln,Pasta" singular="Bandnudeln" plural="Bandnudeln" />
     <ingredient id="basmatireis" q="Reis,Basmati" singular="Basmatireis" plural="Basmatireis" />
+    <ingredient id="milk" q="Milch" singular="Milch" plural="Milch" />
   </other>
   <spices>
     <ingredient id="muskatnuss" q="" singular="Muskatnuss,Muskat" plural="Muskatnüsse" />
@@ -29,6 +30,7 @@
     <ingredient id="truthahnbrust" q="Truthahn,Pute" singular="Truthahnbrust" plural="Truthahnbrüste" />
   </poultry>
   <fruits>
+    <ingredient id="banana" q="Banane" singular="Banane" plural="Bananen" />
     <ingredient id="physalis" q="Physalis" singular="Physalis" plural="Physalis" />
     <ingredient id="pomeranze" q="Bitterorange,Pomeranze" singular="Pomeranze" plural="Pomeranzen" />
   </fruits>


### PR DESCRIPTION
Wir wollen den Namen einer Zutat nicht im XML des Artikels speichern, sonst bekommen wir Aenderungen an der ingredients.xml nicht mit. Stattdessen wird nur noch die id gespeichert (das wurde sie bereits) und der Name aka das Label wird aus der Whitelist extrahiert.