### PR TITLE
BUG-1283: Size of images in image gallery editor is max 500 px times 500 px

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.39.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-1283: Size of images in image gallery editor is max 500 px x 500 px
 
 
 4.39.1 (2020-08-06)

--- a/core/src/zeit/content/gallery/browser/form.py
+++ b/core/src/zeit/content/gallery/browser/form.py
@@ -10,6 +10,8 @@ import zeit.push.browser.form
 import zeit.wysiwyg.interfaces
 import zope.formlib.form
 
+import pdb
+
 base = zeit.cms.content.browser.form.CommonMetadataFormBase
 
 
@@ -71,6 +73,7 @@ class DisplayImageWidget(zope.app.form.browser.widget.DisplayWidget):
             content = self.context.default
         image = zope.component.getMultiAdapter(
             (content, self.request), name='view.html')
+        pdb.set_trace()
         return image.tag()
 
     def hasInput(self):

--- a/core/src/zeit/content/gallery/browser/form.py
+++ b/core/src/zeit/content/gallery/browser/form.py
@@ -10,7 +10,6 @@ import zeit.push.browser.form
 import zeit.wysiwyg.interfaces
 import zope.formlib.form
 
-
 base = zeit.cms.content.browser.form.CommonMetadataFormBase
 
 

--- a/core/src/zeit/content/gallery/browser/form.py
+++ b/core/src/zeit/content/gallery/browser/form.py
@@ -10,7 +10,6 @@ import zeit.push.browser.form
 import zeit.wysiwyg.interfaces
 import zope.formlib.form
 
-import pdb
 
 base = zeit.cms.content.browser.form.CommonMetadataFormBase
 
@@ -72,8 +71,7 @@ class DisplayImageWidget(zope.app.form.browser.widget.DisplayWidget):
         else:
             content = self.context.default
         image = zope.component.getMultiAdapter(
-            (content, self.request), name='view.html')
-        pdb.set_trace()
+            (content, self.request), name='preview')
         return image.tag()
 
     def hasInput(self):

--- a/core/src/zeit/newsletter/category.py
+++ b/core/src/zeit/newsletter/category.py
@@ -118,8 +118,8 @@ class NewsletterCategory(NewsletterCategoryBase,
         now = datetime.datetime.now(pytz.UTC)
         result = connector.search(
             [FIRST_RELEASED, DAILY_NEWSLETTER], (
-            FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
-            (DAILY_NEWSLETTER == 'yes')))  # noqa
+                FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
+                (DAILY_NEWSLETTER == 'yes')))  # noqa
         for item in result:
             unique_id = item[0]
             obj = zeit.cms.interfaces.ICMSContent(unique_id, None)

--- a/core/src/zeit/newsletter/category.py
+++ b/core/src/zeit/newsletter/category.py
@@ -116,10 +116,9 @@ class NewsletterCategory(NewsletterCategoryBase,
         connector = zope.component.getUtility(
             zeit.connector.interfaces.IConnector)
         now = datetime.datetime.now(pytz.UTC)
-        result = connector.search(
-            [FIRST_RELEASED, DAILY_NEWSLETTER], (
-                FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
-                (DAILY_NEWSLETTER == 'yes')))  # noqa
+        result = connector.search([FIRST_RELEASED, DAILY_NEWSLETTER], (
+            FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
+            (DAILY_NEWSLETTER == 'yes')))  # noqa
         for item in result:
             unique_id = item[0]
             obj = zeit.cms.interfaces.ICMSContent(unique_id, None)

--- a/core/src/zeit/newsletter/category.py
+++ b/core/src/zeit/newsletter/category.py
@@ -119,7 +119,7 @@ class NewsletterCategory(NewsletterCategoryBase,
         result = connector.search(
             [FIRST_RELEASED, DAILY_NEWSLETTER], (
             FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
-                (DAILY_NEWSLETTER == 'yes')))  # noqa
+            (DAILY_NEWSLETTER == 'yes')))  # noqa
         for item in result:
             unique_id = item[0]
             obj = zeit.cms.interfaces.ICMSContent(unique_id, None)

--- a/core/src/zeit/newsletter/category.py
+++ b/core/src/zeit/newsletter/category.py
@@ -118,7 +118,7 @@ class NewsletterCategory(NewsletterCategoryBase,
         now = datetime.datetime.now(pytz.UTC)
         result = connector.search([FIRST_RELEASED, DAILY_NEWSLETTER], (
             FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
-            (DAILY_NEWSLETTER == 'yes')))  # noqa
+            (DAILY_NEWSLETTER == 'yes')))
         for item in result:
             unique_id = item[0]
             obj = zeit.cms.interfaces.ICMSContent(unique_id, None)

--- a/core/src/zeit/newsletter/category.py
+++ b/core/src/zeit/newsletter/category.py
@@ -119,7 +119,7 @@ class NewsletterCategory(NewsletterCategoryBase,
         result = connector.search(
             [FIRST_RELEASED, DAILY_NEWSLETTER], (
             FIRST_RELEASED.between(timestamp.isoformat(), now.isoformat()) &
-            (DAILY_NEWSLETTER == 'yes')))  # noqa
+                (DAILY_NEWSLETTER == 'yes')))  # noqa
         for item in result:
             unique_id = item[0]
             obj = zeit.cms.interfaces.ICMSContent(unique_id, None)


### PR DESCRIPTION
BUG-1283: images in vivi image gallery editor are displayed using preview instead of view.html. this reduces their size as requested. Plus unforeseen PEP8 corrections. 