### PR TITLE
ZON-6196: Fix facebook post test for current api version

### DIFF
--- a/core/src/zeit/push/browser/facebook.py
+++ b/core/src/zeit/push/browser/facebook.py
@@ -35,11 +35,18 @@ class TokenForm(zeit.cms.browser.form.FormBase,
 
         # Step 1: Get user token. <https://developers.facebook.com
         # /docs/facebook-login/manually-build-a-login-flow#login>
+        scopes = ','.join([
+            'pages_read_engagement',
+            'pages_manage_posts',
+            'business_management',
+            'pages_manage_metadata',
+            'pages_show_list'
+        ])
         url = ('https://www.facebook.com/dialog/oauth?' +
                six.moves.urllib.parse.urlencode({
                    'client_id': data['app_id'],
                    'redirect_uri': data['redirect_uri'],
-                   'scope': 'manage_pages,publish_pages',
+                   'scope': scopes,
                }))
         self.request.response.redirect(url, trusted=True)
 

--- a/core/src/zeit/push/facebook.py
+++ b/core/src/zeit/push/facebook.py
@@ -98,11 +98,18 @@ def create_access_token(argv=None):
 
     # Step 1: Get user token. <https://developers.facebook.com
     # /docs/facebook-login/manually-build-a-login-flow#login>
+    scopes = ','.join([
+        'pages_read_engagement',
+        'pages_manage_posts',
+        'business_management',
+        'pages_manage_metadata',
+        'pages_show_list'
+    ])
     login_url = ('https://www.facebook.com/dialog/oauth?' +
                  six.moves.urllib.parse.urlencode({
                      'client_id': options.app_id,
                      'redirect_uri': options.redirect_uri,
-                     'scope': 'manage_pages,publish_pages',
+                     'scope': scopes,
                  }))
     print(u'Bitte bei Facebook anmelden und dann diese URL öffnen:\n%s' % (
         login_url))

--- a/core/src/zeit/push/tests/test_facebook.py
+++ b/core/src/zeit/push/tests/test_facebook.py
@@ -49,21 +49,12 @@ class FacebookTest(zeit.push.testing.TestCase):
             if self.nugget in status['message']:
                 post_id = status['id']
 
-                fields = ['message']
-                if self.current_api_version > 3.2:
-                    fields.append('attachments')
-                else:
-                    fields.append('links')
-
+                fields = ['message', 'attachments']
                 status = self.api.get_object(
                     cat='single', id=post_id, fields=fields)
 
-                if self.current_api_version > 3.2:
-                    self.assertIn('example.com', status[
-                        'attachments']['data'][0]['target']['url'])
-                else:
-                    self.assertStartsWith(
-                        'http://example.com/', status['link'])
+                self.assertIn('example.com', status[
+                    'attachments']['data'][0]['target']['url'])
 
                 self.assertIn(u'faceboök', status['message'])
                 break


### PR DESCRIPTION
Der Vivi-Test-Account hatte eine veraltete Version, sodass einige Berechtigungen nicht mehr aktuell waren.
Folgendes sollte auf staging getestet werden:
- neuen Facebook-Token für Vivi-Test anlegen
- testen ob das posten noch funktioniert