### PR TITLE
ZON-6306: Fix replace StringIO by BytesIO to avoid TypeError

### DIFF
--- a/core/src/zeit/content/image/mdb.py
+++ b/core/src/zeit/content/image/mdb.py
@@ -1,4 +1,4 @@
-from six import StringIO
+from six import BytesIO
 import base64
 import lxml.etree
 import os.path
@@ -64,7 +64,7 @@ class MDB(object):
         body = XML_TAGS.sub('', response)
         body = base64.b64decode(body)
         # Cannot use cStringIO since we need to set additional attributes.
-        result = StringIO(body)
+        result = BytesIO(body)
         result.filename = FILE_NAME_ATTRIBUTE.search(response).group(1)
         result.mdb_id = mdb_id
         result.headers = {'content-type': 'image/%s' % os.path.splitext(


### PR DESCRIPTION
Das ist jetzt einfach auf gut Glück: Stackoverflow-Tipp _und_ Wolfgang sind sich einig ;) - allerdings, ohne es bisher debuggen zu können. Ich krieg den Test in zeit/content/image/browser/tests/test_mdb.py nicht ans Laufen. Aber mal schauen, ob's klappt hier alles grün wird. Notfalls kann man wohl auch auf Staging mergen, die Stelle ist ja eh kaputt.