### PR TITLE
WOMA-204: Add aggregations to retresco.ElasticSearch query api

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - WOMA-181: Add notification for empty recipe title
 
+- WOMA-204: Add aggregations to retresco.ElasticSearch query api
+
 
 4.39.4 (2020-09-21)
 -------------------

--- a/core/src/zeit/retresco/search.py
+++ b/core/src/zeit/retresco/search.py
@@ -73,6 +73,14 @@ class Elasticsearch(object):
         result.hits = response['hits']['total']
         return result
 
+    def aggregate(self, query):
+        """Returns aggregated data from payload aggregations. Consult Elastic
+        Search - Aggregations documentation for further information."""
+
+        __traceback_info__ = (self.index, query)
+        response = self.client.search(index=self.index, body=json.dumps(query))
+        return response['aggregations']
+
     def date_range(self, start, end):
         return date_range(start, end)
 


### PR DESCRIPTION
Fügt der Retresco Elasticsearch Klasse eine aggregate Methode hinzu, die aus dem ES JSON Objekt nur `aggregations` zurückgibt. Damit kann für Wochenmarkt einfach geprüft werden, welche Zutaten in Verwendung sind.


![](https://media.giphy.com/media/l46CslpFdTSgelr1u/giphy-downsized.gif)
https://media.giphy.com/media/l46CslpFdTSgelr1u/giphy-downsized.gif