### PR TITLE
MAINT: Update to lxml-4.4 which now keeps attribute order when initialized with a dict

### DIFF
--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -53,8 +53,8 @@ class RecipeListTest(
         milk = ingredients['milk']
         self.module.ingredients = [banana, milk]
         self.assertEllipsis(
-            '<ingredient... amount="2" code="banana" '
-            'details="sautiert" unit="g"/>',
+            '<ingredient... code="banana" amount="2" '
+            'unit="g" details="sautiert"/>',
             zeit.cms.testing.xmltotext(self.module.xml.ingredient))
 
     def test_removing_all_ingredients_should_leave_no_trace(self):

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -3,7 +3,7 @@ from zeit.content.modules.interfaces import validate_servings
 from zeit.content.modules.recipelist import Ingredient
 import lxml.objectify
 import mock
-import six
+import zeit.cms.testing
 import zeit.content.modules.embed
 import zeit.content.modules.testing
 
@@ -55,9 +55,7 @@ class RecipeListTest(
         self.assertEllipsis(
             '<ingredient... amount="2" code="banana" '
             'details="sautiert" unit="g"/>',
-            lxml.etree.tostring(
-                self.module.xml.ingredient,
-                encoding=six.text_type))
+            zeit.cms.testing.xmltotext(self.module.xml.ingredient))
 
     def test_removing_all_ingredients_should_leave_no_trace(self):
         ingredients = self.setup_ingredients('banana')

--- a/core/src/zeit/content/volume/browser/tests/test_form.py
+++ b/core/src/zeit/content/volume/browser/tests/test_form.py
@@ -65,8 +65,8 @@ class VolumeBrowserTest(zeit.content.volume.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2010/02/ausgabe')
-        cover = '...<cover href="http://xml.zeit.de/imagegroup/" ' \
-                'id="landscape" product_id="ZMLB"/>...'
+        cover = '...<cover id="landscape" product_id="ZMLB" ' \
+                'href="http://xml.zeit.de/imagegroup/"/>...'
         self.assertEllipsis(cover, zeit.cms.testing.xmltotext(volume.xml))
 
     def test_displays_warning_if_volume_with_same_name_already_exists(self):

--- a/core/src/zeit/content/volume/browser/tests/test_form.py
+++ b/core/src/zeit/content/volume/browser/tests/test_form.py
@@ -1,10 +1,9 @@
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 from zeit.content.image.testing import create_image_group
 from zeit.content.volume.volume import Volume
-import lxml.etree
-import six
 import zeit.content.text.python
 import zeit.content.volume.testing
+import zeit.cms.testing
 import zeit.cms.content.add
 
 
@@ -66,10 +65,9 @@ class VolumeBrowserTest(zeit.content.volume.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2010/02/ausgabe')
-        cover_string = '<cover href="http://xml.zeit.de/imagegroup/" ' \
-                       'id="landscape" product_id="ZMLB"/>'
-        self.assertIn(cover_string, lxml.etree.tostring(
-            volume.xml, encoding=six.text_type))
+        cover = '...<cover href="http://xml.zeit.de/imagegroup/" ' \
+                'id="landscape" product_id="ZMLB"/>...'
+        self.assertEllipsis(cover, zeit.cms.testing.xmltotext(volume.xml))
 
     def test_displays_warning_if_volume_with_same_name_already_exists(self):
         b = self.browser

--- a/core/src/zeit/content/volume/tests/test_volume.py
+++ b/core/src/zeit/content/volume/tests/test_volume.py
@@ -48,8 +48,8 @@ class TestVolumeCovers(zeit.content.volume.testing.FunctionalTestCase):
         self.volume.set_cover('ipad', 'ZEI', self.repository['imagegroup'])
         self.assertEqual(
             '<covers xmlns:py="http://codespeak.net/lxml/objectify/pytype">'
-            '<cover href="http://xml.zeit.de/imagegroup/" id="ipad" '
-            'product_id="ZEI"/>'
+            '<cover id="ipad" product_id="ZEI" '
+            'href="http://xml.zeit.de/imagegroup/"/>'
             '</covers>',
             lxml.etree.tostring(
                 self.volume.xml.covers, encoding=six.text_type))


### PR DESCRIPTION
JENKINS_BATOU_BRANCH=maint/deps-depr

Needs https://github.com/ZeitOnline/vivi-deployment/pull/128