### PR TITLE
ZON-6383: Handle Markdown using python libraries

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.48.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6383: Handle Markdown using python libraries
 
 
 4.48.7 (2021-02-01)

--- a/core/setup.py
+++ b/core/setup.py
@@ -36,6 +36,7 @@ setup(
         'iso8601>=0.1.2',
         'lxml>=2.0.2',
         'martian',
+        'markdown',
         'markdownify',
         'pendulum>=2.0.0.dev0',
         'persistent',

--- a/core/setup.py
+++ b/core/setup.py
@@ -36,6 +36,7 @@ setup(
         'iso8601>=0.1.2',
         'lxml>=2.0.2',
         'martian',
+        'markdownify',
         'pendulum>=2.0.0.dev0',
         'persistent',
         'pyramid_dogpile_cache2',

--- a/core/src/zeit/cms/browser/tests/test_widget.py
+++ b/core/src/zeit/cms/browser/tests/test_widget.py
@@ -1053,11 +1053,11 @@ class MarkdownWidgetTest(zeit.cms.testing.ZeitCmsTestCase):
     def test_converts_input_to_html(self):
         self.request.form[self.widget.name] = '**umläut**'
         self.assertEqual(
-            '<p><strong>umläut</strong></p>\n', self.widget.getInputValue())
+            '<p><strong>umläut</strong></p>', self.widget.getInputValue())
 
     def test_converts_to_markdown_for_rendering(self):
         self.widget.setRenderedValue('<strong>umläut</strong>')
-        self.assertEqual('**umläut**\n', self.widget._getFormValue())
+        self.assertEqual('**umläut**', self.widget._getFormValue())
 
     def test_respects_missing_value(self):
         self.request.form[self.widget.name] = ''

--- a/core/src/zeit/cms/browser/tests/test_widget.py
+++ b/core/src/zeit/cms/browser/tests/test_widget.py
@@ -1039,8 +1039,6 @@ class ConvertingRestructuredTextWidgetTest(
                 '<strong>foo</strong>', self.widget._getFormValue())
 
 
-@unittest.skipUnless(
-    os.path.exists('/usr/bin/pandoc'), 'pandoc not available')
 class MarkdownWidgetTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):

--- a/core/src/zeit/cms/browser/tests/test_widget.py
+++ b/core/src/zeit/cms/browser/tests/test_widget.py
@@ -39,14 +39,14 @@ class TestObjectDetails(zeit.cms.testing.ZeitCmsBrowserTestCase):
 
     def test_should_contain_teaser_title(self):
         with self.get_content() as co:
-            co.teaserTitle = u'test title'
+            co.teaserTitle = 'test title'
         self.browser.open('@@object-details')
         self.assert_ellipsis(
             '...<div class="teaser_title">test title</div>...')
 
     def test_should_contain_metadata(self):
         with self.get_content() as co:
