### PR TITLE
WOMA-137: Allow duplicate ingredients in recipe list module

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - WOMA-136_2: Update list of ingredient units
 
+- WOMA-137: Allow duplicate ingredients in recipe list module
+
 
 4.36.5 (2020-07-14)
 -------------------

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -81,15 +81,6 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
             '//li[@class="ingredient__item"][2]/a[@class="ingredient__label"]',
             'Bandnudeln')
 
-        # Duplicates should be prevented
-        s.type('//input[@name="add_ingredient"]', 'Nudel')
-        s.waitForVisible('css=ul.ui-autocomplete li')
-        # XXX This is tricky, but we somehow need to lose focus on the whole
-        # widget and blur does not work this time. Maybe there is another way?
-        s.clickAt('css=ul.ui-autocomplete li', '-20,0')
-        s.waitForVisible('css=li.ingredient__item')
-        self.assertEqual(s.getCssCount('css=li.ingredient__item'), 2)  # not 3
-
         # Reorder ingredients
         s.dragAndDrop('css=.ingredient__label', '0,50')
         s.waitForVisible('css=li.ingredient__item')
@@ -159,3 +150,24 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
         assert ingredient_data.get('unit') == ''
         assert ingredient_data.get('details') == ''
         assert ingredient_data.get('unique_id') is not None
+
+    def test_duplicate_ingredients_should_be_allowed(self):
+        s = self.selenium
+        self.add_article()
+        self.create_block('recipelist')
+
+        # Add first ingredient
+        s.type('//input[@name="add_ingredient"]', 'Nudel')
+        s.waitForVisible('css=ul.ui-autocomplete li')
+        s.click('css=ul.ui-autocomplete li')
+
+        # Add duplicate ingredient
+        s.type('//input[@name="add_ingredient"]', 'Nudel')
+        s.waitForVisible('css=ul.ui-autocomplete li')
+        s.click('css=ul.ui-autocomplete li')
+        self.assertEqual(s.getCssCount('css=li.ingredient__item'), 2)
+
+        # ids should be different.
+        uid1 = s.getAttribute('//li[@class="ingredient__item"][1] @data-id')
+        uid2 = s.getAttribute('//li[@class="ingredient__item"][2] @data-id')
+        assert uid1 != uid2

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import zeit.content.article.edit.browser.testing
 
 
@@ -150,7 +151,11 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
         s.runScript(
             'document.querySelector("input.ingredient__amount").blur()')
         s.waitForCssCount('css=.dirty', 0)
-        s.assertAttribute(
-            'css=.ingredients-widget input@value',
-            '[{"code":"brathaehnchen","label":"Brathähnchen",'
-            '"amount":"2","unit":"","details":""}]')
+        ingredient_data = json.loads(
+            s.getAttribute('css=.ingredients-widget input@value'))[0]
+        assert ingredient_data.get('code') == 'brathaehnchen'
+        assert ingredient_data.get('label') == 'Brathähnchen'
+        assert ingredient_data.get('amount') == '2'
+        assert ingredient_data.get('unit') == ''
+        assert ingredient_data.get('details') == ''
+        assert ingredient_data.get('unique_id') is not None

--- a/core/src/zeit/content/modules/recipelist.py
+++ b/core/src/zeit/content/modules/recipelist.py
@@ -1,5 +1,4 @@
 from lxml.objectify import E
-import collections
 import zeit.cms.content.property
 import zeit.content.modules.interfaces
 import zeit.edit.block
@@ -78,7 +77,6 @@ class RecipeList(zeit.edit.block.Element):
     def ingredients(self, value):
         for node in self.xml.xpath('./ingredient'):
             node.getparent().remove(node)
-        value = self._remove_duplicates(value)
         for item in value:
             self.xml.append(
                 E.ingredient(
@@ -86,10 +84,3 @@ class RecipeList(zeit.edit.block.Element):
                     amount=item.amount if hasattr(item, 'amount') else '',
                     unit=item.unit if hasattr(item, 'unit') else '',
                     details=item.details if hasattr(item, 'details') else ''))
