### PR TITLE
WOMA-4: Add defaults for ingredient amount and unit

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.35.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WOMA-4: Add defaults for ingredient amount and unit.
 
 
 4.35.1 (2020-06-30)
@@ -15,6 +15,7 @@ vivi.core changes
   non-browser ZCML files
 
 - WOMA-99: Polish recipelist module
+
 
 4.35.0 (2020-06-25)
 -------------------

--- a/core/src/zeit/content/modules/recipelist.py
+++ b/core/src/zeit/content/modules/recipelist.py
@@ -79,8 +79,8 @@ class RecipeList(zeit.edit.block.Element):
             self.xml.append(
                 E.ingredient(
                     code=item.code,
-                    amount=item.amount,
-                    unit=item.unit))
+                    amount=item.amount if hasattr(item, 'amount') else '',
+                    unit=item.unit if hasattr(item, 'unit') else ''))
 
     def _remove_duplicates(self, ingredients):
         result = collections.OrderedDict()


### PR DESCRIPTION
Im Skript werden die Zutaten direkt via Adapter geladen und besitzen keine Werte für amount und unit. Das gibt beim Erstellen des XML's einen Fehler, welcher durch diese Anpassung aufgelöst wird.