### PR TITLE
ZON-6573: Support legal_text attribute on newsletter signup widgets

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.50.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6573: Support legal_text attribute on newslettersignups
 
 
 4.50.3 (2021-03-30)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -88,7 +88,7 @@ class IJobTicker(zeit.edit.interfaces.IBlock):
 class Newsletter(zeit.cms.content.sources.AllowedBase):
 
     def __init__(self, id, title, image, abo_text, anon_text, redirect_link):
-        super(Newsletter, self).__init__(id, title, available=None)
+        super().__init__(id, title, available=None)
         self.image = image
         self.abo_text = abo_text
         self.anon_text = anon_text

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -87,12 +87,15 @@ class IJobTicker(zeit.edit.interfaces.IBlock):
 
 class Newsletter(zeit.cms.content.sources.AllowedBase):
 
-    def __init__(self, id, title, image, abo_text, anon_text, redirect_link):
+    def __init__(
+            self, id, title, image, abo_text, anon_text, redirect_link,
+            legal_text):
         super().__init__(id, title, available=None)
         self.image = image
         self.abo_text = abo_text
         self.anon_text = anon_text
         self.redirect_link = redirect_link
+        self.legal_text = legal_text
 
 
 @grok.implementer(zeit.content.image.interfaces.IImages)
@@ -125,7 +128,8 @@ class NewsletterSource(zeit.cms.content.sources.ObjectSource,
                 self.child(node, 'image'),
                 self.child(node, 'text'),
                 self.child(node, 'text_anonymous'),
-                self.child(node, 'redirect_link')
+                self.child(node, 'redirect_link'),
+                self.child(node, 'legal_text')
             )
             result[newsletter.id] = newsletter
         return result


### PR DESCRIPTION
Adds support for the new `legal_text` property which is needed in the newsletter.xml (`core/src/zeit/content/modules/tests/fixtures/newsletter.xml`).

I'm unsure wether or not we want to support any attribute in the xml and return it, therefore I didn't implement it right now.
If you think that makes sense, let me know and I'll find a way to add that, aswell :)