### PR TITLE
BUG-1250: Hide no more needed 'external' author checkbox

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.49.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-1250: Hide no more needed 'external' author checkbox
 
 
 4.49.2 (2021-03-10)

--- a/core/src/zeit/content/author/browser/resources/author.css
+++ b/core/src/zeit/content/author/browser/resources/author.css
@@ -32,3 +32,7 @@
     padding: 0;
     margin-left: 0;
 }
+
+.fieldname-external {
+    display: none;
+}


### PR DESCRIPTION
https://zeit-online.atlassian.net/browse/BUG-1250
Der Hintergrund für die Ausblendung dieser Checkbox ist:
1) Der Anwender dachte er müsste sich zwischen 'ist external' und 'ist Autor' entscheiden.
Hier wurde dann 'ist Autor' deaktiviert und dies erzeugt den 404
Ob dies der Grund für die 404er oder nur ein Grund ist, wird sich noch zeigen müssen.

2) Dieses 'ist external' wird nicht mehr verwendet