### PR TITLE
WOMA-115: Add free text details to ingredients in recipelist

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,10 @@ vivi.core changes
 
 - WOMA-4: Add defaults for ingredient amount and unit.
 
+- WOMA-115: Add free text details to ingredients in recipelist
+
+- WOMA-120: Add new values to ingredient unit list
+
 
 4.35.1 (2020-06-30)
 -------------------

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -775,10 +775,12 @@ a.button.configure_search:hover {
 }
 
 .ingredients-widget .ingredient__item {
+  display: flex;
   height: 3em;
 }
 
 .ingredient__label {
+  align-self: center;
   display: inline-block;
   min-width: 10em;
 }
@@ -792,9 +794,14 @@ a.button.configure_search:hover {
 }
 
 .field .ingredient__unit {
+  align-self: center;
   margin-left: 1em;
-  vertical-align: baseline;
   width: 5em;
+}
+
+.field .ingredient__details {
+  flex: 1 1 auto;
+  margin-left: 1em;
 }
 
 .rst-preview {

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -90,7 +90,7 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
         self.assertEqual(s.getCssCount('css=li.ingredient__item'), 2)  # not 3
 
         # Reorder ingredients
-        s.dragAndDrop('css=li.ingredient__item', '0,50')
+        s.dragAndDrop('css=.ingredient__label', '0,50')
         s.waitForVisible('css=li.ingredient__item')
         s.assertText(
             '//li[@class="ingredient__item"][2]/a[@class="ingredient__label"]',

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -153,4 +153,4 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
         s.assertAttribute(
             'css=.ingredients-widget input@value',
             '[{"code":"brathaehnchen","label":"Brathähnchen",'
-            '"amount":"2","unit":""}]')
+            '"amount":"2","unit":"","details":""}]')

--- a/core/src/zeit/content/modules/configure.zcml
+++ b/core/src/zeit/content/modules/configure.zcml
@@ -26,7 +26,7 @@
 
   <class class=".recipelist.Ingredient">
     <require
-      attributes="code label amount unit"
+      attributes="code label amount unit details"
       permission="zope.View"
       />
   </class>

--- a/core/src/zeit/content/modules/recipelist.py
+++ b/core/src/zeit/content/modules/recipelist.py
@@ -1,6 +1,8 @@
 from lxml.objectify import E
 import collections
+import zeit.cms.content.property
 import zeit.content.modules.interfaces
+import zeit.edit.block
 import zeit.wochenmarkt.interfaces
 import zope.interface
 
@@ -27,9 +29,9 @@ class Ingredient(object):
         return cls(
             code,
             name,
-            node.get('amount'),
-            node.get('unit'),
-            node.get('details'))
+            node.get('amount', ''),
+            node.get('unit', ''),
+            node.get('details', ''))
 
 
 @zope.interface.implementer(zeit.content.modules.interfaces.IRecipeList)

--- a/core/src/zeit/content/modules/recipelist.py
+++ b/core/src/zeit/content/modules/recipelist.py
@@ -7,11 +7,12 @@ import zope.interface
 
 class Ingredient(object):
 
-    def __init__(self, code, label, amount, unit):
+    def __init__(self, code, label, amount, unit, details):
         self.code = code
         self.label = label
         self.amount = amount
         self.unit = unit
+        self.details = details
 
     @classmethod
     def from_xml(cls, node):
@@ -27,7 +28,8 @@ class Ingredient(object):
             code,
             name,
             node.get('amount'),
-            node.get('unit'))
+            node.get('unit'),
+            node.get('details'))
 
 
 @zope.interface.implementer(zeit.content.modules.interfaces.IRecipeList)
@@ -80,7 +82,8 @@ class RecipeList(zeit.edit.block.Element):
                 E.ingredient(
                     code=item.code,
                     amount=item.amount if hasattr(item, 'amount') else '',
-                    unit=item.unit if hasattr(item, 'unit') else ''))
+                    unit=item.unit if hasattr(item, 'unit') else '',
+                    details=item.details if hasattr(item, 'details') else ''))
 
     def _remove_duplicates(self, ingredients):
         result = collections.OrderedDict()

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -35,9 +35,13 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 class IngredientsHelper(object):
     """Mixin for tests which need some ingredients infrastrucutre."""
 
