### PR TITLE
WOMA-181: Add notification for empty recipe title

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.39.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WOMA-181: Add notification for empty recipe title
 
 
 4.39.3 (2020-09-10)

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -2051,6 +2051,17 @@
   width: 3em !important;
 }
 
+#edit-form-article-content .type-recipelist .fieldname-title.notification:before {
+  border-radius: 3px;
+  border: 1px solid #269;
+  box-shadow: 1px 1px 2px #aaa;
+  color: #269;
+  content: 'Bitte trag einen Rezeptnamen im Rezept Modul ein, außer du hast mit diesem Rezept Modul nur eine Zwischenüberschrift definiert. (Nur so wird der Artikel später von Suchmaschinen als Rezept erkannt.)';
+  display: block;
+  margin-bottom: 0.5em;
+  padding: 0.8em;
+}
+
 /* Dirty hacks to prevent the whole line of widgets to wrap abominable on error */
 #edit-form-article-content .type-recipelist .fieldname-complexity div.error,
 #edit-form-article-content .type-recipelist .fieldname-time div.error,

--- a/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_recipelist.py
@@ -173,3 +173,25 @@ class FormLoader(
             s.getAttribute('css=.ingredients-widget input@value'))[0]
         assert ingredient_data.get('code') == 'brathaehnchen'
         assert ingredient_data.get('unit') == 'stueck'
+
+    def test_unset_recipe_title_should_print_hint(self):
+        s = self.selenium
+        self.add_article()
+        self.create_block('recipelist')
+
+        # Accessing pseudo elements in selenium is slightly annoying...
+        title_content = (
+            'window.getComputedStyle(document.querySelector('
+            '".type-recipelist .fieldname-title"), ":before"'
+            ').getPropertyValue("content")')
+
+        title_field = '.type-recipelist .fieldname-title input'
+
+        # Show notification if no title has been set
+        assert "Bitte trag einen Rezeptnamen" in s.getEval(title_content)
+
+        # After setting the title, the notification should disappear
+        s.type('css=' + title_field, 'bananabread')
+        s.runScript('document.querySelector("' + title_field + '").blur()')
+        s.waitForCssCount('css=.dirty', 0)
+        assert '"none"' == s.getEval(title_content)

--- a/core/src/zeit/wochenmarkt/browser/resources/recipe.js
+++ b/core/src/zeit/wochenmarkt/browser/resources/recipe.js
@@ -39,6 +39,7 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
         self._initialize_autocomplete();
         self._initialize_sortable();
         self.element.addEventListener("change", function() { self.update_entry(self.data) } );
+        self.validate_recipe_title();
     },
 
     _initialize_autocomplete: function() {
@@ -130,6 +131,16 @@ zeit.wochenmarkt.IngredientsWidget = gocept.Class.extend({
             }
         });
         data.value = JSON.stringify(ingredients);
+    },
+
+    validate_recipe_title: function() {
+        // It's just a simple notification that does not prevent the article
+        // form being edited, checked in or published.
+        const title_id = this.id.replace('.ingredients', '.title');
+        const title = document.getElementById(title_id);
+        if (title.value === "") {
+            title.closest('.fieldname-title').classList.add('notification');
+        }
     },
 
     delete: function(event) {


### PR DESCRIPTION
### Was erledigt dieser PR?
Wenn der Rezepttitel eines Rezeptlistenmoduls unausgefuellt ist, wird ein Hinweis ueber das Feld geschrieben. Dieser Hinweis ist nur optional zu beachten und hat keine Auswirkungen auf die Bearbeitung, das Einchecken oder Veroeffentlichen eines Artikels.

Der Hinweis erscheint in einem Marineblau um sich optisch zwar von einer Fehlermeldung abzuheben, Kontrast und Auszeichnung orientiern sich jedoch am gewohnten Vivi-Stil.

### Wie wird getestet?
Testvorbereitung:
1. Rezeptartikel anlegen
2. Rezeptlistenmodul in Artikeltext ziehen

Testdurchfuehrung:
1. Der Hinweis sollte per default erscheinen
2. Wenn ein Rezepttitel vergeben wird verschwindet der Hinweis
3. Wenn der Rezepttitel wieder geleert wird, erscheint der Hinweis erneut

### Giphy
![](https://media.giphy.com/media/3o6MbsveMB1VkCinra/giphy.gif)