### PR TITLE
WOMA-133: Fetch ingredient units from configuration file

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - WOMA-136_2: Update list of ingredient units
 
+- WOMA-133: Fetch ingredient units from configuration file
+
 
 4.36.5 (2020-07-14)
 -------------------

--- a/core/src/zeit/content/article/edit/browser/testing.py
+++ b/core/src/zeit/content/article/edit/browser/testing.py
@@ -109,3 +109,19 @@ class EditorTestCase(zeit.content.article.testing.SeleniumTestCase,
                      EditorHelper):
     window_width = 1600
     window_height = 1000
+
+
+class RecipeListHelper(object):
+
+    editable_locator = '.block.type-p .editable'
+
+    def setup_ingredient(self, add_location='/repository'):
+        s = self.selenium
+        self.add_article()
+        self.create_block('recipelist')
+        s.waitForElementPresent('//input[@name="add_ingredient"]')
+
+        # Add ingredient
+        s.type('//input[@name="add_ingredient"]', 'Brath')
+        s.waitForVisible('css=ul.ui-autocomplete li')
+        s.click('css=ul.ui-autocomplete li')

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -45,7 +45,9 @@ class RecipeListTest(
             b.contents)
 
 
-class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
+class FormLoader(
+        zeit.content.article.edit.browser.testing.EditorTestCase,
+        zeit.content.article.edit.browser.testing.RecipeListHelper):
 
     def test_recipelist_form_is_loaded(self):
         s = self.selenium
@@ -56,14 +58,7 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_ingredients_should_be_organized_through_recipelist(self):
         s = self.selenium
-        self.add_article()
-        self.create_block('recipelist')
-        s.waitForElementPresent('//input[@name="add_ingredient"]')
-
-        # Add first ingredient
-        s.type('//input[@name="add_ingredient"]', 'Brath')
-        s.waitForVisible('css=ul.ui-autocomplete li')
-        s.click('css=ul.ui-autocomplete li')
+        self.setup_ingredient()
 
         self.assertEqual(s.getCssCount('css=li.ingredient__item'), 1)
         s.assertText('css=a.ingredient__label', 'Brathähnchen')
@@ -102,14 +97,7 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_ingredient_amount_should_be_validated(self):
         s = self.selenium
-        self.add_article()
-        self.create_block('recipelist')
-        s.waitForElementPresent('//input[@name="add_ingredient"]')
-
-        # Add ingredient
-        s.type('//input[@name="add_ingredient"]', 'Brath')
-        s.waitForVisible('css=ul.ui-autocomplete li')
-        s.click('css=ul.ui-autocomplete li')
+        self.setup_ingredient()
 
         # Should accept numbers
         s.type('css=input.ingredient__amount', '2')
@@ -137,14 +125,7 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_ingredient_should_store_values_as_json(self):
         s = self.selenium
-        self.add_article()
-        self.create_block('recipelist')
-        s.waitForElementPresent('//input[@name="add_ingredient"]')
-
-        # Add ingredient
-        s.type('//input[@name="add_ingredient"]', 'Brath')
-        s.waitForVisible('css=ul.ui-autocomplete li')
-        s.click('css=ul.ui-autocomplete li')
+        self.setup_ingredient()
 
         s.type('css=input.ingredient__amount', '2')
         s.runScript(
@@ -154,3 +135,19 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
             'css=.ingredients-widget input@value',
             '[{"code":"brathaehnchen","label":"Brathähnchen",'
             '"amount":"2","unit":"","details":""}]')
+
+    def test_ingredient_units_should_be_fetched_from_endpoint(self):
+        s = self.selenium
+        self.setup_ingredient()
+
+        s.click('css=.ingredient__unit')
+        s.click('//option[text()="Stück"]')
+        s.clickAt('css=.ingredient__unit', '0,40')
+        s.waitForCssCount('css=.dirty', 0)
+        s.assertValue('css=.ingredient__unit', 'stueck')
+        s.assertAttribute(
+            'css=.ingredients-widget input@value',
+            '[{"code":"brathaehnchen","label":"Brathähnchen",'
+            '"amount":"","unit":"stueck","details":""}]')
+
+        s.assertCssCount('css=.ingredient__unit option', 3)

--- a/core/src/zeit/content/article/ftesting.zcml
+++ b/core/src/zeit/content/article/ftesting.zcml
@@ -10,6 +10,7 @@
   <include package="zeit.edit.browser" />
 
   <include package="zeit.content.modules" />
+  <include package="zeit.content.modules.browser" />
 
   <include package="zeit.content.article" />
   <include package="zeit.content.article.browser" />

--- a/core/src/zeit/content/modules/browser/__init__.py
+++ b/core/src/zeit/content/modules/browser/__init__.py
@@ -1,0 +1,1 @@
+# python package

--- a/core/src/zeit/content/modules/browser/configure.zcml
+++ b/core/src/zeit/content/modules/browser/configure.zcml
@@ -1,0 +1,9 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser"
+  xmlns:grok="http://namespaces.zope.org/grok"
+  i18n_domain="zeit.cms">
+
+  <grok:grok package="." />
+
+</configure>

--- a/core/src/zeit/content/modules/browser/sources.py
+++ b/core/src/zeit/content/modules/browser/sources.py
@@ -1,0 +1,19 @@
+import grokcore.component as grok
+import zeit.content.modules.interfaces
+import zeit.cms.content.browser.sources
+
+
+class SerializeRecipeUnitsSource(
+        zeit.cms.content.browser.sources.SerializeContextualSource):
+
+    grok.context(zeit.content.modules.interfaces.RecipeUnitsSource)
+
+    def __call__(self):
+        result = []
+        for unit in self.context._get_tree().xpath('//units/unit'):
+            item = {
+                'id': unit.get('code'),
+                'title': unit.get('singular')
+            }
+            result.append(item)
+        return result

