### PR TITLE
ZON-5643: ensure config is given and valid before using it

### DIFF
--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -284,11 +284,12 @@ class EditCitationComment(zeit.edit.browser.form.InlineForm):
     undo_description = _('edit comment citation block')
 
     def setUpWidgets(self, *args, **kw):
-        super(EditCitationComment, self).setUpWidgets(*args, **kw)
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.content.article')
-        self.widgets['url'].extra = 'data-comments-api-url={}'.format(
-            config['zeit-comments-api-url'])
+        if isinstance(config, dict) and key in config:
+            super(EditCitationComment, self).setUpWidgets(*args, **kw)
+            self.widgets['url'].extra = 'data-comments-api-url={}'.format(
+                config['zeit-comments-api-url'])
 
     @property
     def prefix(self):


### PR DESCRIPTION
Im Zuge dieser Diskussion https://zon.slack.com/archives/C02FT8V2B/p1594029930145900 fiel mir auf, dass es diese Sicherheitsabfrage im Rahmen des Refactorings nicht in den Code geschafft hat...