### PR TITLE
MAINT: Fix DeprecationWarning

### DIFF
--- a/core/src/zeit/cms/content/liveproperty.py
+++ b/core/src/zeit/cms/content/liveproperty.py
@@ -1,7 +1,7 @@
 from zeit.cms.content.interfaces import WRITEABLE_ALWAYS, WRITEABLE_LIVE
 from zeit.cms.content.interfaces import WRITEABLE_ON_CHECKIN
 from zeit.connector.interfaces import DeleteProperty
-import collections
+import collections.abc
 import zeit.cms.checkout.interfaces
 import zeit.cms.repository.interfaces
 import zeit.connector.interfaces
@@ -13,7 +13,7 @@ import zope.security.interfaces
 @zope.component.adapter(zeit.cms.repository.interfaces.IRepositoryContent)
 @zope.interface.implementer(zeit.connector.interfaces.IWebDAVProperties)
 @zope.interface.provider(zeit.cms.content.interfaces.ILivePropertyManager)
-class LiveProperties(collections.MutableMapping):
+class LiveProperties(collections.abc.MutableMapping):
     """Webdav properties which are updated upon change."""
 
     live_properties = dict()

--- a/core/src/zeit/connector/cache.py
+++ b/core/src/zeit/connector/cache.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import BTrees
 import ZODB.POSException
 import ZODB.blob
-import collections
+import collections.abc
 import gocept.lxml.objectify
 import logging
 import lxml.objectify
@@ -495,7 +495,7 @@ class ChildNameCache(PersistentCache):
         return set(a) == set(b)
 
 
-class AlwaysEmptyDict(collections.MutableMapping):
+class AlwaysEmptyDict(collections.abc.MutableMapping):
     """Used by mock connector to disable filesystem transaction bound cache."""
 
     def __getitem__(self, key):

--- a/core/src/zeit/content/author/author.py
+++ b/core/src/zeit/content/author/author.py
@@ -2,7 +2,7 @@ from requests.exceptions import RequestException
 from zeit.cms.content.property import ObjectPathProperty
 from zeit.cms.i18n import MessageFactory as _
 from zeit.content.author.interfaces import IAuthor
-import collections
+import collections.abc
 import grokcore.component as grok
 import lxml.objectify
 import requests
@@ -270,7 +270,7 @@ def author_location(type_, adder):
 @grok.implementer(zeit.content.author.interfaces.IBiographyQuestions)
 class BiographyQuestions(
         grok.Adapter,
-        collections.MutableMapping,
+        collections.abc.MutableMapping,
         zeit.cms.content.xmlsupport.Persistent):
 
     grok.context(zeit.content.author.interfaces.IAuthor)

--- a/core/src/zeit/content/modules/rawtext.py
+++ b/core/src/zeit/content/modules/rawtext.py
@@ -1,7 +1,7 @@
 from zeit.cms.content.property import DAVConverterWrapper
 from zeit.cms.content.property import ObjectPathAttributeProperty
 from zope.cachedescriptors.property import Lazy as cachedproperty
-import collections
+import collections.abc
 import grokcore.component as grok
 import lxml.objectify
 import six
@@ -44,7 +44,7 @@ class RawText(zeit.edit.block.Element):
 @grok.implementer(zeit.content.modules.interfaces.IEmbedParameters)
 class EmbedParameters(
         grok.Adapter,
-        collections.MutableMapping,
+        collections.abc.MutableMapping,
         zeit.cms.content.xmlsupport.Persistent):
     # 99% copy&paste from z.c.author.author.BiographyQuestions, changed the tag
     # name to `param` from `question` and added type conversion.

--- a/core/src/zeit/edit/container.py
+++ b/core/src/zeit/edit/container.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import grokcore.component as grok
 import logging
 import lxml.etree
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 @zope.interface.implementer(zeit.edit.interfaces.IContainer)
 class Base(zeit.edit.block.Element,
            zope.container.contained.Contained,
-           collections.MutableMapping):
+           collections.abc.MutableMapping):
 
     def __init__(self, context, xml):
         self.xml = xml

--- a/core/src/zeit/newsletter/newsletter.py
+++ b/core/src/zeit/newsletter/newsletter.py
@@ -1,5 +1,5 @@
 from zeit.cms.i18n import MessageFactory as _
-import collections
+import collections.abc
 import gocept.lxml.interfaces
 import grokcore.component as grok
 import pkg_resources
@@ -19,7 +19,7 @@ BODY_NAME = 'newsletter_body'
 
 @zope.interface.implementer(zeit.newsletter.interfaces.INewsletter)
 class Newsletter(zeit.cms.content.xmlsupport.XMLContentBase,
-                 collections.Mapping):
+                 collections.abc.Mapping):
 
     default_template = pkg_resources.resource_string(
         __name__, 'template.xml').decode('utf-8')

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -1,5 +1,5 @@
 from zeit.cms.repository.interfaces import AfterObjectConstructedEvent
-import collections
+import collections.abc
 import grokcore.component as grok
 import lxml.objectify
 import os.path
@@ -161,7 +161,7 @@ class FakeDAVResource(zeit.connector.resource.Resource):
 
 
 @grok.implementer(zeit.retresco.interfaces.IElasticDAVProperties)
-class WebDAVProperties(grok.Adapter, collections.MutableMapping):
+class WebDAVProperties(grok.Adapter, collections.abc.MutableMapping):
 
     grok.context(zeit.retresco.interfaces.ITMSContent)
     grok.provides(zeit.connector.interfaces.IWebDAVProperties)


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working.