### PR TITLE
ZON-6149: query parameters for image variants

### DIFF
--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -250,7 +250,8 @@ class VariantTraverser(object):
         if 'viewport' in params:
             result['viewport'] = params['viewport'][0]
         if 'variant' in params:
-            result['variant'] = self._parse_variant_by_name(params['variant'][0])
+            result['variant'] = self._parse_variant_by_name(
+                params['variant'][0])
         return result
 
     def _parse_variant(self, url):

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -9,6 +9,7 @@ import lxml.objectify
 import os.path
 import persistent
 import re
+import urllib
 import six.moves.urllib.parse
 import sys
 import z3c.traverser.interfaces
@@ -214,19 +215,21 @@ class VariantTraverser(object):
                 self.context, name, request)
 
     def parse_url(self, url):
+        path = urllib.parse.urlsplit(url).path
         result = {
-            'variant': self._parse_variant(url),
-            'size': self._parse_size(url),
-            'scale': self._parse_scale(url),
-            'fill': self._parse_fill(url),
-            'viewport': self._parse_viewport(url),
+            'variant': self._parse_variant(path),
+            'size': self._parse_size(path),
+            'scale': self._parse_scale(path),
+            'fill': self._parse_fill(path),
+            'viewport': self._parse_viewport(path),
         }
         # query parameters take precedence:
         result.update(self.parse_params(url))
-        # Make sure no invalid or redundant modifiers were provided
-        if len([x for x in result.values() if x]) != len(url.split('__')):
-            raise KeyError(url)
-        result['url'] = url
+        # Make sure no invalid or redundant modifiers were provided in path
+        if '__' in path:
+            if len([x for x in result.values() if x]) != len(path.split('__')):
+                raise KeyError(path)
+        result['url'] = path
         return result
 
     def parse_params(self, url):

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -229,6 +229,8 @@ class VariantTraverser(object):
         if '__' in path:
             if len([x for x in result.values() if x]) != len(path.split('__')):
                 raise KeyError(path)
+        if result['variant'] is None:
+            raise KeyError(url)
         result['url'] = path
         return result
 
@@ -247,6 +249,8 @@ class VariantTraverser(object):
             result['fill'] = params['fill'][0]
         if 'viewport' in params:
             result['viewport'] = params['viewport'][0]
+        if 'variant' in params:
+            result['variant'] = self._parse_variant_by_name(params['variant'][0])
         return result
 
     def _parse_variant(self, url):
@@ -258,8 +262,6 @@ class VariantTraverser(object):
         variant = self._parse_variant_by_name(url)
         if variant is not None:
             return variant
-
-        raise KeyError(url)
 
     def _parse_variant_by_name(self, url):
         """Select the biggest Variant among those with the given name.

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -249,6 +249,13 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
         assert result['fill'] == '0000ff'
         assert result['viewport'] is None
 
+    def test_parse_url_variant_params(self):
+        result = self.traverser.parse_url('cinema__200x80__scale_2.25__0000ff?scale=3.0&width=300&height=160&fill=000000')
+        assert result['size'] == [300, 160]
+        assert result['scale'] == 3.0
+        assert result['fill'] == '000000'
+        assert result['viewport'] is None
+
     def test_parse_url_variant_params_override(self):
         result = self.traverser.parse_url('cinema__200x80__scale_2.25__0000ff?scale=3.0&width=300&height=160&fill=000000')
         assert result['size'] == [300, 160]

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -244,6 +244,7 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
 
     def test_parse_url_variant(self):
         result = self.traverser.parse_url('cinema__300x160__scale_2.25__0000ff')
+        assert result['variant'].name == 'cinema'
         assert result['size'] == [300, 160]
         assert result['scale'] == 2.25
         assert result['fill'] == '0000ff'
@@ -251,6 +252,14 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
 
     def test_parse_url_variant_params(self):
         result = self.traverser.parse_url('cinema__200x80__scale_2.25__0000ff?scale=3.0&width=300&height=160&fill=000000')
+        assert result['size'] == [300, 160]
+        assert result['scale'] == 3.0
+        assert result['fill'] == '000000'
+        assert result['viewport'] is None
+
+    def test_parse_url_variant_params_only(self):
+        result = self.traverser.parse_url('?variant=cinema&scale=3.0&width=300&height=160&fill=000000')
+        assert result['variant'].name == 'cinema'
         assert result['size'] == [300, 160]
         assert result['scale'] == 3.0
         assert result['fill'] == '000000'


### PR DESCRIPTION
Dieser PR macht, dass man image variants auch via query parameter (`?variant=cinema`) anfordern kann