### PR TITLE
STO-59: Upgrade the `elasticsearch` Python client library to 7.x

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4',
         'bugsnag',
         'collective.monkeypatcher',
-        'elasticsearch >=2.0.0, <3.0.0',
+        'elasticsearch >=7.0.0, <8.0.0',
         'fb',
         'filemagic',
         'gocept.cache >= 2.1',


### PR DESCRIPTION
> This reverts cea6176a and brings back bf6cdf46, upgrading the `elasticsearch` client library to version 7.x again.

Siehe [STO-59](https://zeit-online.atlassian.net/browse/STO-59) / [STO-175](https://zeit-online.atlassian.net/browse/STO-175) & #171 & https://github.com/ZeitOnline/vivi-deployment/pull/160.

JENKINS_BATOU_BRANCH=STO-59-elasticsearch-7.x