### PR TITLE
ZON-6346: Add article module for tickaroo liveblog

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.48.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6346: Add article module for tickaroo liveblog
 
 
 4.48.7 (2021-02-01)

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -115,6 +115,25 @@ class XMLSource(
         return six.text_type(node.text).strip()
 
 
+class SearchableXMLSource(XMLSource):
+
+    def __init__(self, xpath):
+        super().__init__()
+        self.xpath = xpath
+
+    def getValues(self, context):
+        tree = self._get_tree()
+        if self.attribute is NotImplemented:
+            # Return text value of nodes
+            return [six.text_type(node)
+                    for node in tree.xpath(self.xpath)
+                    if self.isAvailable(node, context)]
+        # Return value of provided attribute for nodes
+        return [six.text_type(node.get(self.attribute))
+                for node in tree.xpath(self.xpath)
+                if self.isAvailable(node, context)]
+
+
 def parse_available_interface_list(text):
     result = []
     if text is None:

--- a/core/src/zeit/cms/content/tests/test_sources.py
+++ b/core/src/zeit/cms/content/tests/test_sources.py
@@ -34,6 +34,25 @@ class UnresolveableSource(zeit.cms.content.sources.XMLSource):
 """)
 
 
+class ExampleNestedSource(zeit.cms.content.sources.SearchableXMLSource):
+
+    attribute = NotImplemented
+
+    def _get_tree(self):
+        return gocept.lxml.objectify.fromstring("""\
+<items>
+  <cherries>
+    <cherry id="cherry_one">Cherry One</cherry>
+    <cherry id="cherry_two">Cherry Two</cherry>
+  </cherries>
+  <raisins>
+    <raisin id="raisin_one">Raisin One</raisin>
+    <raisin id="raisin_two">Raisin Two</raisin>
+  </raisins>
+</items>
+""")
+
+
 class XMLSourceTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_values_without_available_attribute_are_returned_for_all_contexts(
@@ -59,6 +78,22 @@ class XMLSourceTest(zeit.cms.testing.ZeitCmsTestCase):
         context = Mock()
         zope.interface.alsoProvides(context, zeit.cms.interfaces.IAsset)
         self.assertEqual(['one', 'two', 'three'], source.getValues(context))
+
+
+class SearchableXMLSourceTest(zeit.cms.testing.ZeitCmsTestCase):
+
+    def test_searchable_source_should_return_text_values_by_xpath(self):
+        cherry_source = ExampleNestedSource('cherries/*').factory
+        self.assertEqual(
+            ['Cherry One', 'Cherry Two'],
+            cherry_source.getValues(Mock()))
+
+    def test_searchable_source_should_return_attribute_values_by_xpath(self):
+        cherry_source = ExampleNestedSource('*//cherry').factory
+        cherry_source.attribute = 'id'
+        self.assertEqual(
+            ['cherry_one', 'cherry_two'],
+            cherry_source.getValues(Mock()))
 
 
 class AddableCMSContentTypeSourceTest(zeit.cms.testing.ZeitCmsTestCase):

--- a/core/src/zeit/content/article/edit/browser/configure.zcml
+++ b/core/src/zeit/content/article/edit/browser/configure.zcml
@@ -482,6 +482,27 @@
     weight="10"
     />
 
+  <!-- tickaroo liveblog -->
+
+  <browser:page
+    for="zeit.content.article.edit.interfaces.ITickarooLiveblog"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="edit-liveblog-tickaroo"
+    class=".edit.EditTickarooLiveblog"
+    permission="zope.View"
+    />
+
+  <browser:viewlet
+    for="zeit.content.article.edit.interfaces.ITickarooLiveblog"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    view="zope.interface.Interface"
+    manager="zeit.edit.interfaces.IContentViewletManager"
+    name="edit-liveblog-tickaroo"
+    class="zeit.edit.browser.form.FormLoader"
+    permission="zope.View"
+    weight="10"
+    />
+
   <!-- cardstack -->
 
   <browser:page

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -321,6 +321,15 @@ class EditLiveblog(zeit.edit.browser.form.InlineForm):
         return 'liveblog.{0}'.format(self.context.__name__)
 
 
+class EditTickarooLiveblog(zeit.edit.browser.form.InlineForm):
+
+    legend = None
+    undo_description = _('edit tickaroo liveblog')
+    form_fields = zope.formlib.form.FormFields(
+        zeit.content.modules.interfaces.ITickarooLiveblog).omit(
+            *list(zeit.edit.interfaces.IBlock))
+
+
 class EditCardstack(zeit.edit.browser.form.InlineForm):
 
     legend = None

--- a/core/src/zeit/content/article/edit/configure.zcml
+++ b/core/src/zeit/content/article/edit/configure.zcml
@@ -251,6 +251,23 @@
       />
   </class>
 
+  <adapter
+    factory=".liveblog.TickarooLiveblogFactory"
+    provides=".interfaces.ITickarooLiveblog"
+    trusted="yes"
+    />
+
+  <class class=".liveblog.TickarooLiveblog">
+    <require
+      interface=".interfaces.ITickarooLiveblog"
+      permission="zope.View"
+      />
+    <require
+      set_schema=".interfaces.ITickarooLiveblog"
+      permission="zeit.EditContent"
+      />
+  </class>
+
   <class class=".cardstack.Cardstack">
     <require
       interface=".interfaces.ICardstack"

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -397,6 +397,10 @@ class ILiveblog(zeit.edit.interfaces.IBlock):
         required=False)
 
 
+class ITickarooLiveblog(zeit.content.modules.interfaces.ITickarooLiveblog):
+    pass
+
+
 class ICardstack(zeit.edit.interfaces.IBlock):
 
     card_id = zope.schema.TextLine(

--- a/core/src/zeit/content/article/edit/liveblog.py
+++ b/core/src/zeit/content/article/edit/liveblog.py
@@ -1,9 +1,13 @@
 from datetime import datetime
 from zeit.cms.i18n import MessageFactory as _
+from zeit.content.article.edit.interfaces import ITickarooLiveblog
 import grokcore.component as grok
 import pytz
 import zeit.content.article.edit.block
 import zeit.content.article.edit.interfaces
+import zeit.content.modules.interfaces
+import zeit.content.modules.liveblog
+import zope.component
 
 
 @grok.implementer(zeit.content.article.edit.interfaces.ILiveblog)
@@ -67,3 +71,18 @@ def set_lsc_default_for_liveblogs(context, event):
             zeit.cms.content.interfaces.ISemanticChange(
                 context).has_semantic_change = True
             break
+
+
+@grok.implementer(zeit.content.article.edit.interfaces.ITickarooLiveblog)
+class TickarooLiveblog(
+        zeit.content.article.edit.block.Block,
+        zeit.content.modules.liveblog.TickarooLiveblog):
+
+    type = 'tickaroo_liveblog'
+
+
+@zope.component.adapter(ITickarooLiveblog)
+class TickarooLiveblogFactory(zeit.content.article.edit.block.BlockFactory):
+
+    produces = TickarooLiveblog
+    title = _('Tickaroo liveblog block')

--- a/core/src/zeit/content/article/edit/tests/modules.xml
+++ b/core/src/zeit/content/article/edit/tests/modules.xml
@@ -13,6 +13,7 @@
   <module id="ingredientdice">Zutatenwürfel</module>
   <module id="jobboxticker">Jobticker Modul</module>
   <module id="liveblog">Liveblog</module>
+  <module id="tickaroo_liveblog">Tickaroo Liveblog</module>
   <module id="mail">Mail-Formular</module>
   <module id="newslettersignup">Newsletter Signup Modul</module>
   <module id="podcast">Podcast-Block</module>

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -206,19 +206,11 @@ class IMail(zeit.edit.interfaces.IBlock):
     body = zope.interface.Attribute('Email body')
 
 
-class RecipeMetadataSource(zeit.cms.content.sources.XMLSource):
+class RecipeMetadataSource(zeit.cms.content.sources.SearchableXMLSource):
 
     product_configuration = 'zeit.content.modules'
     config_url = 'recipe-metadata-source'
     default_filename = 'recipe-metadata.xml'
-
-    def __init__(self, xpath):
-        super(RecipeMetadataSource, self).__init__()
-        self.xpath = xpath
-
-    def getValues(self, context):
-        tree = self._get_tree()
-        return [six.text_type(node) for node in tree.xpath(self.xpath)]
 
     def getNodes(self):
         tree = self._get_tree()
@@ -314,4 +306,9 @@ class ITickarooLiveblog(zeit.edit.interfaces.IBlock):
     collapse_preceding_content = zope.schema.Bool(
         title=_('Collapse preceding content'),
         default=True,
+        required=False)
+
+    status = zope.schema.Choice(
+        title=_('Liveblog status'),
+        source=LiveblogSource('*//status'),
         required=False)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -296,3 +296,22 @@ class IRecipeList(zeit.edit.interfaces.IBlock):
             source=zeit.wochenmarkt.sources.ingredientsSource),
         default=(),
         required=False)
+
+
+class LiveblogSource(zeit.cms.content.sources.SearchableXMLSource):
+    """A source for all liveblog config."""
+
+    attribute = 'id'
+    default_filename = 'liveblog.xml'
+    product_configuration = 'zeit.content.modules'
+
+
+class ITickarooLiveblog(zeit.edit.interfaces.IBlock):
+
+    liveblog_id = zope.schema.TextLine(
+        title=_('Liveblog id'))
+
+    collapse_preceding_content = zope.schema.Bool(
+        title=_('Collapse preceding content'),
+        default=True,
+        required=False)

--- a/core/src/zeit/content/modules/liveblog.py
+++ b/core/src/zeit/content/modules/liveblog.py
@@ -1,0 +1,15 @@
+from zeit.cms.content.property import ObjectPathAttributeProperty
+from zeit.content.modules.interfaces import ITickarooLiveblog
+import zeit.edit.block
+import zope.interface
+
+
+@zope.interface.implementer(zeit.content.modules.interfaces.ITickarooLiveblog)
+class TickarooLiveblog(zeit.edit.block.Element):
+
+    liveblog_id = ObjectPathAttributeProperty(
+        '.', 'liveblog_id', ITickarooLiveblog['liveblog_id'])
+
+    collapse_preceding_content = ObjectPathAttributeProperty(
+        '.', 'collapse_preceding_content',
+        ITickarooLiveblog['collapse_preceding_content'])

--- a/core/src/zeit/content/modules/liveblog.py
+++ b/core/src/zeit/content/modules/liveblog.py
@@ -13,3 +13,6 @@ class TickarooLiveblog(zeit.edit.block.Element):
     collapse_preceding_content = ObjectPathAttributeProperty(
         '.', 'collapse_preceding_content',
         ITickarooLiveblog['collapse_preceding_content'])
+
+    status = ObjectPathAttributeProperty(
+        '.', 'status', ITickarooLiveblog['status'])

--- a/core/src/zeit/content/modules/tests/test_liveblog.py
+++ b/core/src/zeit/content/modules/tests/test_liveblog.py
@@ -1,0 +1,21 @@
+from unittest import mock
+import lxml.etree
+import zeit.content.modules.embed
+import zeit.content.modules.testing
+
+
+class ConsentInfo(zeit.content.modules.testing.FunctionalTestCase):
+
+    def setUp(self):
+        super(ConsentInfo, self).setUp()
+        self.context = mock.Mock()
+        self.context.__parent__ = None
+        self.module = zeit.content.modules.liveblog.TickarooLiveblog(
+            self.context, lxml.objectify.XML('<container/>'))
+
+    def test_liveblog_stores_local_values_in_xml(self):
+        self.module.liveblog_id = '1234'
+        self.module.collapse_preceding_content = True
+        assert lxml.etree.tostring(self.module.xml) == (
+            b'<container liveblog_id="1234" '
+            b'collapse_preceding_content="True"/>')


### PR DESCRIPTION
## Was erledigt dieser PR?
Dieser PR stellt eine neues Artikelmodul "Tickaroo Liveblog" zur Verfuegung. Weil wir auf derzeit noch nicht absehbare Zeit die Bestueckung beider Liveblogsysteme unterstuetzen muessen, macht es aus Benutzer- und struktureller Sicht wenig Sinn beide Liveblog-Module zu mergen, sondern stattdessen parallel fuer jedes System eins anzubieten.

Ich war mir zunaechst nicht ganz sicher, wie schoen ich es finde, den Code mit dem Namen des Dienstleisters zu "branden", auf der anderen Seite erspart man sich so umstaendliche Verrenkungen bei der Benamsung und erkennt beim Lesen eindeutig um welches Liveblogsystem es sich handelt. Zumal sich mit wechselndem Dienstleister auch haeufig die Anforderungen aendern und wir dann beim naechsten mal wieder den gleichen Kopfstand machen muessten.
Bei Mailjet fand ichs bisher auch eher Vorteilhaft.

Ich habe fuer den Liveblog-Status eine eigene config angelegt, weil diese im Laufe der naechsten Monate noch erweitert werden soll.

## Wie wird getestet?
Wenn mans einmal manuell durchtanzen moechte:
* einen Artikel im AAD anlegen und das Modul "Tickaroo Liveblog" reinziehen
* einmal kurz was eintippen und schauen ob's im XML steht

## Was gibt es zu beachten?
Nichts. Ich habe die Konfig fuer den Liveblog-Status bereits auf staging und production hinterlegt.

## Giphy
![](https://media.giphy.com/media/FdU0HwrC6FkiY/giphy.gif)