### PR TITLE
BUG-1315: Fix Update-Token-Tool for Facebook

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.46.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-1315: Fix Update-Token-Tool for Facebook
 
 
 4.46.1 (2020-12-18)

--- a/core/src/zeit/push/browser/facebook.py
+++ b/core/src/zeit/push/browser/facebook.py
@@ -70,8 +70,7 @@ class GenerateToken(zeit.cms.browser.view.Base):
             }))
         if 'error' in r.text:
             raise ValueError(r.text)
-        result = six.moves.urllib.parse.parse_qs(r.text)
-        short_lived_user_token = result['access_token'][0]
+        short_lived_user_token = r.json()['access_token']
 
         # Step 2: Exchange for long-lived token.
         # <https://developers.facebook.com
@@ -86,8 +85,7 @@ class GenerateToken(zeit.cms.browser.view.Base):
             }))
         if 'error' in r.text:
             raise ValueError(r.text)
-        result = six.moves.urllib.parse.parse_qs(r.text)
-        long_lived_user_token = result['access_token'][0]
+        long_lived_user_token = r.json()['access_token']
 
         # Step 3. Retrieve page access token. <https://developers.facebook.com
         # /docs/facebook-login/access-tokens/#pagetokens>


### PR DESCRIPTION
Es kann der Facebook-Test-Account verwendet werden.
Logins stehen in _{{vivi_deployment}}/components/test/buildout.cfg_ (ZEIT_PUSH_FACEBOOK_....)
Anleitung zum Testen siehe Ticket: [https://zeit-online.atlassian.net/browse/BUG-1315]()