### PR TITLE
MAINT: Move browser imports from zeit.wochenmarkt to zeit.wochenmarkt.browser

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.34.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- MAINT: Move browser imports from zeit.wochenmarkt to zeit.wochenmarkt.browser
 
 
 4.34.0 (2020-06-18)

--- a/core/src/zeit/wochenmarkt/browser/configure.zcml
+++ b/core/src/zeit/wochenmarkt/browser/configure.zcml
@@ -6,4 +6,11 @@
 
   <grok:grok package="." />
 
+  <browser:page
+    for="zope.location.interfaces.ISite"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="zeit.wochenmarkt.search"
+    class=".ingredients.IngredientsSearch"
+    permission="zope.View"/>
+
 </configure>

--- a/core/src/zeit/wochenmarkt/configure.zcml
+++ b/core/src/zeit/wochenmarkt/configure.zcml
@@ -7,13 +7,6 @@
 
   <grok:grok package="." exclude="browser" />
 
-  <browser:page
-    for="zope.location.interfaces.ISite"
-    layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="zeit.wochenmarkt.search"
-    class=".browser.ingredients.IngredientsSearch"
-    permission="zope.View"/>
-
   <class class=".categories.RecipeCategory">
     <require
       attributes="code name"


### PR DESCRIPTION
Das wurde bei den Aufraeumarbeiten uebersehen, ist jetzt in der Friedbert-Entwicklung aufgefallen, aber nicht dramatisch, da noch nicht verwendet wird.
Einmal Jenkins drueber laeufen lassen...