### PR TITLE
STO-59: Allow Vivi to talk to two TMS instances during migrations

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.47.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- STO-59: Allow Vivi to talk to two TMS instances
 
 
 4.47.0 (2021-01-06)

--- a/core/setup.py
+++ b/core/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4',
         'bugsnag',
         'collective.monkeypatcher',
-        'elasticsearch >=7.0.0, <8.0.0',
+        'elasticsearch >=2.0.0, <3.0.0',
         'fb',
         'filemagic',
         'gocept.cache >= 2.1',

--- a/core/setup.py
+++ b/core/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4',
         'bugsnag',
         'collective.monkeypatcher',
-        'elasticsearch >=2.0.0, <3.0.0',
+        'elasticsearch >=7.0.0, <8.0.0',
         'fb',
         'filemagic',
         'gocept.cache >= 2.1',

--- a/core/src/zeit/cms/tagging/browser/widget.py
+++ b/core/src/zeit/cms/tagging/browser/widget.py
@@ -86,7 +86,7 @@ class Widget(grok.MultiAdapter,
             # an abstraction instead doesn't really seem worthwile either.
             import zeit.retresco.interfaces
             tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
-            return six.moves.urllib.parse.urlparse(tms.url).netloc
+            return six.moves.urllib.parse.urlparse(tms.primary['url']).netloc
         except (ImportError, LookupError):
             return None
 

--- a/core/src/zeit/retresco/connection.py
+++ b/core/src/zeit/retresco/connection.py
@@ -26,9 +26,9 @@ log = logging.getLogger(__name__)
 class TMS(object):
 
     def __init__(self, primary, secondary=None):
-        self.primary = primary
-        self.secondary = secondary or {}
-        for conn in primary, secondary:
+        self.primary = dict(primary)
+        self.secondary = dict(secondary or {})
+        for conn in self.primary, self.secondary:
             url = conn.get('url') or ''
             if url.endswith('/'):
                 conn['url'] = url.rstrip('/')

--- a/core/src/zeit/retresco/testing.py
+++ b/core/src/zeit/retresco/testing.py
@@ -20,7 +20,8 @@ HTTP_LAYER = zeit.cms.testing.HTTPLayer(
 
 product_config = """
 <product-config zeit.retresco>
-    base-url http://localhost:{port}
+    primary-base-url http://localhost:{port}
+    secondary-base-url http://localhost:{port}/another-tms
     elasticsearch-url http://tms-backend.staging.zeit.de:80/elasticsearch
     elasticsearch-index zeit_pool
     elasticsearch-connection-class zeit.retresco.search.Connection
@@ -73,7 +74,7 @@ class TMSMockLayer(plone.testing.Layer):
         registry = zope.component.getGlobalSiteManager()
         self['old_tms'] = registry.queryUtility(zeit.retresco.interfaces.ITMS)
         self['tms_mock'] = mock.Mock()
-        self['tms_mock'].url = 'http://tms.example.com'
+        self['tms_mock'].primary = dict(url='http://tms.example.com')
         self['tms_mock'].get_article_keywords.return_value = []
         registry.registerUtility(
             self['tms_mock'], zeit.retresco.interfaces.ITMS)

--- a/core/src/zeit/retresco/tests/test_connection.py
+++ b/core/src/zeit/retresco/tests/test_connection.py
@@ -9,6 +9,7 @@ import pytest
 import requests.adapters
 import requests.exceptions
 import time
+import urllib.parse
 import zeit.cms.tagging.interfaces
 import zeit.connector.interfaces
 import zeit.content.rawxml.rawxml
@@ -225,9 +226,16 @@ class TMSTest(zeit.retresco.testing.FunctionalTestCase):
         tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
         tms.get_article_keywords(self.repository['testcontent'])
         # First requests will be enrich and index
-        self.assertTrue(
-            '/in-text-linked-documents/' in
-            self.layer['request_handler'].requests[2].get('path'))
+        content = self.repository['testcontent']
+        uuid = zeit.cms.content.interfaces.IUUID(content).id
+        self.assertEqual(['{} {}'.format(r['verb'], urllib.parse.unquote(
+            r['path'])) for r in self.layer['request_handler'].requests], [
+            'POST /enrich?in-text-linked',
+            'POST /another-tms/enrich?in-text-linked',
+            'PUT /content/{}'.format(uuid),
+            'PUT /another-tms/content/{}'.format(uuid),
+            'GET /in-text-linked-documents/{}'.format(uuid),
+        ])
 
     def test_get_article_keywords_uses_preview_endpoint_if_param_set(self):
         tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)

--- a/core/src/zeit/retresco/tests/test_connection.py
+++ b/core/src/zeit/retresco/tests/test_connection.py
@@ -256,7 +256,7 @@ class IntegrationTest(zeit.retresco.testing.FunctionalTestCase):
     def setUp(self):
         super(IntegrationTest, self).setUp()
         self.tms = zeit.retresco.connection.TMS(
-            os.environ['ZEIT_RETRESCO_URL'])
+            primary=dict(url=os.environ['ZEIT_RETRESCO_URL']))
         self.article = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/online/2007/01/Somalia')
         with checked_out(self.article):


### PR DESCRIPTION
> We can now set up a 'primary' and a 'secondary' TMS. For GET requests only the primary is used, for POST, PUT & DELETE the requests are sent to both. This should make testing and migration between different versions and/or deployments easier.

Siehe [STO-59](https://zeit-online.atlassian.net/browse/STO-59).

JENKINS_BATOU_BRANCH=STO-59-multi-tms