### PR TITLE
ZON-6149: Allow to specify imagegroup variants via query parameters

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -7,6 +7,8 @@ vivi.core changes
 
 - BEM-62: Remove obsolete `IArticle.is_instant_article`
 
+- ZON-6149: Allow to specify imagegroup variants via query parameters
+
 
 4.42.0 (2020-10-08)
 -------------------

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -221,10 +221,27 @@ class VariantTraverser(object):
             'fill': self._parse_fill(url),
             'viewport': self._parse_viewport(url),
         }
+        # query parameters take precedence:
+        result.update(self.parse_params(url))
         # Make sure no invalid or redundant modifiers were provided
         if len([x for x in result.values() if x]) != len(url.split('__')):
             raise KeyError(url)
         result['url'] = url
+        return result
+
+    def parse_params(self, url):
+        result = dict()
+        params = six.moves.urllib.parse.parse_qs(
+            six.moves.urllib.parse.urlparse(url).query)
+
+        if 'width' in params and 'height' in params:
+            result['size'] = [int(params['width'][0]), int(params['height'][0])]
+        if 'scale' in params:
+            result['scale'] = float(params['scale'][0])
+        if 'fill' in params:
+            result['fill'] = params['fill'][0]
+        if 'viewport' in params:
+            result['viewport'] = params['viewport'][0]
         return result
 
     def _parse_variant(self, url):

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -235,7 +235,9 @@ class VariantTraverser(object):
             six.moves.urllib.parse.urlparse(url).query)
 
         if 'width' in params and 'height' in params:
-            result['size'] = [int(params['width'][0]), int(params['height'][0])]
+            result['size'] = [
+                int(params['width'][0]),
+                int(params['height'][0])]
         if 'scale' in params:
             result['scale'] = float(params['scale'][0])
         if 'fill' in params:

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -242,6 +242,35 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
         image.load()
         self.assertEqual('WEBP', image.format)
 
+    def test_parse_url_variant(self):
+        result = self.traverser.parse_url('cinema__300x160__scale_2.25__0000ff')
+        assert result['size'] == [300, 160]
+        assert result['scale'] == 2.25
+        assert result['fill'] == '0000ff'
+        assert result['viewport'] is None
+
+    def test_parse_url_variant_params_override(self):
+        result = self.traverser.parse_url('cinema__200x80__scale_2.25__0000ff?scale=3.0&width=300&height=160&fill=000000')
+        assert result['size'] == [300, 160]
+        assert result['scale'] == 3.0
+        assert result['fill'] == '000000'
+        assert result['viewport'] is None
+
+    def test_parse_size_from_params(self):
+        result = self.traverser.parse_params('cinema?scale=3.0&width=300&height=160')
+        assert result['size'] == [300, 160]
+
+    def test_parse_scale_from_params(self):
+        result = self.traverser.parse_params('cinema?scale=3.0&width=300&height=160')
+        assert result['scale'] == 3.0
+
+    def test_parse_fill_from_params(self):
+        result = self.traverser.parse_params('cinema?fill=0000ff&scale=3.0&width=300&height=160')
+        assert result['fill'] == '0000ff'
+
+    def test_parse_viewport_from_params(self):
+        result = self.traverser.parse_params('cinema?fill=0000ff&viewport=foo')
+        assert result['viewport'] == 'foo'
 
 class ExternalIDTest(zeit.content.image.testing.FunctionalTestCase):
 


### PR DESCRIPTION
Mit diesem PR koennen alle bisher unterstuetzten Parameter der Imagegroup Varianten wahlweise auch in Form von Querystringparametern uebergeben werden.

Die Queryparameter haben dabei immer Vorrang gegenuber den Parametern, die Teil des Pfades sind. 