### PR TITLE
WOMA-130: Use ids for ingredient units

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - WOMA-126: Remove duplicates in recipe from ES payload.
 
+- WOMA-130: Use ids for ingredient units
+
 
 4.36.1 (2020-07-07)
 -------------------

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -7,9 +7,10 @@ zeit.cms.declare_namespace('zeit.wochenmarkt');
 
 zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
-    // XXX These should better be placed in a config file and handed through
-    // another hidden input field.
-    VALID_UNITS: ['', 'Stück', 'kg', 'g', 'l', 'ml', 'cl', 'Prise', 'EL', 'TL', 'Tasse', 'Päckchen', 'Schuss', 'Messerspitze', 'Bund', 'etwas', 'Blätter', 'Scheiben', 'Dose', 'Messerspitze', 'Stängel', 'Handvoll', 'Schote', 'Stange', 'Glas', 'Kopf', 'Kugel', 'Knolle', 'Zehe'],
+    // XXX WOMA-130: Currently these ids are rendered as is in vivi frontend.
+    // They will be translated into proper strings at a later date during the
+    // development of WOMA-112, providing a configuration file for all units.
+    VALID_UNITS: ['', 'stueck', 'kg', 'g', 'l', 'ml', 'cl', 'prise', 'el', 'tl', 'tasse', 'paeckchen', 'schuss', 'messerspitze', 'bund', 'etwas', 'blaetter', 'scheiben', 'dose', 'messerspitze', 'staengel', 'handvoll', 'schote', 'stange', 'glas', 'kopf', 'kugel', 'knolle', 'zehe', 'spritzer', 'tropfen', 'becher'],
 
     construct: function(id) {
         var self = this;


### PR DESCRIPTION
### Was erledigt dieser PR?
Zutaten werden als id gespeichert, damit diese spaeter (WOMA-112) via konfiguration uebersetzt werden koennen, z.b. um singular/plural-Darstellung zu ermoeglichen.