### PR TITLE
ZON-6140: Support additional attributes from newslettersignup config

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,7 +5,7 @@ vivi.core changes
 4.43.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6140: Support additional attributes from newslettersignup config
 
 
 4.43.2 (2020-10-22)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -87,11 +87,12 @@ class IJobTicker(zeit.edit.interfaces.IBlock):
 
 class Newsletter(zeit.cms.content.sources.AllowedBase):
 
-    def __init__(self, id, title, image, abo_text, anon_text):
+    def __init__(self, id, title, image, abo_text, anon_text, redirect_link):
         super(Newsletter, self).__init__(id, title, available=None)
         self.image = image
         self.abo_text = abo_text
         self.anon_text = anon_text
+        self.redirect_link = redirect_link
 
 
 @grok.implementer(zeit.content.image.interfaces.IImages)
@@ -124,6 +125,7 @@ class NewsletterSource(zeit.cms.content.sources.ObjectSource,
                 self.child(node, 'image'),
                 self.child(node, 'text'),
                 self.child(node, 'text_anonymous'),
+                self.child(node, 'redirect_link')
             )
             result[newsletter.id] = newsletter
         return result


### PR DESCRIPTION
Allows one more attribute from the config file to be read in zeit.web..