-            co.ressort = u'International'
+            co.ressort = 'International'
         self.browser.handleErrors = False
         self.browser.open('@@object-details')
         self.assert_ellipsis("""...<ul class="metadata">
@@ -210,7 +210,7 @@ class TestObjectSequenceWidgetIntegration(
         from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         field = self.get_field()
         content = ExampleContentType()
-        content.ressort = u'Politik'
+        content.ressort = 'Politik'
         field = field.bind(content)
         widget = self.get_widget(field)
         widget.add_type = (
@@ -226,7 +226,7 @@ class TestObjectSequenceWidgetIntegration(
         widget = self.get_widget(field)
         with mock.patch.object(
                 field.value_type.source, 'get_check_types') as types:
-            types.return_value = [u'foo', 'bar']
+            types.return_value = ['foo', 'bar']
             self.assertEqual('["type-foo", "type-bar"]', widget.accept_classes)
 
     def test_widget_detail_view_name_can_be_configured(self):
@@ -239,7 +239,7 @@ class TestObjectSequenceWidgetIntegration(
 
     def test_shows_description_if_present(self):
         field = self.get_field()
-        field.description = u'foo'
+        field.description = 'foo'
         widget = self.get_widget(field)
         self.assert_ellipsis("""...
             new zeit.cms.ObjectSequenceWidget(
@@ -263,7 +263,7 @@ class TestObjectSequenceWidgetJavascript(zeit.cms.testing.SeleniumTestCase):
     def test_widget_should_render_note_about_new_items(self):
         s = self.selenium
         s.waitForTextPresent(
-            u'Ziehen Sie Inhalte hierher um sie zu verknüpfen.')
+            'Ziehen Sie Inhalte hierher um sie zu verknüpfen.')
 
     def test_widget_should_insert_dropped_objects(self):
         s = self.selenium
@@ -642,7 +642,7 @@ class TestDropObjectWidgetIntegration(
         ANY = None
         widget = DropObjectWidget(choice, choice.source, ANY)
         with mock.patch.object(choice.source, 'get_check_types') as types:
-            types.return_value = [u'foo', 'bar']
+            types.return_value = ['foo', 'bar']
             self.assertEqual('["type-foo", "type-bar"]', widget.accept_classes)
 
     def test_widget_detail_view_name_can_be_configured(self):
@@ -656,7 +656,7 @@ class TestDropObjectWidgetIntegration(
 
     def test_shows_description_if_present(self):
         choice = self.get_choice()
-        choice.description = u'foo'
+        choice.description = 'foo'
         request = zope.publisher.browser.TestRequest()
         widget = zeit.cms.browser.widget.DropObjectWidget(
             choice, choice.source, request)
@@ -675,7 +675,7 @@ class TestDropObjectWidgetIntegration(
         choice = self.get_choice()
         request = zope.publisher.browser.TestRequest()
         content = ExampleContentType()
-        content.ressort = u'Politik'
+        content.ressort = 'Politik'
         choice = choice.bind(content)
         widget = zeit.cms.browser.widget.DropObjectWidget(
             choice, choice.source, request)
@@ -1051,13 +1051,13 @@ class MarkdownWidgetTest(zeit.cms.testing.ZeitCmsTestCase):
         self.widget = MarkdownWidget(field, self.request)
 
     def test_converts_input_to_html(self):
-        self.request.form[self.widget.name] = u'**umläut**'
+        self.request.form[self.widget.name] = '**umläut**'
         self.assertEqual(
-            u'<p><strong>umläut</strong></p>\n', self.widget.getInputValue())
+            '<p><strong>umläut</strong></p>\n', self.widget.getInputValue())
 
     def test_converts_to_markdown_for_rendering(self):
-        self.widget.setRenderedValue(u'<strong>umläut</strong>')
-        self.assertEqual(u'**umläut**\n', self.widget._getFormValue())
+        self.widget.setRenderedValue('<strong>umläut</strong>')
+        self.assertEqual('**umläut**\n', self.widget._getFormValue())
 
     def test_respects_missing_value(self):
         self.request.form[self.widget.name] = ''

--- a/core/src/zeit/cms/browser/tests/test_widget.py
+++ b/core/src/zeit/cms/browser/tests/test_widget.py
@@ -24,7 +24,7 @@ import zope.schema.interfaces
 class TestObjectDetails(zeit.cms.testing.ZeitCmsBrowserTestCase):
 
     def setUp(self):
-        super(TestObjectDetails, self).setUp()
+        super().setUp()
         self.browser.open(
             'http://localhost:8080/++skin++vivi/repository/testcontent/')
 
@@ -116,7 +116,7 @@ class TestObjectSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
             widget._toFieldValue(['http://xml.zeit.de/testcontent']))
 
     def test_uniqueId_not_in_source_should_raise(self):
-        class FakeSource(object):
+        class FakeSource:
             def __contains__(self, value):
                 return False
 
@@ -138,7 +138,7 @@ class TestObjectSequenceWidgetIntegration(
 
     def setUp(self):
         import zope.security.management
-        super(TestObjectSequenceWidgetIntegration, self).setUp()
+        super().setUp()
         zope.security.management.endInteraction()
 
     def get_field(self):
@@ -251,7 +251,7 @@ class TestObjectSequenceWidgetJavascript(zeit.cms.testing.SeleniumTestCase):
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(TestObjectSequenceWidgetJavascript, self).setUp()
+        super().setUp()
         self.open(
             '/@@/zeit.cms.browser.tests.fixtures/objectsequencewidget.html')
 
@@ -440,13 +440,13 @@ class ObjectWidgetDetailViews(zeit.cms.testing.SeleniumTestCase):
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(ObjectWidgetDetailViews, self).setUp()
+        super().setUp()
         ObjectWidgetMyDetails.raise_error = False
         setup_mydetails()
 
     def tearDown(self):
         teardown_mydetails()
-        super(ObjectWidgetDetailViews, self).tearDown()
+        super().tearDown()
 
     def test_object_sequence_widgets_use_their_configured_views(self):
         self.open(
@@ -494,7 +494,7 @@ class TestObjectSequenceWidgetAutocompleteJavascript(
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(TestObjectSequenceWidgetAutocompleteJavascript, self).setUp()
+        super().setUp()
         self.open(
             '/@@/zeit.cms.browser.tests.fixtures/'
             'objectsequencewidget-autocomplete.html')
@@ -525,7 +525,7 @@ class TestDropObjectWidgetFoo(zeit.cms.testing.SeleniumTestCase):
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(TestDropObjectWidgetFoo, self).setUp()
+        super().setUp()
         self.open(
             '/@@/zeit.cms.browser.tests.fixtures/dropobjectwidget.html')
 
@@ -574,7 +574,7 @@ class TestDropObjectWidgetAccept(zeit.cms.testing.SeleniumTestCase):
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(TestDropObjectWidgetAccept, self).setUp()
+        super().setUp()
         self.open(
             '/@@/zeit.cms.browser.tests.fixtures/dropobjectwidget-accept.html')
 
@@ -601,7 +601,7 @@ class TestDropObjectWidgetIntegration(
 
     def setUp(self):
         import zope.security.management
-        super(TestDropObjectWidgetIntegration, self).setUp()
+        super().setUp()
         zope.security.management.endInteraction()
 
     def get_choice(self):
@@ -710,7 +710,7 @@ class DropObjectWidget(zeit.cms.testing.ZeitCmsTestCase):
             widget._toFieldValue('http://xml.zeit.de/testcontent'))
 
     def test_uniqueId_not_in_source_should_raise(self):
-        class FakeSource(object):
+        class FakeSource:
             def __contains__(self, value):
                 return False
 
@@ -766,13 +766,13 @@ class TestObjectSequenceDisplayWidgetIntegration(
 
     def setUp(self):
         import zope.security.management
-        super(TestObjectSequenceDisplayWidgetIntegration, self).setUp()
+        super().setUp()
         zope.security.management.endInteraction()
         setup_mydetails()
 
     def tearDown(self):
         teardown_mydetails()
-        super(TestObjectSequenceDisplayWidgetIntegration, self).tearDown()
+        super().tearDown()
 
     def get_field(self):
         import zeit.cms.content.contentsource
@@ -826,13 +826,13 @@ class TestDropObjectDisplayWidgetIntegration(
 
     def setUp(self):
         import zope.security.management
-        super(TestDropObjectDisplayWidgetIntegration, self).setUp()
+        super().setUp()
         zope.security.management.endInteraction()
         setup_mydetails()
 
     def tearDown(self):
         teardown_mydetails()
-        super(TestDropObjectDisplayWidgetIntegration, self).tearDown()
+        super().tearDown()
 
     def get_field(self):
         import zeit.cms.content.contentsource
@@ -882,7 +882,7 @@ class TestDropObjectDisplayWidgetIntegration(
 class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
-        super(TestReferenceSequenceWidget, self).setUp()
+        super().setUp()
         ExampleContentType.references = \
             zeit.cms.content.reference.ReferenceProperty(
                 '.body.references.reference', 'related')
@@ -890,7 +890,7 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
         self.repository['target'] = ExampleContentType()
 
         @zope.interface.implementer(zope.schema.interfaces.ISource)
-        class FakeSource(object):
+        class FakeSource:
 
             def __contains__(self, value):
                 return True
@@ -902,7 +902,7 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
 
     def tearDown(self):
         del ExampleContentType.references
-        super(TestReferenceSequenceWidget, self).tearDown()
+        super().tearDown()
 
     def test_invalid_unique_id_fails_validation(self):
         widget = ReferenceSequenceWidget(self.field, mock.Mock(), mock.Mock())
@@ -930,7 +930,7 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
             self.repository['target'], result[0].target)
 
     def test_content_not_in_source_should_raise(self):
-        class FakeSource(object):
+        class FakeSource:
             def __contains__(self, value):
                 return False
 
@@ -947,7 +947,7 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
 class RestructuredTextWidgetTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
-        super(RestructuredTextWidgetTest, self).setUp()
+        super().setUp()
         from zeit.cms.browser.widget import RestructuredTextWidget
         request = zope.publisher.browser.TestRequest(
             skin=zeit.cms.browser.interfaces.ICMSSkin)
@@ -980,7 +980,7 @@ class RestructuredTextWidgetJavascriptTest(
     layer = zeit.cms.testing.WEBDRIVER_LAYER
 
     def setUp(self):
-        super(RestructuredTextWidgetJavascriptTest, self).setUp()
+        super().setUp()
         self.open(
             '/@@/zeit.cms.browser.tests.fixtures/restructuredtext.html')
 
@@ -1013,7 +1013,7 @@ class ConvertingRestructuredTextWidgetTest(
         zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
-        super(ConvertingRestructuredTextWidgetTest, self).setUp()
+        super().setUp()
         from zeit.cms.browser.widget import ConvertingRestructuredTextWidget
         self.request = zope.publisher.browser.TestRequest(
             skin=zeit.cms.browser.interfaces.ICMSSkin)
@@ -1042,7 +1042,7 @@ class ConvertingRestructuredTextWidgetTest(
 class MarkdownWidgetTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
-        super(MarkdownWidgetTest, self).setUp()
+        super().setUp()
         from zeit.cms.browser.widget import MarkdownWidget
         self.request = zope.publisher.browser.TestRequest(
             skin=zeit.cms.browser.interfaces.ICMSSkin)

--- a/core/src/zeit/cms/browser/widget.py
+++ b/core/src/zeit/cms/browser/widget.py
@@ -5,7 +5,7 @@ import grokcore.component as grok
 import json
 import markdownify
 import pypandoc
-import six.moves.urllib.parse
+import urllib.parse
 import time
 import xml.sax.saxutils
 import zc.datetimewidget.datetimewidget
@@ -40,7 +40,7 @@ class ObjectReferenceWidget(zope.app.form.browser.widget.SimpleInputWidget):
         'object-reference-widget.pt')
 
     def __init__(self, context, source, request):
-        super(ObjectReferenceWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.source = source
 
     def __call__(self):
@@ -125,7 +125,7 @@ class ObjectReferenceSequenceWidget(
         quoted_name = xml.sax.saxutils.quoteattr(self.name)
         result = ['<div id=%s>%s</div>' % (
             quoted_name,
-            super(ObjectReferenceSequenceWidget, self).__call__())]
+            super().__call__())]
         result.append('<script language="javascript">')
         result.append('new zeit.cms.ObjectReferenceSequenceWidget(%s);' %
                       quoted_name)
@@ -138,7 +138,7 @@ class ObjectReferenceDisplayWidget(
     """DEPRECATED, superceeded by DropObjectDisplayWidget"""
 
     def __init__(self, context, source, request):
-        super(ObjectReferenceDisplayWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.source = source
 
     def __call__(self):
@@ -190,7 +190,7 @@ def objectDisplayWidgetMultiplexer(context, field, request):
         zope.app.form.interfaces.IDisplayWidget)
 
 
-class AddViewMixin(object):
+class AddViewMixin:
 
     @zope.cachedescriptors.property.Lazy
     def add_view(self):
@@ -233,7 +233,7 @@ class ObjectSequenceWidget(
     display_url_field = True
 
     def __init__(self, context, source, request):
-        super(ObjectSequenceWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.source = source
 
     def __call__(self):
@@ -324,8 +324,7 @@ class ObjectSequenceDisplayWidget(
     detail_view_name = '@@object-details'
 
     def __init__(self, context, source, request):
-        super(ObjectSequenceDisplayWidget, self).__init__(
-            context, request)
+        super().__init__(context, request)
         self.source = source
 
     def __call__(self):
@@ -357,8 +356,8 @@ class DropObjectDisplayWidget(ObjectSequenceDisplayWidget):
 
 
 def js_escape_check_types(source):
-    # convert unicode, JS needs 'foo', not u'foo'
-    return json.dumps([u'type-' + x for x in source.get_check_types()])
+    # convert unicode, JS needs 'foo', not 'foo'
+    return json.dumps(['type-' + x for x in source.get_check_types()])
 
 
 class ContentNotFoundError(zope.formlib.interfaces.ConversionError):
@@ -367,7 +366,7 @@ class ContentNotFoundError(zope.formlib.interfaces.ConversionError):
         msg = _("The object '${id}' could not be found.",
                 mapping=dict(id=uniqueId))
         msg = zope.i18n.translate(msg, context=request)
-        super(ContentNotFoundError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class WrongContentTypeError(zope.formlib.interfaces.ConversionError):
@@ -376,7 +375,7 @@ class WrongContentTypeError(zope.formlib.interfaces.ConversionError):
         msg = _("'${id}' does not have an accepted type (${types}).",
                 mapping=dict(id=uniqueId, types=', '.join(accepted_types)))
         msg = zope.i18n.translate(msg, context=request)
-        super(WrongContentTypeError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class DropObjectWidget(
@@ -393,7 +392,7 @@ class DropObjectWidget(
     display_url_field = True
 
     def __init__(self, context, source, request):
-        super(DropObjectWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.source = source
 
     def __call__(self):
@@ -462,8 +461,8 @@ class ReferenceSequenceWidget(ObjectSequenceWidget):
 
 def resolve_reference(unique_id, field, source, request):
     if not field.context.uniqueId:  # Support AddForms
-        params = six.moves.urllib.parse.parse_qs(
-            six.moves.urllib.parse.urlparse(unique_id).query)
+        params = urllib.parse.parse_qs(
+            urllib.parse.urlparse(unique_id).query)
         if 'target' in params:
             unique_id = params['target'][0]
 
@@ -516,7 +515,7 @@ class DatetimeWidget(zc.datetimewidget.datetimewidget.DatetimeWidget):
     """A datetime widget with additional buttons."""
 
     def __call__(self):
-        html = super(self.__class__, self).__call__()
+        html = super().__call__()
         week = DATETIME_WIDGET_ADDITIONAL % dict(
             field=self.name,
             label="1W",
@@ -529,12 +528,12 @@ class DatetimeWidget(zc.datetimewidget.datetimewidget.DatetimeWidget):
             increase="date.setMonth(date.getMonth() + 1)")
         infty = DATETIME_WIDGET_INFTY % dict(
             field=self.name)
-        return (u'<div class="dateTimeWidget">' +
+        return ('<div class="dateTimeWidget">' +
                 html + week + month + infty +
                 '</div>')
 
     def _configuration(self):
-        conf = super(DatetimeWidget, self)._configuration()
+        conf = super()._configuration()
         conf.onClose = "zeit.cms.get_datetime_close('{0}')".format(self.name)
         return conf
 
@@ -542,11 +541,11 @@ class DatetimeWidget(zc.datetimewidget.datetimewidget.DatetimeWidget):
 class CheckBoxWidget(zope.formlib.boolwidgets.CheckBoxWidget):
 
     def __init__(self, context, request):
-        super(CheckBoxWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.reversed = True
 
     def __call__(self):
-        result = super(CheckBoxWidget, self).__call__()
+        result = super().__call__()
         result += '\n<span class="checkbox"></span>'
         return result
 
@@ -576,7 +575,7 @@ class RestructuredTextWidget(zope.formlib.textwidgets.TextAreaWidget):
         'rst-widget.pt')
 
     def __call__(self):
-        self.textarea = super(RestructuredTextWidget, self).__call__()
+        self.textarea = super().__call__()
         return self.template()
 
     @property
@@ -587,21 +586,19 @@ class RestructuredTextWidget(zope.formlib.textwidgets.TextAreaWidget):
 class ConvertingRestructuredTextWidget(RestructuredTextWidget):
 
     def _toFieldValue(self, value):
-        value = super(ConvertingRestructuredTextWidget, self)._toFieldValue(
-            value)
+        value = super()._toFieldValue(value)
         return rst2html(value)
 
     def _toFormValue(self, value):
-        value = super(ConvertingRestructuredTextWidget, self)._toFormValue(
-            value)
+        value = super()._toFormValue(value)
         return html2rst(value)
 
 
 class RestructuredTextDisplayWidget(zope.formlib.widgets.DisplayWidget):
 
     def __call__(self):
-        value = super(RestructuredTextDisplayWidget, self).__call__()
-        return (u'<div class="rst-display-widget">%s</div>' % rst2html(value)
+        value = super().__call__()
+        return ('<div class="rst-display-widget">%s</div>' % rst2html(value)
                 if value else value)
 
 
@@ -610,7 +607,7 @@ class AutocompleteWidget(zope.formlib.textwidgets.TextWidget):
     cssClass = 'autocomplete-widget'
 
     def __init__(self, context, source, request):
-        super(AutocompleteWidget, self).__init__(context, request)
+        super().__init__(context, request)
         self.source = source
         self.extra = 'cms:autocomplete-source="%s"' % (
             self.query_url)
@@ -625,7 +622,7 @@ class AutocompleteWidget(zope.formlib.textwidgets.TextWidget):
 class AutocompleteDisplayWidget(zope.formlib.widgets.DisplayWidget):
 
     def __init__(self, context, source, request):
-        super(AutocompleteDisplayWidget, self).__init__(context, request)
+        super().__init__(context, request)
 
 
 class AutocompleteSourceQuery(grok.MultiAdapter,
@@ -642,9 +639,9 @@ class AutocompleteSourceQuery(grok.MultiAdapter,
 
     def __call__(self):
         return (
-            u'<input type="text" class="autocomplete" '
-            u'placeholder={placeholder} '
-            u'cms:autocomplete-source="{url}" />').format(
+            '<input type="text" class="autocomplete" '
+            'placeholder={placeholder} '
+            'cms:autocomplete-source="{url}" />').format(
             url=zope.component.queryMultiAdapter(
                 (self.source, self.request),
                 zeit.cms.browser.interfaces.ISourceQueryURL),
@@ -662,7 +659,7 @@ def empty_toFieldValue(self, input):
     # XXX Work around formlib bug, browser always POSTs the parameter with
     # no value, which somehow gets converted to a list containing an empty
     # string [''], which formlib does not expect.
-    if input == [u'']:
+    if input == ['']:
         input = None
     return orig_toFieldValue(self, input)
 
@@ -676,7 +673,7 @@ class MarkdownWidget(zope.formlib.textwidgets.TextAreaWidget):
     _extra_pandoc_args = ["--email-obfuscation", "none"]
 
     def _toFieldValue(self, value):
-        value = super(MarkdownWidget, self)._toFieldValue(
+        value = super()._toFieldValue(
             value)
         if not value:
             return value
@@ -687,7 +684,7 @@ class MarkdownWidget(zope.formlib.textwidgets.TextAreaWidget):
             return value
 
     def _toFormValue(self, value):
-        value = super(MarkdownWidget, self)._toFormValue(
+        value = super()._toFormValue(
             value)
         try:
             return markdownify.markdownify(value)

--- a/core/src/zeit/cms/browser/widget.py
+++ b/core/src/zeit/cms/browser/widget.py
@@ -3,6 +3,7 @@ from zeit.cms.i18n import MessageFactory as _
 import docutils.core
 import grokcore.component as grok
 import json
+import markdown
 import markdownify
 import pypandoc
 import urllib.parse
@@ -678,8 +679,7 @@ class MarkdownWidget(zope.formlib.textwidgets.TextAreaWidget):
         if not value:
             return value
         try:
-            return pypandoc.convert_text(value, to='html', format='markdown',
-                                         extra_args=self._extra_pandoc_args)
+            return markdown.markdown(value)
         except OSError:
             return value
 

--- a/core/src/zeit/cms/browser/widget.py
+++ b/core/src/zeit/cms/browser/widget.py
@@ -671,8 +671,6 @@ zope.formlib.itemswidgets.MultiDataHelper._toFieldValue = empty_toFieldValue
 
 class MarkdownWidget(zope.formlib.textwidgets.TextAreaWidget):
 
-    _extra_pandoc_args = ["--email-obfuscation", "none"]
-
     def _toFieldValue(self, value):
         value = super()._toFieldValue(
             value)

--- a/core/src/zeit/cms/browser/widget.py
+++ b/core/src/zeit/cms/browser/widget.py
@@ -3,6 +3,7 @@ from zeit.cms.i18n import MessageFactory as _
 import docutils.core
 import grokcore.component as grok
 import json
+import markdownify
 import pypandoc
 import six.moves.urllib.parse
 import time
@@ -689,7 +690,7 @@ class MarkdownWidget(zope.formlib.textwidgets.TextAreaWidget):
         value = super(MarkdownWidget, self)._toFormValue(
             value)
         try:
-            return pypandoc.convert_text(value, to='markdown', format='html')
+            return markdownify.markdownify(value)
         except OSError:
             return value
 


### PR DESCRIPTION
### Was erledigt dieser PR?
Die Bibliotheken Markdown und Markdownify ersetzen Pandoc zur Konvertierung Makrdown <-> HTML. 

### Wo geht's los?
`vivi.cms.browser.widget.py`

### Wie kann getestet werden?
`bin/test  vivi/core/src/zeit/cms/browser/tests/test_widget.py`

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6383

### Todos
- [x] Python Bibliothek HTML to RST finden und einbauen, sodass Pandoc vollständig entfällt
- [x] vivi-deployment PR stellen
- [x] erst [vivi-deployment PR](https://github.com/ZeitOnline/vivi-deployment/pull/165) mergen