### PR TITLE
ZON-6213: Configure newsimport dogpile cache

### DIFF
--- a/core/src/zeit/cms/interfaces.py
+++ b/core/src/zeit/cms/interfaces.py
@@ -29,6 +29,7 @@ from zeit.connector.interfaces import (  # noqa
 
 CONFIG_CACHE = pyramid_dogpile_cache2.get_region('config')
 FEATURE_CACHE = pyramid_dogpile_cache2.get_region('feature')
+NEWSIMPORT_CACHE = pyramid_dogpile_cache2.get_region('newsimport')
 
 
 class ICMSContentType(zope.interface.interfaces.IInterface):

--- a/core/src/zeit/cms/testing.py
+++ b/core/src/zeit/cms/testing.py
@@ -510,9 +510,10 @@ cms_product_config = """\
   trisolute-ressort-url file://{base}/tagging/tests/fixtures/tris-ressorts.xml
   breadcrumbs-use-common-metadata true
 
-  cache-regions config, feature, dav
+  cache-regions config, feature, newsimport, dav
   cache-expiration-config 600
   cache-expiration-feature 15
+  cache-expiration-newsimport 900
   cache-expiration-dav 0
   feature-toggle-source file://{base}/content/feature-toggle.xml
 


### PR DESCRIPTION
Wird von https://github.com/ZeitOnline/zeit.newsimport/pull/25 benötigt.

Konfiguriert ein eigenes Dogpile Cache BE für den Newsimport.