### PR TITLE
BUG-1273: Handle toplevel br nodes that can appear when pasting content

### DIFF
--- a/core/src/zeit/cms/browser/js/base.js
+++ b/core/src/zeit/cms/browser/js/base.js
@@ -280,6 +280,9 @@ zeit.cms.with_lock = function(callable) {
     d.addCallback(function(result) {
         return pfunc();
     });
+    d.addErrback(function(error) {
+        zeit.cms.log_error(error);
+    });
     d.addBoth(function(result_or_error) {
         zeit.cms.request_lock.release();
         return result_or_error;

--- a/core/src/zeit/content/article/edit/browser/resources/html.js
+++ b/core/src/zeit/content/article/edit/browser/resources/html.js
@@ -56,7 +56,9 @@ function translate_tags(tree) {
 
 
 function kill_empty_p(tree) {
-    forEach(tree.childNodes, function(el) {
+    var children = [];
+    MochiKit.Base.extend(children, tree.childNodes);
+    forEach(children, function(el) {
         if (tag(el) == 'p' && ! el.hasChildNodes()) {
             MochiKit.DOM.removeElement(el);
         } else {

--- a/core/src/zeit/content/article/edit/browser/resources/html.js
+++ b/core/src/zeit/content/article/edit/browser/resources/html.js
@@ -7,8 +7,8 @@ zeit.content.article.html.to_xml = function(tree) {
     var steps = [
         wrap_toplevel_children_in_p,
         translate_tags,
-        kill_empty_p,
         replace_double_br_with_p,
+        kill_empty_p,
         escape_missing_href,
         normalize_quotation_marks
     ];
@@ -117,7 +117,8 @@ function wrap_toplevel_children_in_p(tree) {
     };
 
     forEach(tree.childNodes, function(el) {
-        if (el.nodeType == el.TEXT_NODE || display(el) == 'inline') {
+        if (el.nodeType == el.TEXT_NODE || display(el) == 'inline' ||
+            tag(el) == 'br') {
             collect.push(el);
         } else {
             if (collect.length) {

--- a/core/src/zeit/content/article/edit/browser/tests/test_html.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_html.py
@@ -62,6 +62,16 @@ class HTMLConvertTest(
                          self.eval('window.jQuery(".editable")[0].innerHTML'))
         s.assertXpathCount('//*[@class="editable"]//br', 0)
 
+    def test_trailing_br_does_not_break_see_BUG_1273(self):
+        self.execute("""\
+            window.tree = MochiKit.DOM.createDOM('p');
+            window.tree.innerHTML = '<p>foo</p><br><br>';
+            window.cloned = window.tree.cloneNode(true);
+            window.zeit.content.article.html.to_xml(window.cloned);
+        """)
+        # br/br transforms to p, and empty p is removed
+        self.assertEqual('<p>foo</p>', self.eval('window.cloned.innerHTML'))
+
     def test_single_br_is_conserved(self):
         s = self.selenium
         self.create('<p>foo<br>bar</p>')

--- a/core/src/zeit/content/article/edit/browser/tests/test_html.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_html.py
@@ -45,6 +45,14 @@ class HTMLConvertTest(
         s.assertElementPresent('jquery=.editable p:contains(foo)')
         s.assertXpathCount('//*[@class="editable"]//p', 1)
 
+    def test_empty_p_are_removed(self):
+        s = self.selenium
+        self.create('<p>foo</p><p></p><p></p>')
+        self.convert()
+        self.assertEqual(
+            '<p>foo</p>', self.eval('window.jQuery(".editable")[0].innerHTML'))
+        s.assertXpathCount('//*[@class="editable"]//p', 1)
+
     def test_all_double_brs_are_translated_to_p(self):
         s = self.selenium
         self.create('<p>foo<br><br>bar<br><br>baz</p>')


### PR DESCRIPTION
Siehe [BUG-1273](https://zeit-online.atlassian.net/browse/BUG-1273).