### PR TITLE
OPS-1490: Allow volume to be set to 54

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.45.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- OPS-1490: Allow volume to be set to 54
 
 
 4.45.2 (2020-12-10)

--- a/core/src/zeit/cms/settings/interfaces.py
+++ b/core/src/zeit/cms/settings/interfaces.py
@@ -14,7 +14,7 @@ class IGlobalSettings(zope.interface.Interface):
     default_volume = zope.schema.Int(
         title=_("Default volume"),
         min=1,
-        max=53)
+        max=54)
 
     def get_working_directory(template):
         """Return the collection which is the main working directory.


### PR DESCRIPTION
Because in 2020 things are different.

Siehe [OPS-1490](https://zeit-online.atlassian.net/browse/OPS-1490).