-    def get_ingredient(self, code):
+    def get_ingredient(self, code, **kwargs):
+        amount = kwargs.get('amount', '2')
+        unit = kwargs.get('unit', 'g')
+        details = kwargs.get('details', 'sautiert')
         ingredient = zeit.content.modules.recipelist.Ingredient(
-            code=code, label='_' + code, amount='2', unit='g')
+            code=code, label='_' + code, amount=amount,
+            unit=unit, details=details)
         return ingredient
 
     def setup_ingredients(self, *codes):

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -50,7 +50,8 @@ class RecipeListTest(
         milk = ingredients['milk']
         self.module.ingredients = [banana, milk]
         self.assertEllipsis(
-            '<ingredient... amount="2" code="banana" unit="g"/>',
+            '<ingredient... amount="2" code="banana" '
+            'details="sautiert" unit="g"/>',
             lxml.etree.tostring(
                 self.module.xml.ingredient,
                 encoding=six.text_type))

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -1,3 +1,4 @@
+from zeit.content.modules.recipelist import Ingredient
 import lxml.objectify
 import mock
 import six
@@ -72,3 +73,10 @@ class RecipeListTest(
         content.ingredients = [moepelspeck, banana]
         result = content.ingredients
         self.assertEqual(['banana'], [x.code for x in result])
+
+    def test_missing_xml_attributes_should_have_empty_string_as_default(self):
+        node = lxml.objectify.XML(
+            '<ingredient code="banana" amount="1" unit="kg"/>')
+        ingredient = Ingredient(None, None, None, None, None).from_xml(node)
+        assert ingredient.code == 'banana'
+        assert ingredient.details == ''  # not provided as xml attribute

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -7,6 +7,10 @@ zeit.cms.declare_namespace('zeit.wochenmarkt');
 
 zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
+    // XXX These should better be placed in a config file and handed through
+    // another hidden input field.
+    VALID_UNITS: ['', 'Stück', 'kg', 'g', 'l', 'ml', 'cl', 'Prise', 'EL', 'TL', 'Tasse', 'Päckchen', 'Schuss', 'Messerspitze', 'Bund', 'etwas', 'Blätter', 'Scheiben', 'Dose', 'Messerspitze', 'Stängel', 'Handvoll', 'Schote', 'Stange', 'Glas', 'Kopf', 'Kugel', 'Knolle', 'Zehe'],
+
     construct: function(id) {
         var self = this;
         self.id = id;
@@ -135,8 +139,8 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
         // Add unit
         let select = SELECT({'class': 'ingredient__unit', 'data-id': 'unit'});
-        const valid_units = ['', 'Stück', 'kg', 'g', 'l', 'ml', 'Prise', 'EL', 'TL', 'Tasse', 'Päckchen', 'Schuss', 'Messerspitze']
-        valid_units.forEach(function(i) {
+
+        self.VALID_UNITS.forEach(function(i) {
             select.appendChild(OPTION({}, i));
         });
         item.appendChild(select);

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -36,6 +36,7 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
                     ui.item.value, ui.item.label,
                     '', /*amount*/
                     '', /*unit*/
+                    '', /*details*/
                 );
                 $(self.autocomplete).val('');
                 return false;
@@ -56,8 +57,9 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
             }
         });
         self.list.querySelectorAll('[data-name = "ingredient__item"]').forEach(function(i) {
-            i.querySelector('input').value = i.getAttribute('data-amount');
-            i.querySelector('select').value = i.getAttribute('data-unit');
+            i.querySelector('.ingredient__amount').value = i.getAttribute('data-amount');
+            i.querySelector('.ingredient__unit').value = i.getAttribute('data-unit');
+            i.querySelector('.ingredient__details').value = i.getAttribute('data-details');
         });
     },
 
@@ -80,9 +82,10 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
             el = $(el);
             result.push({
                 code: el.attr('cms:uniqueId'),
-                label: el.contents().get(1).text,
+                label: el.contents().get(0).text,
                 amount: el.attr('data-amount'),
-                unit: el.attr('data-unit')
+                unit: el.attr('data-unit'),
+                details: el.attr('data-details')
             });
         });
         return result;
