### PR TITLE
ZON-5577: Update default for `force_mobile_image`

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.43.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5577: Set default for `force_mobile_images` to true 
 
 
 4.43.0 (2020-10-13)

--- a/core/src/zeit/content/cp/blocks/teaser.py
+++ b/core/src/zeit/content/cp/blocks/teaser.py
@@ -28,7 +28,7 @@ class TeaserBlock(
 
     force_mobile_image = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'force_mobile_image', zeit.content.cp.interfaces.ITeaserBlock[
-            'force_mobile_image'])
+            'force_mobile_image'], use_default=True)
 
     def __init__(self, context, xml):
         super(TeaserBlock, self).__init__(context, xml)

--- a/core/src/zeit/content/cp/blocks/tests/test_automatic.py
+++ b/core/src/zeit/content/cp/blocks/tests/test_automatic.py
@@ -51,3 +51,18 @@ class AutomaticTeaserBlockTest(zeit.content.cp.testing.FunctionalTestCase):
         self.elastic.search.return_value.hits = 1
         teaser = duo_region.values()[0]
         self.assertEqual('two-side-by-side', teaser.layout.id)
+
+    def test_automatic_teaser_block_should_not_force_mobile_image(self):
+        self.repository['t1'] = ExampleContentType()
+        cp = self.repository['cp']
+        region = cp['feature'].create_item('area')
+        region.kind = u'major'
+        region.count = 1
+        region.automatic = True
+        region.automatic_type = 'query'
+
+        self.elastic.search.return_value = zeit.cms.interfaces.Result(
+            [{'url': '/t1'}])
+        self.elastic.search.return_value.hits = 1
+        teaser = region.values()[0]
+        self.assertFalse(teaser.force_mobile_image)

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
@@ -212,6 +212,9 @@ class FunctionalTeaserDisplayTest(zeit.content.cp.testing.FunctionalTestCase):
             zeit.edit.interfaces.IElement)
         assert block.force_mobile_image
 
+    def test_teaser_forces_mobile_image_per_default(self):
+        assert self.create_teaserblock('large').force_mobile_image
+
     def test_teaser_with_non_quote_layout_shows_teaser_text(
             self):
         article = self.create_article_with_citation()

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -774,7 +774,11 @@ class ITeaserBlock(IReadTeaserBlock, IWriteTeaserBlock):
 
 
 class IReadAutomaticTeaserBlock(IReadTeaserBlock):
-    pass
+
+    force_mobile_image = zope.schema.Bool(
+        title=_('Force image on mobile'),
+        required=False,
+        default=False)
 
 
 class IWriteAutomaticTeaserBlock(IWriteTeaserBlock):

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -757,8 +757,7 @@ class IReadTeaserBlock(IBlock, zeit.cms.syndication.interfaces.IReadFeed):
 
     force_mobile_image = zope.schema.Bool(
         title=_('Force image on mobile'),
-        required=False,
-        default=False)
+        default=True)
 
 
 class IWriteTeaserBlock(zeit.cms.syndication.interfaces.IWriteFeed):


### PR DESCRIPTION
This PR should update the default `force_mobile_image` value for manually dragged teasers..

Ticket: [ZON-5577](https://zeit-online.atlassian.net/browse/ZON-5577)