### PR TITLE
ZON-6521: Support theme in liveblogs

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.50.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6521: Support theme in liveblogs
 
 
 4.50.0 (2021-03-16)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -312,3 +312,9 @@ class ITickarooLiveblog(zeit.edit.interfaces.IBlock):
         title=_('Liveblog status'),
         source=LiveblogSource('*//status'),
         required=True)
+
+    theme = zope.schema.Choice(
+        title=_('Liveblog theme'),
+        source=LiveblogSource('*//theme'),
+        default='default',
+        required=True)

--- a/core/src/zeit/content/modules/liveblog.py
+++ b/core/src/zeit/content/modules/liveblog.py
@@ -16,3 +16,6 @@ class TickarooLiveblog(zeit.edit.block.Element):
 
     status = ObjectPathAttributeProperty(
         '.', 'status', ITickarooLiveblog['status'])
+
+    theme = ObjectPathAttributeProperty(
+        '.', 'theme', ITickarooLiveblog['theme'])


### PR DESCRIPTION
Im Vivi muss in der `liveblog.xml` dafür das hier eingetragen werden.
```
<themes>
    <theme id=default>Default</theme>
    <theme id=solo>Solo</theme>
</themes>
```

## Fragen:
- [x] In der Konfig ist das Oberobjekt `themes` hab ich das dann im Code richtig gemacht?
- [x] Braucht es noch Übersetzungen? Im [Ursprungs-PR](https://github.com/ZeitOnline/vivi/pull/180/files) konnte ich keine finden.