### PR TITLE
ZON-6383: Markdown property for markdown class

### DIFF
--- a/core/src/zeit/content/cp/blocks/markup.py
+++ b/core/src/zeit/content/cp/blocks/markup.py
@@ -1,4 +1,5 @@
 from zeit.cms.i18n import MessageFactory as _
+import markdownify
 import grokcore.component as grok
 import zeit.cms.content.property
 import zeit.content.cp.blocks.block
@@ -11,9 +12,12 @@ class MarkupBlock(zeit.content.cp.blocks.block.Block):
     type = 'markup'
 
     text = zeit.cms.content.property.Structure('.text')
-    markdown = zeit.cms.content.property.Structure('.text')
     alignment = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'align', zeit.content.cp.interfaces.IMarkupBlock['alignment'])
+
+    @property
+    def markdown(self):
+        return markdownify.markdownify(self.text)
 
 
 class Factory(zeit.content.cp.blocks.block.BlockFactory):

--- a/core/src/zeit/content/cp/blocks/markup.py
+++ b/core/src/zeit/content/cp/blocks/markup.py
@@ -11,6 +11,7 @@ class MarkupBlock(zeit.content.cp.blocks.block.Block):
     type = 'markup'
 
     text = zeit.cms.content.property.Structure('.text')
+    markdown = zeit.cms.content.property.Structure('.text')
     alignment = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'align', zeit.content.cp.interfaces.IMarkupBlock['alignment'])
 

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -903,7 +903,7 @@ class IMarkupBlock(IBlock):
         title=_('Contents'),
         description=_('Use Markdown'),
         required=False)
-    markdown = zope.interface.Attribute()
+    markdown = zope.interface.Attribute('Text in markdown format')
     alignment = zope.schema.Choice(
         title=_('Alignment'),
         description=_('Choose alignment'),

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -903,6 +903,9 @@ class IMarkupBlock(IBlock):
         title=_('Contents'),
         description=_('Use Markdown'),
         required=False)
+    markdown = zope.schema.Text(
+        title=_('Markdown contents'),
+        description=_('Store text as markdown'),
     alignment = zope.schema.Choice(
         title=_('Alignment'),
         description=_('Choose alignment'),

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -903,10 +903,7 @@ class IMarkupBlock(IBlock):
         title=_('Contents'),
         description=_('Use Markdown'),
         required=False)
-    markdown = zope.schema.Text(
-        title=_('Markdown'),
-        description=_('Store text as markdown'),
-        required=False)
+    markdown = zope.interface.Attribute()
     alignment = zope.schema.Choice(
         title=_('Alignment'),
         description=_('Choose alignment'),

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -904,7 +904,7 @@ class IMarkupBlock(IBlock):
         description=_('Use Markdown'),
         required=False)
     markdown = zope.schema.Text(
-        title=_('Markdown contents'),
+        title=_('Markdown'),
         description=_('Store text as markdown'),
         required=False)
     alignment = zope.schema.Choice(

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -906,6 +906,7 @@ class IMarkupBlock(IBlock):
     markdown = zope.schema.Text(
         title=_('Markdown contents'),
         description=_('Store text as markdown'),
+        required=False)
     alignment = zope.schema.Choice(
         title=_('Alignment'),
         description=_('Choose alignment'),


### PR DESCRIPTION
### Was erledigt dieser PR?

Fügt ein Attribute hinzu um den Zugriff auf in Markdown formatierten Text zu ermöglichen. Dies wird beispielsweise in Zappi benötigt, da nativ gerenderte Centerpages kein HTML enthalten dürfen.

gehört zu ZON-6383, dafür gibt es bereits einen `CHANGES.txt` Eintrag

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6383