### PR TITLE
STO-185: Clean up path/mtime handling

### DIFF
--- a/core/src/zeit/cms/content/tests/test_filesystem_caching.py
+++ b/core/src/zeit/cms/content/tests/test_filesystem_caching.py
@@ -88,21 +88,21 @@ class FilesystemCachingTest(ZeitCmsTestCase):
         ICMSContent('http://xml.zeit.de/2007/01/Miami')
         ICMSContent('http://xml.zeit.de/2007/02/Verfolgt')
         assert len(cache) == 5
-        assert '2006/49/Young' in cache
-        assert '2007/01/Miami' in cache
-        assert '2007/02/Vita' not in cache
+        assert 'http://xml.zeit.de/2006/49/Young' in cache
+        assert 'http://xml.zeit.de/2007/01/Miami' in cache
+        assert 'http://xml.zeit.de/2007/02/Vita' not in cache
         ICMSContent('http://xml.zeit.de/2007/02/Vita')
         assert len(cache) == 5
-        assert '2006/49/Young' not in cache
-        assert '2007/01/Miami' in cache
-        assert '2007/02/Vita' in cache
+        assert 'http://xml.zeit.de/2006/49/Young' not in cache
+        assert 'http://xml.zeit.de/2007/01/Miami' in cache
+        assert 'http://xml.zeit.de/2007/02/Vita' in cache
         ICMSContent('http://xml.zeit.de/2006/49/Young')
         ICMSContent('http://xml.zeit.de/2006/52/Stimmts')
         ICMSContent('http://xml.zeit.de/2007/01/Macher')
         assert len(cache) == 5
-        assert '2007/02/Vita' in cache
-        assert '2006/49/Young' in cache
-        assert '2007/01/Miami' not in cache
+        assert 'http://xml.zeit.de/2007/02/Vita' in cache
+        assert 'http://xml.zeit.de/2006/49/Young' in cache
+        assert 'http://xml.zeit.de/2007/01/Miami' not in cache
 
     def test_cache_info(self):
         assert caching.info() == dict(
@@ -112,17 +112,17 @@ class FilesystemCachingTest(ZeitCmsTestCase):
         ICMSContent('http://xml.zeit.de/2007/01/Macher')
         assert caching.info() == dict(
             size=5, count=3, hits=0, misses=3, usage={
-                '2006/49/Young': 1,
-                '2006/52/Stimmts': 1,
-                '2007/01/Macher': 1,
+                'http://xml.zeit.de/2006/49/Young': 1,
+                'http://xml.zeit.de/2006/52/Stimmts': 1,
+                'http://xml.zeit.de/2007/01/Macher': 1,
             })
         ICMSContent('http://xml.zeit.de/2006/52/Stimmts')
         ICMSContent('http://xml.zeit.de/2007/01/Macher')
         ICMSContent('http://xml.zeit.de/2007/02/Vita')
         assert caching.info() == dict(
             size=5, count=4, hits=2, misses=4, usage={
-                '2006/49/Young': 1,
-                '2006/52/Stimmts': 2,
-                '2007/01/Macher': 2,
-                '2007/02/Vita': 1,
+                'http://xml.zeit.de/2006/49/Young': 1,
+                'http://xml.zeit.de/2006/52/Stimmts': 2,
+                'http://xml.zeit.de/2007/01/Macher': 2,
+                'http://xml.zeit.de/2007/02/Vita': 1,
             })

--- a/core/src/zeit/connector/filesystem.py
+++ b/core/src/zeit/connector/filesystem.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from urllib.parse import urlparse
 from zeit.connector.connector import CannonicalId
 from zeit.connector.dav.interfaces import DAVNotFoundError
 import ast
@@ -121,10 +122,9 @@ class Connector(object):
         # XXX kludgy: writing here modifies our cached properties value, so
         # future accesses get this as well; some tests/fixtures rely on this.
         properties[zeit.connector.interfaces.RESOURCE_TYPE_PROPERTY] = type
-        path = self._path(id).split('/')
-        name = path[-1] if path else ''
+        path = urlparse(id).path.strip('/').split('/')
         return self.resource_class(
-            six.text_type(id), name, type,
+            six.text_type(id), path[-1], type,
             lambda: self._get_properties(id),
             lambda: self._get_body(id),
             content_type=self._get_content_type(id))

--- a/core/src/zeit/connector/filesystem.py
+++ b/core/src/zeit/connector/filesystem.py
@@ -205,6 +205,9 @@ class Connector(object):
         except KeyError:
             pass
 
+        if result.endswith('/'):
+            result = result[:-1]
+
         if self.canonicalize_directories:
             path = self._path(result)
             if os.path.isdir(path):

--- a/core/src/zeit/connector/filesystem.py
+++ b/core/src/zeit/connector/filesystem.py
@@ -221,7 +221,7 @@ class Connector(object):
         if not id.startswith(ID_NAMESPACE):
             raise ValueError("The id %r is invalid." % id)
         path = id.replace(ID_NAMESPACE, '', 1).rstrip('/')
-        return os.path.join(self.repository_path, path)
+        return os.path.join(self.repository_path, path).rstrip('/')
 
     def _get_file(self, id):
         filename = self._path(id)

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -135,9 +135,9 @@ class Connector(zeit.connector.filesystem.Connector):
         # Just a very basic in-memory data storage for testing purposes.
         resource.data.seek(0)
         self._data[id] = resource.data.read()
-        path = self._path(id)[:-1]
-        name = self._path(id)[-1]
-        self._paths.setdefault(path, set()).add(name)
+        path = self._path(id)
+        self._paths.setdefault(os.path.dirname(path), set()).add(
+            os.path.basename(path))
 
         resource.properties[
             zeit.connector.interfaces.RESOURCE_TYPE_PROPERTY] = resource.type

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -260,15 +260,10 @@ class Connector(zeit.connector.filesystem.Connector):
             return CannonicalId(id + '/')
         if self._properties.get(id) is not None:
             return CannonicalId(id)
-        path = self._absolute_path(self._path(id))
+        path = self._path(id)
         if os.path.isdir(path):
             return CannonicalId(id + '/')
         return CannonicalId(id)
-
-    def _absolute_path(self, path):
-        if not path:
-            return self.repository_path
-        return os.path.join(self.repository_path, os.path.join(*path))
 
     def _get_file(self, id):
         if id in self._data:


### PR DESCRIPTION
Attempt to refactor the connector/caching code to somewhat clean up the path & 'mtime' handling as discussed. Also see https://github.com/ZeitOnline/vivi/pull/183#discussion_r598655497

A number of tests are currently failing, so this is **WIP**.

> […] A good starting point to debug this is:
> ```
> $ bin/test vivi/core/src/zeit/cms/repository/
> ```
> Those are the only failures within `zeit/cms/`