### PR TITLE
WOMA-142: Return nodes not just strings of RecipeMetadataSource

### DIFF
--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -218,6 +218,10 @@ class RecipeMetadataSource(zeit.cms.content.sources.XMLSource):
         tree = self._get_tree()
         return [six.text_type(node) for node in tree.xpath(self.xpath)]
 
+    def getNodes(self):
+        tree = self._get_tree()
+        return [node for node in tree.xpath(self.xpath)]
+
 
 # Servings are valid if all of these are satisfied:
 # <num> is a number > 0


### PR DESCRIPTION
Fügt der der `RecipeMetadataSource` eine Funktion hinzu, die die ganzen Knoten und nicht nur in Strings umgeformte Werte wie getValues zurückgibt. Wird im Skript WOMA-142 für das Korrigieren der alten Einheitennamen zu ihren entsprechenden Codes benötigt.

![](https://media.giphy.com/media/3oEjHIAP0GiBrwBXuo/giphy.gif)
