### PR TITLE
ZON-6108 invalid linebreaks

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - BUG-1283: Size of images in image gallery editor is max 500 px x 500 px
 
+- ZON-6108: Remove legacy ``type`` attribute from content editor line breaks
+
 
 4.39.1 (2020-08-06)
 -------------------

--- a/core/src/zeit/content/article/edit/browser/resources/editor.js
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.js
@@ -549,7 +549,7 @@ zeit.content.article.Editable = gocept.Class.extend({
                 //  <p>asdf|</p> type 4xbackspace
                 //  <p>|<br></p> type `asdf`, then enter
                 //  <p>asdf</p><p><br></p> Note NO br in the first p!
-                par.append('<br type="moz"/>');
+                par.append('<br/>');
             }
         } else {
             return null;


### PR DESCRIPTION
We (still) need the ``<br>`` tag but it also works without the legacy
``type`` attribute. so instead of filtering it out during rendering, we
simply never add it in the first place now.