### PR TITLE
Revert "MAINT: lxml-4.4 now keeps attribute order when initialized wi…

### DIFF
--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -53,8 +53,8 @@ class RecipeListTest(
         milk = ingredients['milk']
         self.module.ingredients = [banana, milk]
         self.assertEllipsis(
-            '<ingredient... code="banana" amount="2" '
-            'unit="g" details="sautiert"/>',
+            '<ingredient... amount="2" code="banana" '
+            'details="sautiert" unit="g"/>',
             zeit.cms.testing.xmltotext(self.module.xml.ingredient))
 
     def test_removing_all_ingredients_should_leave_no_trace(self):

--- a/core/src/zeit/content/volume/browser/tests/test_form.py
+++ b/core/src/zeit/content/volume/browser/tests/test_form.py
@@ -65,8 +65,8 @@ class VolumeBrowserTest(zeit.content.volume.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2010/02/ausgabe')
-        cover = '...<cover id="landscape" product_id="ZMLB" ' \
-                'href="http://xml.zeit.de/imagegroup/"/>...'
+        cover = '...<cover href="http://xml.zeit.de/imagegroup/" ' \
+                'id="landscape" product_id="ZMLB"/>...'
         self.assertEllipsis(cover, zeit.cms.testing.xmltotext(volume.xml))
 
     def test_displays_warning_if_volume_with_same_name_already_exists(self):

--- a/core/src/zeit/content/volume/tests/test_volume.py
+++ b/core/src/zeit/content/volume/tests/test_volume.py
@@ -48,8 +48,8 @@ class TestVolumeCovers(zeit.content.volume.testing.FunctionalTestCase):
         self.volume.set_cover('ipad', 'ZEI', self.repository['imagegroup'])
         self.assertEqual(
             '<covers xmlns:py="http://codespeak.net/lxml/objectify/pytype">'
-            '<cover id="ipad" product_id="ZEI" '
-            'href="http://xml.zeit.de/imagegroup/"/>'
+            '<cover href="http://xml.zeit.de/imagegroup/" id="ipad" '
+            'product_id="ZEI"/>'
             '</covers>',
             lxml.etree.tostring(
                 self.volume.xml.covers, encoding=six.text_type))


### PR DESCRIPTION
…th a dict"

We're temporarily switching back to lxml-4.2.

This reverts commit a8e8edabcf47d299e06affecc379e9917cb69bde.
See also vivi-deployment:56f00213c481a5c26cc718938867c016cb80e817