### PR TITLE
MAINT: Add missing import

### DIFF
--- a/core/src/zeit/wochenmarkt/categories.py
+++ b/core/src/zeit/wochenmarkt/categories.py
@@ -4,6 +4,7 @@ import collections
 import grokcore.component as grok
 import logging
 import lxml.etree
+import zeit.cms.content.sources
 import zeit.wochenmarkt.interfaces
 import zope.interface
 


### PR DESCRIPTION
This has not been noticed until now because it seems to be made
available somewhere up in the dependency chain, but of course we
want to make the module work on its own.