### PR TITLE
WOMA-141: Update portion range validation for servings

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.36.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WOMA-141: Update portion range validation for servings
 
 
 4.36.6 (2020-07-20)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -227,10 +227,13 @@ VALID_SERVINGS = re.compile(r'^[1-9]\d*(-\d+)?$')
 
 def validate_servings(value):
     if VALID_SERVINGS.match(value) is not None:
-        v = value.split('-')
-        # In case it's a range, the second value must be higher.
-        if len(v) == 1 or v[0] < v[1]:
-            return True
+        try:
+            v = list(map(int, value.split('-')))
+            # In case it's a range, the second value must be higher.
+            if len(v) == 1 or int(v[0]) < int(v[1]):
+                return True
+        except ValueError:
+            pass
     raise zeit.cms.interfaces.ValidationError(
         _('Value must be number or range.'))
 

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -77,7 +77,9 @@ class RecipeListTest(
     def test_servings_should_be_validated(self):
         assert validate_servings('1') is True
         assert validate_servings('1-2') is True
+        assert validate_servings('9-12') is True
         assert validate_servings('10-12') is True
+        assert validate_servings('100-225') is True
 
         with self.assertRaises(ValidationError):
             validate_servings('')


### PR DESCRIPTION
### Was erledigt dieser PR
Manche Portionsangaben wurden auf Grund von String-Vergleich falsch validiert. Jetzt wird explizit zu int konvertiert.

### Wie wird getestet
Voraussetzung:
* Artikel anlegen (Genre: Zeit Magazin)
* Rezeptlistenmodul in Artikeltext ziehen

Test:
* Portionsangabe a la `9-12` wird akzeptiert

### Giphy
![](https://media.giphy.com/media/BFUHnCMC6m4kE/giphy.gif)