--- a/core/src/zeit/content/modules/browser/tests/__init__.py
+++ b/core/src/zeit/content/modules/browser/tests/__init__.py
@@ -1,0 +1,1 @@
+# python package

--- a/core/src/zeit/content/modules/browser/tests/test_sources.py
+++ b/core/src/zeit/content/modules/browser/tests/test_sources.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+import zeit.content.modules.testing
+
+
+class SourceAPI(zeit.content.modules.testing.BrowserTestCase):
+
+    def test_units_endpoint_should_return_valid_json(self):
+        self.browser.open('http://localhost/@@source?name='
+                          'zeit.content.modules.interfaces.RecipeUnitsSource')
+        self.assert_json([
+            {'id': '', 'title': ''},
+            {'id': 'stueck', 'title': 'Stück'},
+            {'id': 'kg', 'title': 'kg'},
+        ])

--- a/core/src/zeit/content/modules/configure.zcml
+++ b/core/src/zeit/content/modules/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:grok="http://namespaces.zope.org/grok">
 
-  <grok:grok package="." />
+  <grok:grok package="." exclude="browser" />
 
   <include package="zeit.cmp" />
 

--- a/core/src/zeit/content/modules/ftesting.zcml
+++ b/core/src/zeit/content/modules/ftesting.zcml
@@ -7,6 +7,8 @@
   <include package="zeit.cms" file="ftesting.zcml" />
 
   <include package="zeit.content.modules" />
+  <include package="zeit.content.modules.browser" />
+
   <include package="zeit.content.text" />
   <include package="zeit.wochenmarkt" />
 

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -219,6 +219,12 @@ class RecipeMetadataSource(zeit.cms.content.sources.XMLSource):
         return [six.text_type(node) for node in tree.xpath(self.xpath)]
 
 
+class RecipeUnitsSource(RecipeMetadataSource):
+
+    def __init__(self):
+        super().__init__('//unit')
+
+
 # Servings are valid if all of these are satisfied:
 # <num> is a number > 0
 # format is: <num> or <num>-<num>

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -25,11 +25,17 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(product_config, bases=(
     zeit.wochenmarkt.testing.CONFIG_LAYER))
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
+WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 
     layer = ZOPE_LAYER
+
+
+class BrowserTestCase(zeit.cms.testing.ZeitCmsBrowserTestCase):
+
+    layer = WSGI_LAYER
 
 
 class IngredientsHelper(object):

--- a/core/src/zeit/content/modules/tests/fixtures/recipe-metadata.xml
+++ b/core/src/zeit/content/modules/tests/fixtures/recipe-metadata.xml
@@ -10,4 +10,9 @@
     <time>30-60 Minuten</time>
     <time>über 60 Minuten</time>
   </times>
+  <units>
+    <unit code="" singular="" plural=""/>
+    <unit code="stueck" singular="Stück" plural="Stücke" ingredient_singular="true"/>
+    <unit code="kg" singular="kg" plural="kg" ingredient_plural="true"/>
+  </units>
 </recipe-metadata>

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -154,25 +154,21 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
         // Add unit
         let select = SELECT({'class': 'ingredient__unit', 'data-id': 'unit'});
-        self._add_units(select, unit);
+        units.forEach(function(u) {
+            select.appendChild(OPTION({'value': u.id}, u.title));
+        });
+        select.value = unit;
         item.appendChild(select);
 
         // Add details
         const details_input = INPUT({'id': self.id + '.ingredient__details', 'class': 'ingredient__details', 'data-id': 'details', 'size': 1, 'placeholder': 'weitere Angaben'});
         item.appendChild(details_input);
 
-        // Delete button
+        // Add delete button
         item.appendChild(
             SPAN({'class': 'icon delete', 'cms:call': 'delete'}));
 
         $(self.list).append(item);
-    },
-
-    _add_units: function(element, value) {
-        units.forEach(function(u) {
-            element.appendChild(OPTION({'value': u.id}, u.title));
-        });
-        element.value = value;
     },
 
     populate_ingredients: function(ingredients) {


### PR DESCRIPTION
JENKINS_BATOU_BRANCH=WOMA-133

### Obacht
Muss gemeinsam mit folgendem PR gemergt werden: https://github.com/ZeitOnline/vivi-deployment/pull/131

### Was erledigt dieser PR?
Die Einheiten von Zutaten werden nun aus einer Konfigurationsdatei gelesen.

### Wie wird getestet?
Voraussetzung:
* Einen Artikel anlegen
* Das Rezeptlistenmodul in den Artikeltext ziehen
* Eine Zutat hinzufuegen

Tests:
1. Einheit auswaehlen
1.1 In der Auswahl befinden sich die Einheiten aus der Konfiguration: https://vivi.staging.zeit.de/repository/data/recipe-metadata.xml
1.2 Der Name der Einheit entspricht dem XML-Attribut `singular`. Wurde Einheit ausgewaehlt, steht im XML des Artikels der Wert des XML-Attributs `code`.

2. Einheiten hinzufuegen/aendern
2.1 Den Wert `singular` oder `code` einer vorhandenen Einheit in der Konfiguration aendern oder eine weitere Einheit hinzufuegen: https://vivi.staging.zeit.de/repository/data/recipe-metadata.xml
2.2 Nach einem reload steht die geaenderte/neue Einheit im Rezeptlistenmodul Verfuegung (Das kann bis zu 10 Minuten dauern)

### Giphy
![](https://media.giphy.com/media/3orieOiUngX5aXVP3i/giphy.gif)

### Obacht
Muss gemeinsam mit folgendem PR gemergt werden: https://github.com/ZeitOnline/vivi-deployment/pull/131