@@ -116,33 +119,48 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
         $(self.data).trigger('change');
     },
 
-    add: function(code, label, amount, unit) {
+    add: function(code, label, amount, unit, details) {
         var self = this;
-        self._add(code, label, amount, unit);
+        self._add(code, label, amount, unit, details);
         self._sync_json_widget_value();
     },
 
-    _add: function(code, label, amount, unit) {
+    _add: function(code, label, amount, unit, details) {
         var self = this;
         var item = LI(
-            {'class': 'ingredient__item', 'cms:uniqueId': code, 'data-amount': amount, 'data-unit': unit, 'data-name': 'ingredient__item'},
-            SPAN({'class': 'icon delete', 'cms:call': 'delete'}),
+            {'class': 'ingredient__item', 'cms:uniqueId': code, 'data-amount': amount, 'data-unit': unit, 'data-details': details, 'data-name': 'ingredient__item'},
             A({'class': 'ingredient__label'}, label),
             INPUT({'id': self.id + '.ingredient__amount', 'class': 'ingredient__amount', 'data-id': 'amount', 'placeholder': 'Anzahl'}),
         );
+
+        // Add unit
         let select = SELECT({'class': 'ingredient__unit', 'data-id': 'unit'});
         const valid_units = ['', 'Stück', 'kg', 'g', 'l', 'ml', 'Prise', 'EL', 'TL', 'Tasse', 'Päckchen', 'Schuss', 'Messerspitze']
         valid_units.forEach(function(i) {
             select.appendChild(OPTION({}, i));
         });
         item.appendChild(select);
+
+        // Add details
+        const details_input = INPUT({'id': self.id + '.ingredient__details', 'class': 'ingredient__details', 'data-id': 'details', 'size': 1, 'placeholder': 'weitere Angaben'});
+        item.appendChild(details_input);
+
+        // Delete button
+        item.appendChild(
+            SPAN({'class': 'icon delete', 'cms:call': 'delete'}));
+
         $(self.list).append(item);
     },
 
-    populate_ingredients: function(tags) {
+    populate_ingredients: function(ingredients) {
         var self = this;
-        $.each(tags, function(i, tag) {
-            self._add(tag.code, tag.label, tag.amount, tag.unit);
+        $.each(ingredients, function(i, ingredient) {
+            self._add(
+                ingredient.code,
+                ingredient.label,
+                ingredient.amount,
+                ingredient.unit,
+                ingredient.details);
         });
         self._sync_json_widget_value();
     },

--- a/core/src/zeit/wochenmarkt/browser/widget.py
+++ b/core/src/zeit/wochenmarkt/browser/widget.py
@@ -53,14 +53,15 @@ class IngredientsWidget(
     def _toFormValue(self, value):
         return json.dumps([{
             'code': x.code, 'label': x.label,
-            'amount': x.amount, 'unit': x.unit
+            'amount': x.amount, 'unit': x.unit,
+            'details': x.details
         } for x in value or ()])
 
     def _toFieldValue(self, value):
         data = json.loads(value)
         return tuple([
             Ingredient(
-                x['code'], x['label'], x['amount'], x['unit']
+                x['code'], x['label'], x['amount'], x['unit'], x['details']
             ) for x in data])
 
 


### PR DESCRIPTION
### Was erledigt dieser PR?
* Es gibt es neues Freitextfeld an Zutaten im Rezeptlistenmodul
* Die Liste der moeglichen Zutaten-Einheiten wurde erweitert

### Relevante Tickets
WOMA-115
WOMA-120

### Wie wird getestet?
* Artikel auschecken
* Rezeptlistenmodul in Artikeltext ziehen
* Zutat via autocomplete hinzufuegen

1. Es existiert nun ein weiteres Eingabefeld. Der eingegebene Freitext wird im XML am Zutaten-Attribut `details` gespeichert 
2. Das dropdown einre Zutat umfasst nun die Werte aus WOMA-120

### Giphy
![](https://media.giphy.com/media/6901DbEbbm4o0/giphy.gif)