-
-    def _remove_duplicates(self, ingredients):
-        result = collections.OrderedDict()
-        for ingredient in ingredients:
-            if ingredient.code not in result:
-                result[ingredient.code] = ingredient
-        return result.values()

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -40,11 +40,11 @@ class RecipeListTest(
         self.assertEqual(['banana', 'milk'], (
             [x.code for x in self.module.ingredients]))
 
-    def test_set_should_add_duplicate_values_only_once(self):
+    def test_set_should_allow_duplicate_ingredients(self):
         ingredients = self.setup_ingredients('banana')
         banana = ingredients['banana']
         self.module.ingredients = [banana, banana]
-        self.assertEqual(['banana'], (
+        self.assertEqual(['banana', 'banana'], (
             [x.code for x in self.module.ingredients]))
 
     def test_set_should_write_ingredients_to_xml_head(self):

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -86,7 +86,8 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
         $('> li', self.list).each(function(i, el) {
             el = $(el);
             result.push({
-                code: el.attr('cms:uniqueId'),
+                unique_id: el.attr('data-id'),
+                code: el.attr('data-code'),
                 label: el.contents().get(0).text,
                 amount: el.attr('data-amount'),
                 unit: el.attr('data-unit'),
@@ -98,10 +99,10 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
     update_entry: function(data) {
         const parent_el = event.target.parentElement;
-        const id = parent_el.getAttribute('cms:uniqueid');
+        const id = parent_el.getAttribute('data-id');
         let ingredients = JSON.parse(data.value);
         ingredients.forEach(function(i) {
-            if (i.code === id) {
+            if (i.unique_id === id) {
                 const val = event.target.value;
                 // amount either needs to be a number or empty.
                 if (event.target.getAttribute('data-id') === 'amount' && (isNaN(Number(val)) && val !== '')) {
@@ -132,8 +133,17 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
 
     _add: function(code, label, amount, unit, details) {
         var self = this;
+        // As it is possible to add duplicate ingredients, we cannot rely on the
+        // ingredient id (aka code) alone. Thus we add a random number stub,
+        // serving as unique id. Since we're dealing only with a relatively
+        // small number of ingredients per document, using a simple random
+        // function is sufficient.
+        //
+        // Math.random() always returns something like 0.123..., so for our id,
+        // we only want to use the stub from the right side of the comma.
+        const unique_id = code + '_' + Math.random().toString().split('.')[1];
         var item = LI(
-            {'class': 'ingredient__item', 'cms:uniqueId': code, 'data-amount': amount, 'data-unit': unit, 'data-details': details, 'data-name': 'ingredient__item'},
+            {'class': 'ingredient__item', 'data-id': unique_id, 'data-code': code, 'data-amount': amount, 'data-unit': unit, 'data-details': details, 'data-name': 'ingredient__item'},
             A({'class': 'ingredient__label'}, label),
             INPUT({'id': self.id + '.ingredient__amount', 'class': 'ingredient__amount', 'data-id': 'amount', 'placeholder': 'Anzahl'}),
         );


### PR DESCRIPTION
### Was erledigt dieser PR?
Bisher wurde verhindert, dass Zutaten doppelt hinzugefuegt werden koennen. Da es aber gelegentlich vorkommen kann, dass ein Rezept dieselbe Zutat mehrmals auflistet, ggf. unter veraenderten Werten fuer `Einheit` und/oder `weitere Angaben`, soll dies nun ermoeglicht werden.

### Wie wird getestet?
Voraussetzung:
* Im Vivi einen Artikel anlegen
* Das Rezeptlistenmodul in den Artikeltext ziehen

Test:
1. Eine Zutat mehrfach hinzufuegen
* Ein bisschen mit den Werten rumspielen / neu sortieren etc.
  * Die Zutaten muessen unabhaengig voneinander editiert werden koennen - wenn die z.B. die Mengenangabe fuer eine Einheit eingegeben wird, darf sie nicht auf die andere kopiert werden
* An jedem `li` muss eine eindeutige `data-id` haengen

### Was fehlt noch?
- [ ] Changelog-Eintrag durch Reviewer

### Giphy
![](https://media.giphy.com/media/3orieX9hy38h6mwyHK/giphy.gif)