### PR TITLE
ZON-6068 header color using master/slave widget

### DIFF
--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -52,7 +52,7 @@ zeit.cms.MasterSlaveDropDown = gocept.Class.extend({
 });
 
 
-zeit.cms.MultiGenerationDropDown = gocept.Class.extend({
+zeit.cms.MultiGenerationDropDown = zeit.cms.MasterSlaveDropDown.extend({
 
     construct: function(grandparent, parent, child, update_url) {
         var self = this;
@@ -72,11 +72,6 @@ zeit.cms.MultiGenerationDropDown = gocept.Class.extend({
 
         MochiKit.Signal.connect(grandparent, 'onchange', self, self.update);
         self.update();
-    },
-
-    destroy: function() {
-        var self = this;
-        MochiKit.Signal.disconnectAllTo(self, self.update);
     },
 
     update: function(event) {

--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -56,9 +56,22 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.ParentChildDropDown.extend({
 
     construct: function(parent, child, grandchild, update_url) {
         var self = this;
+        self.parent = parent;
+        self.child = child;
         self.grandchild = grandchild;
+        self.update_url = update_url;
+
+        // XXX The following selector makes sense only in part of the forms
+        // used by vivi. In particular, it doesn't work for the subpage form
+        // of addcentral. When we implemented hiding the child drop-down to
+        // fix #10664, the resulting difference in behaviour between
+        // addcentral and, e.g., an article's edit form happened to be what
+        // was requested, so we left it at that.
+        self.child_field = jQuery(child).closest('.field');
         self.grandchild_field = jQuery(grandchild).closest('.field');
-        arguments.callee.$.construct.call(self);
+
+        MochiKit.Signal.connect(parent, 'onchange', self, self.update);
+        self.update();
     },
 
     update: function(event) {

--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -1,20 +1,20 @@
-zeit.cms.MasterSlaveDropDown = gocept.Class.extend({
+zeit.cms.ParentChildDropDown = gocept.Class.extend({
 
-    construct: function(master, slave, update_url) {
+    construct: function(parent, child, update_url) {
         var self = this;
-        self.master = master;
-        self.slave = slave;
+        self.parent = parent;
+        self.child = child;
         self.update_url = update_url;
 
         // XXX The following selector makes sense only in part of the forms
         // used by vivi. In particular, it doesn't work for the subpage form
-        // of addcentral. When we implemented hiding the slave drop-down to
+        // of addcentral. When we implemented hiding the child drop-down to
         // fix #10664, the resulting difference in behaviour between
         // addcentral and, e.g., an article's edit form happened to be what
         // was requested, so we left it at that.
-        self.slave_field = jQuery(slave).closest('.field');
+        self.child_field = jQuery(child).closest('.field');
 
-        MochiKit.Signal.connect(master, 'onchange', self, self.update);
+        MochiKit.Signal.connect(parent, 'onchange', self, self.update);
         self.update();
     },
 
@@ -26,18 +26,18 @@ zeit.cms.MasterSlaveDropDown = gocept.Class.extend({
     update: function(event) {
         var self = this;
         var d = MochiKit.Async.doSimpleXMLHttpRequest(
-            self.update_url, {master_token: self.master.value});
+            self.update_url, {parent_token: self.parent.value});
         d.addCallback(function(result) {
             var data = MochiKit.Async.evalJSONRequest(result);
 
             if (data.length == 0) {
-                self.slave_field.hide();
+                self.child_field.hide();
             } else {
-                self.slave_field.show();
+                self.child_field.show();
             }
 
-            var selected = self.slave.value;
-            self.slave.options.length = 1;
+            var selected = self.child.value;
+            self.child.options.length = 1;
             forEach(data, function(new_option) {
                 var label = new_option[0];
                 var value = new_option[1];
@@ -45,14 +45,14 @@ zeit.cms.MasterSlaveDropDown = gocept.Class.extend({
                 if (value == selected) {
                     option.selected = true;
                 }
-                self.slave.options[self.slave.options.length] = option;
+                self.child.options[self.child.options.length] = option;
             });
         });
     }
 });
 
 
-zeit.cms.MultiGenerationDropDown = zeit.cms.MasterSlaveDropDown.extend({
+zeit.cms.MultiGenerationDropDown = zeit.cms.ParentChildDropDown.extend({
 
     construct: function(parent, child, grandchild, update_url) {
         var self = this;
@@ -63,7 +63,7 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.MasterSlaveDropDown.extend({
 
         // XXX The following selector makes sense only in part of the forms
         // used by vivi. In particular, it doesn't work for the subpage form
-        // of addcentral. When we implemented hiding the slave drop-down to
+        // of addcentral. When we implemented hiding the child drop-down to
         // fix #10664, the resulting difference in behaviour between
         // addcentral and, e.g., an article's edit form happened to be what
         // was requested, so we left it at that.
@@ -77,7 +77,7 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.MasterSlaveDropDown.extend({
     update: function(event) {
         var self = this;
         var d = MochiKit.Async.doSimpleXMLHttpRequest(
-            self.update_url, {master_token: self.parent.value});
+            self.update_url, {parent_token: self.parent.value});
         d.addCallback(function(result) {
             var data = MochiKit.Async.evalJSONRequest(result);
 
@@ -104,26 +104,26 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.MasterSlaveDropDown.extend({
 });
 
 
-zeit.cms.master_slave_dropdown = {};
+zeit.cms.parent_child_dropdown = {};
 
-zeit.cms.configure_master_slave = function(prefix, master, slave, update_url) {
+zeit.cms.configure_parent_child = function(prefix, parent, child, update_url) {
     if (isUndefinedOrNull(prefix)) {
         prefix = 'form.';
     }
-    master = $(prefix + master);
-    slave = $(prefix + slave);
+    parent = $(prefix + parent);
+    child = $(prefix + child);
 
-    if (isNull(master) || isNull(slave)) {
+    if (isNull(parent) || isNull(child)) {
         return;
     }
-    if (!isUndefinedOrNull(zeit.cms.master_slave_dropdown[master.name])) {
-        zeit.cms.master_slave_dropdown[master.name].destroy();
+    if (!isUndefinedOrNull(zeit.cms.parent_child_dropdown[parent.name])) {
+        zeit.cms.parent_child_dropdown[parent.name].destroy();
     }
     var path = window.location.pathname.split('/').slice(0, -1);
     path.push(update_url);
     path = path.join('/');
-    zeit.cms.master_slave_dropdown[master.name] =
-        new zeit.cms.MasterSlaveDropDown(master, slave, path);
+    zeit.cms.parent_child_dropdown[parent.name] =
+        new zeit.cms.ParentChildDropDown(parent, child, path);
 };
 
 
@@ -138,37 +138,37 @@ zeit.cms.configure_multigeneration = function(prefix, parent, child, grandchild,
     if (isNull(parent) || isNull(child) || isNull(grandchild)) {
         return;
     }
-    if (!isUndefinedOrNull(zeit.cms.master_slave_dropdown[parent.name])) {
-        zeit.cms.master_slave_dropdown[parent.name].destroy();
+    if (!isUndefinedOrNull(zeit.cms.parent_child_dropdown[parent.name])) {
+        zeit.cms.parent_child_dropdown[parent.name].destroy();
     }
     var path = window.location.pathname.split('/').slice(0, -1);
     path.push(update_url);
     path = path.join('/');
-    zeit.cms.master_slave_dropdown[parent.name] =
+    zeit.cms.parent_child_dropdown[parent.name] =
         new zeit.cms.MultiGenerationDropDown(parent, child, grandchild, path);
 };
 
 
 zeit.cms.configure_ressort_dropdown = function(prefix) {
-    zeit.cms.configure_master_slave(
+    zeit.cms.configure_parent_child(
         prefix, 'ressort', 'sub_ressort', '@@subnavigationupdater.json');
 };
 
 
 zeit.cms.configure_channel_dropdowns = function(
-        prefix, field, master_index, slave_index) {
+        prefix, field, parent_index, child_index) {
     // XXX Rather ugly API to support usage in both z.c.article and z.c.cp.
     if (isUndefinedOrNull(prefix)) {
         prefix = 'form.';
     }
-    var masters = jQuery(
-        '[id^="' + prefix + field + '"][id$="combination_' + master_index + '"]'
+    var parents = jQuery(
+        '[id^="' + prefix + field + '"][id$="combination_' + parent_index + '"]'
         );
 
-    jQuery.each(masters, function(index, value) {
-        zeit.cms.configure_master_slave(
-            prefix, field + '.' + index + '..combination_' + master_index,
-            field + '.' + index + '..combination_' + slave_index,
+    jQuery.each(parents, function(index, value) {
+        zeit.cms.configure_parent_child(
+            prefix, field + '.' + index + '..combination_' + parent_index,
+            field + '.' + index + '..combination_' + child_index,
             '@@channelupdater.json');
     });
 };

--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -162,11 +162,11 @@ zeit.cms.configure_channel_dropdowns = function(
 
 /**
  * The item currently in display belongs to the <select>, not the <option>,
- * but since CSS doesn't have neither a child selector nor a
+ * but since CSS doesn't have neither a parent selector nor a
  * 'attribute != value' comparison, we need to use JS for this.
  */
 zeit.cms.style_dropdowns = function(container) {
-    jQuery('.required option[value = ""]', container).child().css(
+    jQuery('.required option[value = ""]', container).parent().css(
         'color', 'red');
     jQuery('.required option[value = ""]', container).css('color', 'red');
     jQuery('.required option[value != ""]', container).css('color', 'black');

--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -29,26 +29,31 @@ zeit.cms.ParentChildDropDown = gocept.Class.extend({
             self.update_url, {parent_token: self.parent.value});
         d.addCallback(function(result) {
             var data = MochiKit.Async.evalJSONRequest(result);
+            self._update(data);
+        });
+    },
 
-            if (data.length == 0) {
-                self.child_field.hide();
-            } else {
-                self.child_field.show();
+    _update: function(data) {
+        var self = this;
+        if (data.length == 0) {
+            self.child_field.hide();
+        } else {
+            self.child_field.show();
+        }
+
+        var selected = self.child.value;
+        self.child.options.length = 1;
+        forEach(data, function(new_option) {
+            var label = new_option[0];
+            var value = new_option[1];
+            var option = new Option(label, value);
+            if (value == selected) {
+                option.selected = true;
             }
-
-            var selected = self.child.value;
-            self.child.options.length = 1;
-            forEach(data, function(new_option) {
-                var label = new_option[0];
-                var value = new_option[1];
-                var option = new Option(label, value);
-                if (value == selected) {
-                    option.selected = true;
-                }
-                self.child.options[self.child.options.length] = option;
-            });
+            self.child.options[self.child.options.length] = option;
         });
     }
+
 });
 
 
@@ -56,50 +61,14 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.ParentChildDropDown.extend({
 
     construct: function(parent, child, grandchild, update_url) {
         var self = this;
-        self.parent = parent;
-        self.child = child;
-        self.grandchild = grandchild;
-        self.update_url = update_url;
-
-        // XXX The following selector makes sense only in part of the forms
-        // used by vivi. In particular, it doesn't work for the subpage form
-        // of addcentral. When we implemented hiding the child drop-down to
-        // fix #10664, the resulting difference in behaviour between
-        // addcentral and, e.g., an article's edit form happened to be what
-        // was requested, so we left it at that.
-        self.child_field = jQuery(child).closest('.field');
         self.grandchild_field = jQuery(grandchild).closest('.field');
-
-        MochiKit.Signal.connect(parent, 'onchange', self, self.update);
-        self.update();
+        arguments.callee.$.construct.call(self, parent, child, update_url);
     },
 
-    update: function(event) {
+    _update: function(data) {
         var self = this;
-        var d = MochiKit.Async.doSimpleXMLHttpRequest(
-            self.update_url, {parent_token: self.parent.value});
-        d.addCallback(function(result) {
-            var data = MochiKit.Async.evalJSONRequest(result);
-
-            if (data.length == 0) {
-                self.child_field.hide();
-                self.grandchild_field.hide();
-            } else {
-                self.child_field.show();
-            }
-
-            var selected = self.child.value;
-            self.child.options.length = 1;
-            forEach(data, function(new_option) {
-                var label = new_option[0];
-                var value = new_option[1];
-                var option = new Option(label, value);
-                if (value == selected) {
-                    option.selected = true;
-                }
-                self.child.options[self.child.options.length] = option;
-            });
-        });
+        self.grandchild_field.hide();
+        arguments.callee.$._update.call(self, data);
     }
 });
 

--- a/core/src/zeit/cms/content/browser/resources/dropdown.js
+++ b/core/src/zeit/cms/content/browser/resources/dropdown.js
@@ -56,22 +56,9 @@ zeit.cms.MultiGenerationDropDown = zeit.cms.ParentChildDropDown.extend({
 
     construct: function(parent, child, grandchild, update_url) {
         var self = this;
-        self.parent = parent;
-        self.child = child;
         self.grandchild = grandchild;
-        self.update_url = update_url;
-
-        // XXX The following selector makes sense only in part of the forms
-        // used by vivi. In particular, it doesn't work for the subpage form
-        // of addcentral. When we implemented hiding the child drop-down to
-        // fix #10664, the resulting difference in behaviour between
-        // addcentral and, e.g., an article's edit form happened to be what
-        // was requested, so we left it at that.
-        self.child_field = jQuery(child).closest('.field');
         self.grandchild_field = jQuery(grandchild).closest('.field');
-
-        MochiKit.Signal.connect(parent, 'onchange', self, self.update);
-        self.update();
+        arguments.callee.$.construct.call(self);
     },
 
     update: function(event) {

--- a/core/src/zeit/cms/content/browser/widget-subnav.txt
+++ b/core/src/zeit/cms/content/browser/widget-subnav.txt
@@ -16,10 +16,10 @@ Get the json view:
 ...     (getRootFolder(), request), name='subnavigationupdater.json')
 
 
->>> u'Deutschland' in updater.master_source
+>>> u'Deutschland' in updater.parent_source
 True
->>> dt_term = updater.master_terms.getTerm(u'Deutschland')
->>> updater(master_token=dt_term.token)
+>>> dt_term = updater.parent_terms.getTerm(u'Deutschland')
+>>> updater(parent_token=dt_term.token)
 '[["Datenschutz", "3da775df8d065507c482a20bf7a93427"],
   ["Integration", "1115b855bb2a508bc2ca0609cc2d0f65"],
   ["Joschka Fisher", "d3eaed24e3bebd3c218443bd44778823"],
@@ -34,5 +34,5 @@ Make sure those results are cached:
 
 For values which are not in the source we'll get an empty list:
 
->>> updater(master_token='foo')
+>>> updater(parent_token='foo')
 '[]'

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -264,7 +264,7 @@ class RessortSource(XMLSource):
         return six.text_type(node['title'])
 
 
-class MasterSlaveSource(XMLSource):
+class ParentChildSource(XMLSource):
 
     slave_tag = NotImplemented
     master_node_xpath = NotImplemented
@@ -336,7 +336,7 @@ class MasterSlaveSource(XMLSource):
         return getattr(data, self.master_value_key)
 
 
-class SubRessortSource(MasterSlaveSource):
+class SubRessortSource(ParentChildSource):
 
     config_url = RessortSource.config_url
     default_filename = RessortSource.default_filename
@@ -366,7 +366,7 @@ class ChannelSource(XMLSource):
         return six.text_type(node['title'])
 
 
-class SubChannelSource(MasterSlaveSource):
+class SubChannelSource(ParentChildSource):
 
     config_url = ChannelSource.config_url
     default_filename = ChannelSource.default_filename
@@ -383,13 +383,13 @@ class SubChannelSource(MasterSlaveSource):
 
     def _get_master_nodes(self, context):
         if type(context).__name__ == 'Fake':
-            # for .browser.MasterSlaveDropdownUpdater
+            # for .browser.ParentChildDropdownUpdater
             return super(SubChannelSource, self)._get_master_nodes(context)
         # The ``channels`` field is a list of combination values.
         # The formlib validation machinery does not give us enough context
         # to determine the master value, so we are forced to allow all values.
         # We can get away with this since the UI only offers valid subchannel
-        # values (powered by MasterSlaveDropdownUpdater above).
+        # values (powered by ParentChildDropdownUpdater above).
         tree = self._get_tree()
         all_nodes = tree.xpath(self.master_node_xpath)
         return all_nodes

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -266,74 +266,74 @@ class RessortSource(XMLSource):
 
 class ParentChildSource(XMLSource):
 
-    slave_tag = NotImplemented
-    master_node_xpath = NotImplemented
-    master_value_iface = NotImplemented
-    master_value_key = NotImplemented
+    child_tag = NotImplemented
+    parent_node_xpath = NotImplemented
+    parent_value_iface = NotImplemented
+    parent_value_key = NotImplemented
 
     def getValues(self, context):
         __traceback_info__ = (context,)
-        master_nodes = self._get_master_nodes(context)
-        slave_nodes = reduce(
+        parent_nodes = self._get_parent_nodes(context)
+        child_nodes = reduce(
             operator.add, [
-                node.findall(self.slave_tag) for node in master_nodes])
+                node.findall(self.child_tag) for node in parent_nodes])
         result = set([six.text_type(node.get(self.attribute))
-                      for node in slave_nodes
+                      for node in child_nodes
                       if self.isAvailable(node, context)])
         return result
 
     def getTitle(self, context, value):
         tree = self._get_tree()
-        master_value = self._get_master_value(context)
-        if master_value is None:
+        parent_value = self._get_parent_value(context)
+        if parent_value is None:
             nodes = tree.xpath(
-                '//{slave_tag}[@{attribute} = {value}]'.format(
-                    slave_tag=self.slave_tag,
+                '//{child_tag}[@{attribute} = {value}]'.format(
+                    child_tag=self.child_tag,
                     attribute=self.attribute,
                     value=xml.sax.saxutils.quoteattr(value)))
         else:
             nodes = tree.xpath(
-                '{master_node_xpath}[@{attribute} = {master}]'
-                '/{slave_tag}[@{attribute} = {value}]'.format(
-                    master_node_xpath=self.master_node_xpath,
+                '{parent_node_xpath}[@{attribute} = {master}]'
+                '/{child_tag}[@{attribute} = {value}]'.format(
+                    parent_node_xpath=self.parent_node_xpath,
                     attribute=self.attribute,
-                    slave_tag=self.slave_tag,
-                    master=xml.sax.saxutils.quoteattr(master_value),
+                    child_tag=self.child_tag,
+                    master=xml.sax.saxutils.quoteattr(parent_value),
                     value=xml.sax.saxutils.quoteattr(value)))
         if nodes:
             return six.text_type(self._get_title_for(nodes[0]))
         return value
 
-    def _get_master_nodes(self, context):
+    def _get_parent_nodes(self, context):
         tree = self._get_tree()
-        all_nodes = tree.xpath(self.master_node_xpath)
-        master_value = self._get_master_value(context)
-        if not master_value:
+        all_nodes = tree.xpath(self.parent_node_xpath)
+        parent_value = self._get_parent_value(context)
+        if not parent_value:
             return all_nodes
 
         nodes = tree.xpath(
-            '{master_node_xpath}[@{attribute} = "{value}"]'.format(
-                master_node_xpath=self.master_node_xpath,
+            '{parent_node_xpath}[@{attribute} = "{value}"]'.format(
+                parent_node_xpath=self.parent_node_xpath,
                 attribute=self.attribute,
                 # XXX not sure why we do manual quoting instead of quoteattr
                 # here, doesn't feel as it was thought through. There's a
                 # random doctest example about 'Bildung & Beruf' however that
                 # breaks if I change it.
-                value=master_value))
+                value=parent_value))
         if not nodes:
             return None
         # assert len(nodes) == 1
         return nodes
 
-    def _get_master_value(self, context):
+    def _get_parent_value(self, context):
         if isinstance(context, six.text_type):
             return context
         if zeit.cms.interfaces.ICMSContent.providedBy(context):
             return None
-        data = self.master_value_iface(context, None)
+        data = self.parent_value_iface(context, None)
         if data is None:
             return None
-        return getattr(data, self.master_value_key)
+        return getattr(data, self.parent_value_key)
 
 
 class SubRessortSource(ParentChildSource):
@@ -341,12 +341,12 @@ class SubRessortSource(ParentChildSource):
     config_url = RessortSource.config_url
     default_filename = RessortSource.default_filename
     attribute = RessortSource.attribute
-    slave_tag = 'subnavigation'
-    master_node_xpath = '/ressorts/ressort'
-    master_value_key = 'ressort'
+    child_tag = 'subnavigation'
+    parent_node_xpath = '/ressorts/ressort'
+    parent_value_key = 'ressort'
 
     @property
-    def master_value_iface(self):
+    def parent_value_iface(self):
         # prevent circular import
         import zeit.cms.content.interfaces
         return zeit.cms.content.interfaces.ICommonMetadata
@@ -371,27 +371,27 @@ class SubChannelSource(ParentChildSource):
     config_url = ChannelSource.config_url
     default_filename = ChannelSource.default_filename
     attribute = ChannelSource.attribute
-    slave_tag = 'subnavigation'
-    master_node_xpath = '/ressorts/ressort'
-    master_value_key = 'ressort'
+    child_tag = 'subnavigation'
+    parent_node_xpath = '/ressorts/ressort'
+    parent_value_key = 'ressort'
 
     @property
-    def master_value_iface(self):
+    def parent_value_iface(self):
         # prevent circular import
         import zeit.cms.content.interfaces
         return zeit.cms.content.interfaces.ICommonMetadata
 
-    def _get_master_nodes(self, context):
+    def _get_parent_nodes(self, context):
         if type(context).__name__ == 'Fake':
             # for .browser.ParentChildDropdownUpdater
-            return super(SubChannelSource, self)._get_master_nodes(context)
+            return super(SubChannelSource, self)._get_parent_nodes(context)
         # The ``channels`` field is a list of combination values.
         # The formlib validation machinery does not give us enough context
         # to determine the master value, so we are forced to allow all values.
         # We can get away with this since the UI only offers valid subchannel
         # values (powered by ParentChildDropdownUpdater above).
         tree = self._get_tree()
-        all_nodes = tree.xpath(self.master_node_xpath)
+        all_nodes = tree.xpath(self.parent_node_xpath)
         return all_nodes
 
     def _get_title_for(self, node):

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -322,7 +322,7 @@ class MasterSlaveSource(XMLSource):
                 value=master_value))
         if not nodes:
             return None
-        assert len(nodes) == 1
+        # assert len(nodes) == 1
         return nodes
 
     def _get_master_value(self, context):

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -61,8 +61,8 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
     zeit.cms.content.dav.mapProperties(
         zeit.content.article.interfaces.IArticle,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        ('has_recensions', 'artbox_thema', 'genre',
-         'template', 'header_layout', 'header_color', 'is_instant_article', 'is_amp',
+        ('has_recensions', 'artbox_thema', 'genre', 'template',
+         'header_layout', 'header_color', 'is_instant_article', 'is_amp',
          'hide_ligatus_recommendations', 'prevent_ligatus_indexing',
          'recent_comments_first'))
 

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -62,7 +62,7 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
         zeit.content.article.interfaces.IArticle,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
         ('has_recensions', 'artbox_thema', 'genre',
-         'template', 'header_layout', 'is_instant_article', 'is_amp',
+         'template', 'header_layout', 'header_color', 'is_instant_article', 'is_amp',
          'hide_ligatus_recommendations', 'prevent_ligatus_indexing',
          'recent_comments_first'))
 

--- a/core/src/zeit/content/article/edit/browser/form.zcml
+++ b/core/src/zeit/content/article/edit/browser/form.zcml
@@ -1018,6 +1018,14 @@
     permission="zope.View"
     />
 
+  <browser:page
+    for="*"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="zeit.content.article.update_articleheader.json"
+    class=".template.HeaderUpdater"
+    permission="zope.View"
+    />
+
   <class class=".push.AuthorPush">
     <require
       interface=".push.IAuthorPush"

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -3,7 +3,6 @@ from zeit.content.article.edit.browser.form import FormFields
 import zeit.cms.content.browser.widget
 import zeit.content.article.source
 import zeit.edit.browser.form
-import zope.interface
 
 
 class EditTemplate(zeit.edit.browser.form.InlineForm):
@@ -46,26 +45,3 @@ class HeaderUpdater(
 
     master_source = zeit.content.article.source.ArticleTemplateSource()
     slave_source = zeit.content.article.source.ArticleHeaderColorSource()
-
-    def get_result(self, master_token):
-        try:
-            master_value = self.master_terms.getValue(master_token)
-        except KeyError:
-            return []
-
-        @zope.interface.implementer(
-            self.slave_source.factory.master_value_iface)
-        class Fake(object):
-            pass
-        fake = Fake()
-        setattr(fake, self.slave_source.factory.master_value_key, master_value)
-
-        source = self.slave_source(fake)
-        terms = zope.component.getMultiAdapter(
-            (source, self.request), zope.app.form.browser.interfaces.ITerms)
-        result = []
-        for value in source:
-            term = terms.getTerm(value)
-            result.append((term.title, term.token))
-
-        return sorted(result)

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -22,7 +22,7 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
     zeit.cms.configure_multigeneration(
         "%s.", "template", "header_layout", "header_color",
         "@@zeit.content.article.update_articletemplate.json");
-    zeit.cms.configure_master_slave(
+    zeit.cms.configure_parent_child(
         "%s.", "header_layout", "header_color",
         "@@zeit.content.article.update_articleheader.json");
 </script>""" % (self.prefix, self.prefix)

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -34,14 +34,14 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
 
 
 class TemplateUpdater(
-        zeit.cms.content.browser.widget.MasterSlaveDropdownUpdater):
+        zeit.cms.content.browser.widget.ParentChildDropdownUpdater):
 
     master_source = zeit.content.article.source.ArticleTemplateSource()
     slave_source = zeit.content.article.source.ArticleHeaderSource()
 
 
 class HeaderUpdater(
-        zeit.cms.content.browser.widget.MasterSlaveDropdownUpdater):
+        zeit.cms.content.browser.widget.ParentChildDropdownUpdater):
 
     master_source = zeit.content.article.source.ArticleHeaderSource()
     slave_source = zeit.content.article.source.ArticleHeaderColorSource()

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -23,7 +23,7 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
         "%s.", "template", "header_layout",
         "@@zeit.content.article.update_articletemplate.json");
     zeit.cms.configure_master_slave(
-        "%s.", "template", "header_color",
+        "%s.", "header_layout", "header_color",
         "@@zeit.content.article.update_articleheader.json");
 </script>""" % (self.prefix, self.prefix)
         return result
@@ -43,5 +43,5 @@ class TemplateUpdater(
 class HeaderUpdater(
         zeit.cms.content.browser.widget.MasterSlaveDropdownUpdater):
 
-    master_source = zeit.content.article.source.ArticleTemplateSource()
+    master_source = zeit.content.article.source.ArticleHeaderSource()
     slave_source = zeit.content.article.source.ArticleHeaderColorSource()

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -12,7 +12,7 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
     undo_description = _('edit options')
     form_fields = FormFields(
         zeit.content.article.interfaces.IArticle).select(
-        'template', 'header_layout')
+        'template', 'header_layout', 'header_color')
 
     def render(self):
         result = super(EditTemplate, self).render()

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -19,9 +19,9 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
         if result:
             result += """\
 <script type="text/javascript">
-    zeit.cms.configure_multigeneration(
-        "%s.", "template", "header_layout", "header_color",
-        "@@zeit.content.article.update_articletemplate.json");
+    zeit.cms.configure_parent_child(
+        "%s.", "template", "header_layout",
+        "@@zeit.content.article.update_articletemplate.json", "header_color");
     zeit.cms.configure_parent_child(
         "%s.", "header_layout", "header_color",
         "@@zeit.content.article.update_articleheader.json");

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -19,8 +19,8 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
         if result:
             result += """\
 <script type="text/javascript">
-    zeit.cms.configure_master_slave(
-        "%s.", "template", "header_layout",
+    zeit.cms.configure_multigeneration(
+        "%s.", "template", "header_layout", "header_color",
         "@@zeit.content.article.update_articletemplate.json");
     zeit.cms.configure_master_slave(
         "%s.", "header_layout", "header_color",

--- a/core/src/zeit/content/article/edit/browser/template.py
+++ b/core/src/zeit/content/article/edit/browser/template.py
@@ -36,12 +36,12 @@ class EditTemplate(zeit.edit.browser.form.InlineForm):
 class TemplateUpdater(
         zeit.cms.content.browser.widget.ParentChildDropdownUpdater):
 
-    master_source = zeit.content.article.source.ArticleTemplateSource()
-    slave_source = zeit.content.article.source.ArticleHeaderSource()
+    parent_source = zeit.content.article.source.ArticleTemplateSource()
+    child_source = zeit.content.article.source.ArticleHeaderSource()
 
 
 class HeaderUpdater(
         zeit.cms.content.browser.widget.ParentChildDropdownUpdater):
 
-    master_source = zeit.content.article.source.ArticleHeaderSource()
-    slave_source = zeit.content.article.source.ArticleHeaderColorSource()
+    parent_source = zeit.content.article.source.ArticleHeaderSource()
+    child_source = zeit.content.article.source.ArticleHeaderColorSource()

--- a/core/src/zeit/content/article/edit/tests/templates.xml
+++ b/core/src/zeit/content/article/edit/tests/templates.xml
@@ -41,4 +41,37 @@
       <title>Ich habe einen Traum</title>
     </header>
   </template>
+  <template name="visual-article">
+    <title>Visual Article</title>
+    <header name="embed" allow_header_module="true">
+      <title>Header-Modul oben</title>
+    </header>
+    <header name="fullwidth-classic">
+      <title>Vollbreit, classic</title>
+    </header>
+    <header name="fullwidth-split">
+      <title>Vollbreit, split (also, geteilt, ja?)</title>
+      <color name="#eeeefa">
+        <title>Steingrau frisch</title>
+      </color>
+      <color name="#ccccca">
+        <title>Mausgrau</title>
+      </color>
+      <color name="#085066">
+        <title>Kornblau</title>
+      </color>
+    </header>
+    <header name="fullwidth-alternative">
+      <title>Vollbreit, alternative</title>
+      <color name="#eeeef0">
+        <title>Silbergrau 1</title>
+      </color>
+      <color name="#cccccf">
+        <title>Silbergrau 2</title>
+      </color>
+      <color name="#085064">
+        <title>Ozeanblau 4</title>
+      </color>
+    </header>
+  </template>
 </templates>

--- a/core/src/zeit/content/article/interfaces.py
+++ b/core/src/zeit/content/article/interfaces.py
@@ -75,6 +75,11 @@ class IArticleMetadata(zeit.cms.content.interfaces.ICommonMetadata):
         source=zeit.content.article.source.ArticleHeaderSource(),
         required=False)
 
+    header_color = zope.schema.Choice(
+        title=_("Header color"),
+        source=zeit.content.article.source.ArticleHeaderColorSource(),
+        required=False)
+
     is_instant_article = zope.schema.Bool(
         title=_('Is instant article'),
         default=False,

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -129,12 +129,12 @@ class ArticleHeaderSource(zeit.cms.content.sources.ParentChildSource):
     config_url = ArticleTemplateSource.config_url
     default_filename = ArticleTemplateSource.default_filename
     attribute = 'name'
-    slave_tag = 'header'
-    master_node_xpath = '/templates/template'
-    master_value_key = 'template'
+    child_tag = 'header'
+    parent_node_xpath = '/templates/template'
+    parent_value_key = 'template'
 
     @property
-    def master_value_iface(self):
+    def parent_value_iface(self):
         # prevent circular import
         import zeit.content.article.interfaces
         return zeit.content.article.interfaces.IArticleMetadata
@@ -145,9 +145,9 @@ class ArticleHeaderSource(zeit.cms.content.sources.ParentChildSource):
 
 class ArticleHeaderColorSource(ArticleHeaderSource):
 
-    slave_tag = 'color'
-    master_node_xpath = '/templates/template/header'
-    master_value_key = 'header'
+    child_tag = 'color'
+    parent_node_xpath = '/templates/template/header'
+    parent_value_key = 'header'
 
 
 class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -123,7 +123,7 @@ class ArticleTemplateSource(zeit.cms.content.sources.XMLSource):
 ARTICLE_TEMPLATE_SOURCE = ArticleTemplateSource()
 
 
-class ArticleHeaderSource(zeit.cms.content.sources.MasterSlaveSource):
+class ArticleHeaderSource(zeit.cms.content.sources.ParentChildSource):
 
     product_configuration = ArticleTemplateSource.product_configuration
     config_url = ArticleTemplateSource.config_url

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -143,24 +143,12 @@ class ArticleHeaderSource(zeit.cms.content.sources.MasterSlaveSource):
         return six.text_type(node['title'])
 
 
-class ArticleHeaderColorSource(zeit.cms.content.sources.MasterSlaveSource):
+class ArticleHeaderColorSource(ArticleHeaderSource):
 
-    product_configuration = ArticleTemplateSource.product_configuration
-    config_url = ArticleTemplateSource.config_url
-    default_filename = ArticleTemplateSource.default_filename
     attribute = 'value'
     slave_tag = 'color'
     master_node_xpath = '/templates/template'
     master_value_key = 'template'
-
-    @property
-    def master_value_iface(self):
-        # prevent circular import
-        import zeit.content.article.interfaces
-        return zeit.content.article.interfaces.IArticleMetadata
-
-    def _get_title_for(self, node):
-        return six.text_type(node['title'])
 
 
 class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -143,6 +143,26 @@ class ArticleHeaderSource(zeit.cms.content.sources.MasterSlaveSource):
         return six.text_type(node['title'])
 
 
+class ArticleHeaderColorSource(zeit.cms.content.sources.MasterSlaveSource):
+
+    product_configuration = ArticleTemplateSource.product_configuration
+    config_url = ArticleTemplateSource.config_url
+    default_filename = ArticleTemplateSource.default_filename
+    attribute = 'name'
+    slave_tag = 'color'
+    master_node_xpath = '/templates/template'
+    master_value_key = 'template'
+
+    @property
+    def master_value_iface(self):
+        # prevent circular import
+        import zeit.content.article.interfaces
+        return zeit.content.article.interfaces.IArticleMetadata
+
+    def _get_title_for(self, node):
+        return six.text_type(node['title'])
+
+
 class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -148,7 +148,7 @@ class ArticleHeaderColorSource(zeit.cms.content.sources.MasterSlaveSource):
     product_configuration = ArticleTemplateSource.product_configuration
     config_url = ArticleTemplateSource.config_url
     default_filename = ArticleTemplateSource.default_filename
-    attribute = 'name'
+    attribute = 'value'
     slave_tag = 'color'
     master_node_xpath = '/templates/template'
     master_value_key = 'template'

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -145,10 +145,9 @@ class ArticleHeaderSource(zeit.cms.content.sources.MasterSlaveSource):
 
 class ArticleHeaderColorSource(ArticleHeaderSource):
 
-    attribute = 'value'
     slave_tag = 'color'
-    master_node_xpath = '/templates/template'
-    master_value_key = 'template'
+    master_node_xpath = '/templates/template/header'
+    master_value_key = 'header'
 
 
 class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):

--- a/core/src/zeit/content/article/tests/article-templates.xml
+++ b/core/src/zeit/content/article/tests/article-templates.xml
@@ -1,0 +1,50 @@
+<templates>
+  <template name="zon-article" available="zeit.cms.section.interfaces.IZONContent">
+    <title>Artikel</title>
+    <header name="default" default_for="zeit.cms.section.interfaces.IZONContent">
+      <title>Standard</title>
+    </header>
+    <header name="embed" allow_header_module="true">
+      <title>Header-Modul oben</title>
+    </header>
+    <header name="podcast" allow_header_module="true">
+      <title>Podcast</title>
+    </header>
+    <header name="narrow">
+      <title>Spiele</title>
+    </header>
+  </template>
+  <template name="visual-article">
+    <title>Visual Article</title>
+    <header name="embed" allow_header_module="true">
+      <title>Header-Modul oben</title>
+    </header>
+    <header name="fullwidth-classic">
+      <title>Vollbreit, classic</title>
+    </header>
+    <header name="fullwidth-split">
+      <title>Vollbreit, split (also, geteilt, ja?)</title>
+      <color name="#eeeefa">
+        <title>Steingrau frisch</title>
+      </color>
+      <color name="#ccccca">
+        <title>Mausgrau</title>
+      </color>
+      <color name="#085066">
+        <title>Kornblau</title>
+      </color>
+    </header>
+    <header name="fullwidth-alternative">
+      <title>Vollbreit, alternative</title>
+      <color name="#eeeef0">
+        <title>Silbergrau 1</title>
+      </color>
+      <color name="#cccccf">
+        <title>Silbergrau 2</title>
+      </color>
+      <color name="#085064">
+        <title>Ozeanblau 4</title>
+      </color>
+    </header>
+  </template>
+</templates>

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -189,7 +189,7 @@ class LayoutHeaderByArticleTemplate(
     def test_header_layout_should_allow_for_backgroundcolor(self):
         article = self.get_article()
         source = zeit.content.article.source.ArticleHeaderColorSource().factory
-        assert source.slave_tag == 'color'
+        assert source.child_tag == 'color'
         assert '#cccccf' in source.getValues(article)
 
 

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -186,6 +186,12 @@ class LayoutHeaderByArticleTemplate(
         source = zeit.content.article.source.ArticleTemplateSource().factory
         self.assertTrue(source.allow_header_module(article))
 
+    def test_header_layout_should_allow_for_backgroundcolor(self):
+        article = self.get_article()
+        source = zeit.content.article.source.ArticleHeaderColorSource().factory
+        assert source.slave_tag == 'color'
+        assert '#cccccf' in source.getValues(article)
+
 
 class DefaultTemplateByContentType(
         zeit.content.article.testing.FunctionalTestCase):

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -326,8 +326,8 @@ class QueryOperatorSource(SimpleDictSource):
 
 class QuerySubRessortSource(zeit.cms.content.sources.SubRessortSource):
 
-    def _get_master_value(self, context):
-        # `context` is the IArea, which is adaptable to `master_value_iface`
+    def _get_parent_value(self, context):
+        # `context` is the IArea, which is adaptable to `parent_value_iface`
         # ICommonMetadata, since it is adaptable to ICenterPage -- but of
         # course we don't want to restrict the query subressort according to
         # the CP's ressort. So we disable this validation here and rely on the


### PR DESCRIPTION
Abseits jeglicher rassistischen Sprachgewohnheiten implementiert dieser PR nun das gewuenschte dritte Dropdown mit Farbwerten fuer vollbreite Header visueller Artikel in Form einer verschachtelten Hierarchie von master/slave widgets.

TTW funktioniert es nun inswoweit, dass man die Werte in Abhaengigkeite der Header korrekt auswaehlen kann.

Was noch fehlt ist, dass das Farbendropdown auch wieder verschwindet, wenn man ein Template auswaehlt, das weder Header noch Farben unterstuetzt (bspw. "Kolumne").

Dieser PR ersetzt #131 