### PR TITLE
ZON-6614: Support caching_time attribute on centerpages

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.50.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6614: Support caching time attribute on centerpages
 
 
 4.50.5 (2021-04-08)

--- a/core/src/zeit/cms/admin/browser/admin.py
+++ b/core/src/zeit/cms/admin/browser/admin.py
@@ -22,7 +22,7 @@ class EditFormCI(zeit.cms.browser.form.EditForm):
         _('admin-field-group'), 'column-left-small'),)
 
     def __init__(self, context, request):
-        super().__init__(context, request)
+        super(EditFormCI, self).__init__(context, request)
         for name, entry in zope.component.getAdapters(
                 (context,), zeit.cms.admin.interfaces.IAdditionalFields):
             iface, fields = entry
@@ -44,7 +44,7 @@ class EditFormCO(zeit.cms.browser.form.EditForm):
         _('admin-field-group'), 'column-left-small'),)
 
     def __init__(self, context, request):
-        super().__init__(context, request)
+        super(EditFormCO, self).__init__(context, request)
         for name, entry in zope.component.getAdapters(
                 (context,), zeit.cms.admin.interfaces.IAdditionalFieldsCO):
             iface, fields = entry

--- a/core/src/zeit/cms/admin/browser/admin.py
+++ b/core/src/zeit/cms/admin/browser/admin.py
@@ -22,7 +22,7 @@ class EditFormCI(zeit.cms.browser.form.EditForm):
         _('admin-field-group'), 'column-left-small'),)
 
     def __init__(self, context, request):
-        super(EditFormCI, self).__init__(context, request)
+        super().__init__(context, request)
         for name, entry in zope.component.getAdapters(
                 (context,), zeit.cms.admin.interfaces.IAdditionalFields):
             iface, fields = entry
@@ -41,7 +41,7 @@ class EditFormCO(zeit.cms.browser.form.EditForm):
         _('admin-field-group'), 'column-left-small'),)
 
     def __init__(self, context, request):
-        super(EditFormCO, self).__init__(context, request)
+        super().__init__(context, request)
         for name, entry in zope.component.getAdapters(
                 (context,), zeit.cms.admin.interfaces.IAdditionalFieldsCO):
             iface, fields = entry

--- a/core/src/zeit/cms/admin/browser/admin.py
+++ b/core/src/zeit/cms/admin/browser/admin.py
@@ -31,10 +31,13 @@ class EditFormCI(zeit.cms.browser.form.EditForm):
 
 class EditFormCO(zeit.cms.browser.form.EditForm):
 
-    form_fields = zope.formlib.form.Fields(
-        zeit.cms.content.interfaces.ICommonMetadata).select(
-        'banner', 'banner_content', 'banner_outer',
-        'hide_adblocker_notification')
+    form_fields = (
+        zope.formlib.form.Fields(zeit.cms.content.interfaces.ICachingTime) +
+        zope.formlib.form.Fields(
+            zeit.cms.content.interfaces.ICommonMetadata).select(
+            'banner', 'banner_content', 'banner_outer',
+            'hide_adblocker_notification')
+    )
 
     # Without field group it will look weird when context is an Article.
     field_groups = (gocept.form.grouped.RemainingFields(

--- a/core/src/zeit/cms/admin/browser/tests/test_admin.py
+++ b/core/src/zeit/cms/admin/browser/tests/test_admin.py
@@ -47,3 +47,20 @@ class TestAdminMenu(zeit.cms.testing.ZeitCmsBrowserTestCase):
         self.assertEqual(
             datetime(2001, 1, 8, 10, 22, 33, tzinfo=pytz.UTC),
             publish.date_first_released)
+
+    def test_admin_menu_co_has_caching_time_field(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi'
+               '/repository/testcontent')
+        b.getLink('Checkout').click()
+        b.open('http://localhost/++skin++vivi'
+               '/repository/testcontent/@@admin-edit.html')
+        b.getControl('Caching time browser').value = 0
+        b.getControl('Caching time server').value = 60
+        b.getControl('Apply').click()
+        b.getLink('Checkin').click()
+        zope.component.hooks.setSite(self.getRootFolder())
+        content = self.repository['testcontent']
+        caching_time = zeit.cms.content.interfaces.ICachingTime(content)
+        self.assertEqual(0, caching_time.browser)
+        self.assertEqual(60, caching_time.server)

--- a/core/src/zeit/cms/admin/browser/tests/test_admin.py
+++ b/core/src/zeit/cms/admin/browser/tests/test_admin.py
@@ -53,8 +53,7 @@ class TestAdminMenu(zeit.cms.testing.ZeitCmsBrowserTestCase):
         b.open('http://localhost/++skin++vivi'
                '/repository/testcontent')
         b.getLink('Checkout').click()
-        b.open('http://localhost/++skin++vivi'
-               '/repository/testcontent/@@admin-edit.html')
+        b.getLink('Admin').click()
         b.getControl('Caching time browser').value = 0
         b.getControl('Caching time server').value = 60
         b.getControl('Apply').click()

--- a/core/src/zeit/cms/content/cachingtime.py
+++ b/core/src/zeit/cms/content/cachingtime.py
@@ -1,0 +1,17 @@
+import zeit.cms.content.dav
+import zeit.cms.content.interfaces
+import zope.interface
+
+
+@zope.interface.implementer(
+    zeit.cms.content.interfaces.ICachingTime)
+class CachingTime(zeit.cms.content.dav.DAVPropertiesAdapter):
+
+    caching_time_browser = zeit.cms.content.dav.DAVProperty(
+        zeit.cms.content.interfaces.ICachingTime['browser'],
+        zeit.cms.interfaces.IR_NAMESPACE,
+        'caching_time')
+    caching_time_server = zeit.cms.content.dav.DAVProperty(
+        zeit.cms.content.interfaces.ICachingTime['server'],
+        zeit.cms.interfaces.IR_NAMESPACE,
+        'caching_time')

--- a/core/src/zeit/cms/content/cachingtime.py
+++ b/core/src/zeit/cms/content/cachingtime.py
@@ -9,9 +9,9 @@ class CachingTime(zeit.cms.content.dav.DAVPropertiesAdapter):
 
     browser = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['browser'],
-        zeit.cms.interfaces.IR_NAMESPACE,
-        'caching_time')
+        'zeit.web',
+        'browser')
     server = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['server'],
-        zeit.cms.interfaces.IR_NAMESPACE,
-        'caching_time')
+        'zeit.web',
+        'server')

--- a/core/src/zeit/cms/content/cachingtime.py
+++ b/core/src/zeit/cms/content/cachingtime.py
@@ -7,11 +7,11 @@ import zope.interface
     zeit.cms.content.interfaces.ICachingTime)
 class CachingTime(zeit.cms.content.dav.DAVPropertiesAdapter):
 
-    caching_time_browser = zeit.cms.content.dav.DAVProperty(
+    browser = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['browser'],
         zeit.cms.interfaces.IR_NAMESPACE,
         'caching_time')
-    caching_time_server = zeit.cms.content.dav.DAVProperty(
+    server = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['server'],
         zeit.cms.interfaces.IR_NAMESPACE,
         'caching_time')

--- a/core/src/zeit/cms/content/cachingtime.py
+++ b/core/src/zeit/cms/content/cachingtime.py
@@ -9,9 +9,9 @@ class CachingTime(zeit.cms.content.dav.DAVPropertiesAdapter):
 
     browser = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['browser'],
-        'zeit.web',
+        'http://namespaces.zeit.de/CMS/zeit.web',
         'browser')
     server = zeit.cms.content.dav.DAVProperty(
         zeit.cms.content.interfaces.ICachingTime['server'],
-        'zeit.web',
+        'http://namespaces.zeit.de/CMS/zeit.web',
         'server')

--- a/core/src/zeit/cms/content/configure.zcml
+++ b/core/src/zeit/cms/content/configure.zcml
@@ -249,14 +249,14 @@
       permission="zope.View" />
   </class>
 
-  <!-- Server and browser cache ->
+  <!-- Server and browser cache -->
   <class class="zeit.cms.content.cachingtime.CachingTime">
     <require
-      interface="zeit.cms.interfaces.ICachingTime"
+      interface="zeit.cms.content.interfaces.ICachingTime"
       permission="zope.View" />
     <require
-      set_schema="zeit.cms.interfaces.ICachingTime"
-      permission="zeit.cms.browser.form.EditForm" />
-  </class>-
+      set_schema="zeit.cms.content.interfaces.ICachingTime"
+      permission="zope.View" />
+  </class>
 
 </configure>

--- a/core/src/zeit/cms/content/configure.zcml
+++ b/core/src/zeit/cms/content/configure.zcml
@@ -249,4 +249,14 @@
       permission="zope.View" />
   </class>
 
+  <!-- Server and browser cache ->
+  <class class="zeit.cms.content.cachingtime.CachingTime">
+    <require
+      interface="zeit.cms.interfaces.ICachingTime"
+      permission="zope.View" />
+    <require
+      set_schema="zeit.cms.interfaces.ICachingTime"
+      permission="zeit.cms.browser.form.EditForm" />
+  </class>-
+
 </configure>

--- a/core/src/zeit/cms/content/configure.zcml
+++ b/core/src/zeit/cms/content/configure.zcml
@@ -253,10 +253,10 @@
   <class class="zeit.cms.content.cachingtime.CachingTime">
     <require
       interface="zeit.cms.content.interfaces.ICachingTime"
-      permission="zope.View" />
+      permission="zeit.EditContent" />
     <require
       set_schema="zeit.cms.content.interfaces.ICachingTime"
-      permission="zope.View" />
+      permission="zeit.EditContent" />
   </class>
 
 </configure>

--- a/core/src/zeit/cms/content/configure.zcml
+++ b/core/src/zeit/cms/content/configure.zcml
@@ -253,7 +253,7 @@
   <class class="zeit.cms.content.cachingtime.CachingTime">
     <require
       interface="zeit.cms.content.interfaces.ICachingTime"
-      permission="zeit.EditContent" />
+      permission="zope.View" />
     <require
       set_schema="zeit.cms.content.interfaces.ICachingTime"
       permission="zeit.EditContent" />

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -58,7 +58,7 @@ class ReferenceField(zope.schema.Choice):
         if self._init_field:
             return
         # skip immediate superclass, since that's what we want to change
-        super()._validate(value)
+        super(zope.schema.Choice, self)._validate(value)
         if value.target not in self.vocabulary:
             raise zope.schema.interfaces.ConstraintNotSatisfied(value)
 
@@ -114,7 +114,7 @@ class ICommonMetadata(zope.interface.Interface):
         title=_("Print ressort"),
         readonly=True,
         required=False,
-        default='n/a')
+        default=u'n/a')
 
     # not required since e.g. Agenturmeldungen don't have an author, only
     # a copyright notice
@@ -132,8 +132,8 @@ class ICommonMetadata(zope.interface.Interface):
         title=_("Authors (freetext)"),
         value_type=zope.schema.TextLine(),
         required=False,
-        default=('',),
-        description=_('overwritten if any non-freetext authors are set'))
+        default=(u'',),
+        description=_(u'overwritten if any non-freetext authors are set'))
 
     agencies = zope.schema.Tuple(
         title=_("Agencies"),
@@ -143,7 +143,7 @@ class ICommonMetadata(zope.interface.Interface):
 
     access = zope.schema.Choice(
         title=_('Access'),
-        default='free',
+        default=u'free',
         source=zeit.cms.content.sources.ACCESS_SOURCE)
 
     keywords = zeit.cms.tagging.interfaces.Keywords(
@@ -183,13 +183,13 @@ class ICommonMetadata(zope.interface.Interface):
 
     title = zope.schema.Text(
         title=_("Title"),
-        missing_value='')
+        missing_value=u'')
 
     title.setTaggedValue('zeit.cms.charlimit', 70)
 
     subtitle = zope.schema.Text(
         title=_("Subtitle"),
-        missing_value='',
+        missing_value=u'',
         required=False)
 
     subtitle.setTaggedValue('zeit.cms.charlimit', 170)
@@ -205,8 +205,8 @@ class ICommonMetadata(zope.interface.Interface):
         max_length=170)
 
     teaserSupertitle = zope.schema.TextLine(
-        title=_('Teaser kicker'),
-        description=_('Please take care of capitalisation.'),
+        title=_(u'Teaser kicker'),
+        description=_(u'Please take care of capitalisation.'),
         required=False,
         max_length=70)
 
@@ -265,7 +265,7 @@ class ICommonMetadata(zope.interface.Interface):
         # XXX kludgy, we expect a product with this ID to be present in the XML
         # file. We only need to set an ID here, since to read the product we'll
         # ask the source anyway.
-        default=zeit.cms.content.sources.Product('ZEDE'),
+        default=zeit.cms.content.sources.Product(u'ZEDE'),
         source=zeit.cms.content.sources.PRODUCT_SOURCE)
 
     overscrolling = zope.schema.Bool(

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -734,7 +734,12 @@ class ISkipDefaultChannel(zope.interface.Interface):
 class ICachingTime(zope.interface.Interface):
     """Cacheing time interface for """
 
-    caching_time_fastly = zope.schema.Int(
-        title=_("Caching Time Fastly"),
-        min=60,
+    browser = zope.schema.Int(
+        title=_("Caching time browser"),
+        min=0,
+        max=3600)
+
+    server = zope.schema.Int(
+        title=_("Caching time server"),
+        min=0,
         max=3600)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -58,7 +58,7 @@ class ReferenceField(zope.schema.Choice):
         if self._init_field:
             return
         # skip immediate superclass, since that's what we want to change
-        super(zope.schema.Choice, self)._validate(value)
+        super()._validate(value)
         if value.target not in self.vocabulary:
             raise zope.schema.interfaces.ConstraintNotSatisfied(value)
 
@@ -114,7 +114,7 @@ class ICommonMetadata(zope.interface.Interface):
         title=_("Print ressort"),
         readonly=True,
         required=False,
-        default=u'n/a')
+        default='n/a')
 
     # not required since e.g. Agenturmeldungen don't have an author, only
     # a copyright notice
@@ -132,8 +132,8 @@ class ICommonMetadata(zope.interface.Interface):
         title=_("Authors (freetext)"),
         value_type=zope.schema.TextLine(),
         required=False,
-        default=(u'',),
-        description=_(u'overwritten if any non-freetext authors are set'))
+        default=('',),
+        description=_('overwritten if any non-freetext authors are set'))
 
     agencies = zope.schema.Tuple(
         title=_("Agencies"),
@@ -143,7 +143,7 @@ class ICommonMetadata(zope.interface.Interface):
 
     access = zope.schema.Choice(
         title=_('Access'),
-        default=u'free',
+        default='free',
         source=zeit.cms.content.sources.ACCESS_SOURCE)
 
     keywords = zeit.cms.tagging.interfaces.Keywords(
@@ -183,13 +183,13 @@ class ICommonMetadata(zope.interface.Interface):
 
     title = zope.schema.Text(
         title=_("Title"),
-        missing_value=u'')
+        missing_value='')
 
     title.setTaggedValue('zeit.cms.charlimit', 70)
 
     subtitle = zope.schema.Text(
         title=_("Subtitle"),
-        missing_value=u'',
+        missing_value='',
         required=False)
 
     subtitle.setTaggedValue('zeit.cms.charlimit', 170)
@@ -205,8 +205,8 @@ class ICommonMetadata(zope.interface.Interface):
         max_length=170)
 
     teaserSupertitle = zope.schema.TextLine(
-        title=_(u'Teaser kicker'),
-        description=_(u'Please take care of capitalisation.'),
+        title=_('Teaser kicker'),
+        description=_('Please take care of capitalisation.'),
         required=False,
         max_length=70)
 
@@ -265,7 +265,7 @@ class ICommonMetadata(zope.interface.Interface):
         # XXX kludgy, we expect a product with this ID to be present in the XML
         # file. We only need to set an ID here, since to read the product we'll
         # ask the source anyway.
-        default=zeit.cms.content.sources.Product(u'ZEDE'),
+        default=zeit.cms.content.sources.Product('ZEDE'),
         source=zeit.cms.content.sources.PRODUCT_SOURCE)
 
     overscrolling = zope.schema.Bool(
@@ -734,7 +734,7 @@ class ISkipDefaultChannel(zope.interface.Interface):
 class ICachingTime(zope.interface.Interface):
     """Cacheing time interface for """
 
-    caching_time = zope.schema.Int(
-        title=_("Caching Time"),
+    caching_time_fastly = zope.schema.Int(
+        title=_("Caching Time Fastly"),
         min=60,
         max=3600)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -737,9 +737,11 @@ class ICachingTime(zope.interface.Interface):
     browser = zope.schema.Int(
         title=_("Caching time browser"),
         min=0,
-        max=3600)
+        max=3600,
+        required=False)
 
     server = zope.schema.Int(
         title=_("Caching time server"),
         min=0,
-        max=3600)
+        max=3600,
+        required=False)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -729,3 +729,12 @@ class IAddableContent(zope.interface.interfaces.IInterface):
 class ISkipDefaultChannel(zope.interface.Interface):
     """Marker interface to opt out of setting default
     ICommonMetadata.channels according to ressort/sub_ressort."""
+
+
+class ICachingTime(zope.interface.Interface):
+    """Cacheing time interface for """
+
+    caching_time = zope.schema.Int(
+        title=_("Caching Time"),
+        min=60,
+        max=3600)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -732,7 +732,10 @@ class ISkipDefaultChannel(zope.interface.Interface):
 
 
 class ICachingTime(zope.interface.Interface):
-    """Cacheing time interface for """
+    """
+    Caching time interface for adjusting browser and server caching time in
+    zeit.web. For admins only.
+    """
 
     browser = zope.schema.Int(
         title=_("Caching time browser"),

--- a/core/src/zeit/content/cp/browser/form.py
+++ b/core/src/zeit/content/cp/browser/form.py
@@ -11,7 +11,7 @@ import zope.formlib.form
 base = zeit.cms.content.browser.form.CommonMetadataFormBase
 
 
-class FormBase(object):
+class FormBase:
 
     form_fields = (
         zope.formlib.form.FormFields(

--- a/core/src/zeit/content/cp/browser/form.py
+++ b/core/src/zeit/content/cp/browser/form.py
@@ -27,7 +27,7 @@ class FormBase:
             'topiclink_label_2', 'topiclink_url_2',
             'topiclink_label_3', 'topiclink_url_3',
             'og_title', 'og_description', 'og_image',
-            'keywords', 'caching_time'))
+            'keywords'))
 
     text_fields = gocept.form.grouped.Fields(
         _("Texts"),

--- a/core/src/zeit/content/cp/browser/form.py
+++ b/core/src/zeit/content/cp/browser/form.py
@@ -27,7 +27,7 @@ class FormBase(object):
             'topiclink_label_2', 'topiclink_url_2',
             'topiclink_label_3', 'topiclink_url_3',
             'og_title', 'og_description', 'og_image',
-            'keywords'))
+            'keywords', 'caching_time'))
 
     text_fields = gocept.form.grouped.Fields(
         _("Texts"),

--- a/core/src/zeit/content/cp/centerpage.py
+++ b/core/src/zeit/content/cp/centerpage.py
@@ -120,10 +120,6 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
         '.head.og_meta.og_image',
         zeit.content.cp.interfaces.ICenterPage['og_image'])
 
-    caching_time = zeit.cms.content.property.ObjectPathProperty(
-        '.head.caching_time',
-        zeit.content.cp.interfaces.ICenterPage['caching_time'])
-
     def updateMetadata(self, content):
         # Note that this method is a shortcut using XPath to query instead of
         # instantiating all blocks and their content objects to find the

--- a/core/src/zeit/content/cp/centerpage.py
+++ b/core/src/zeit/content/cp/centerpage.py
@@ -135,10 +135,10 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
         # Support renaming (see doc/implementation/move.txt).
         possible_ids = set((
             content.uniqueId,) + IRenameInfo(content).previous_uniqueIds)
-        unique_ids = u' or '.join(['@href=%s' % xml.sax.saxutils.quoteattr(x)
+        unique_ids = ' or '.join(['@href=%s' % xml.sax.saxutils.quoteattr(x)
                                   for x in possible_ids])
         # @uniqueId is for free teasers only, and those can't be renamed.
-        query = u'//block[@uniqueId={id} or {unique_ids}]'.format(
+        query = '//block[@uniqueId={id} or {unique_ids}]'.format(
             id=xml.sax.saxutils.quoteattr(content.uniqueId),
             unique_ids=unique_ids)
         for entry in self.xml.xpath(query):
@@ -237,7 +237,7 @@ class Body(zeit.edit.container.Base,
         if key in ['lead', 'informatives']:
             # backwards compatiblity for tests
             return self['feature'][key]
-        return super(Body, self).__getitem__(key)
+        return super().__getitem__(key)
 
 
 @grok.adapter(zeit.content.cp.interfaces.ICenterPage)

--- a/core/src/zeit/content/cp/centerpage.py
+++ b/core/src/zeit/content/cp/centerpage.py
@@ -120,6 +120,10 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
         '.head.og_meta.og_image',
         zeit.content.cp.interfaces.ICenterPage['og_image'])
 
+    caching_time = zeit.cms.content.property.ObjectPathProperty(
+        '.head.caching_time',
+        zeit.content.cp.interfaces.ICenterPage['caching_time'])
+
     def updateMetadata(self, content):
         # Note that this method is a shortcut using XPath to query instead of
         # instantiating all blocks and their content objects to find the

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -73,7 +73,7 @@ class ICenterPage(zeit.cms.content.interfaces.ICommonMetadata,
     type = zope.schema.Choice(
         title=_('CP type'),
         source=zeit.content.cp.source.CPTypeSource(),
-        default=u'centerpage')
+        default='centerpage')
 
     caching_time = zope.schema.TextLine(
         title=_('Caching time'),
@@ -292,7 +292,7 @@ class AreaColorThemesSource(zeit.cms.content.sources.XMLSource):
 
     def isAvailable(self, node, context):
         cp = zeit.content.cp.interfaces.ICenterPage(context, None)
-        return super(AreaColorThemesSource, self).isAvailable(node, cp)
+        return super().isAvailable(node, cp)
 
 
 AREA_COLOR_THEMES_SOURCE = AreaColorThemesSource()
@@ -315,7 +315,7 @@ class IReadArea(
     kind = zope.schema.TextLine(
         title=_("Kind"),
         description=_("Used internally for rendering on Friedbert"),
-        default=u'solo')
+        default='solo')
 
     kind_title = zope.interface.Attribute(
         "Translation of kind to a human friendly information")
@@ -509,7 +509,7 @@ class IntChoice(zope.schema.Choice):
             value = int(value)
         except Exception:
             pass
-        return super(IntChoice, self).fromUnicode(value)
+        return super().fromUnicode(value)
 
 
 class IReadTeaserBlock(IBlock, zeit.cms.syndication.interfaces.IReadFeed):
@@ -605,7 +605,7 @@ class ITeaser(zeit.cms.content.interfaces.ICommonMetadata,
     """A standalone teaser object which references the article."""
 
     original_content = zope.schema.Choice(
-        title=u'The referenced article.',
+        title='The referenced article.',
         source=zeit.cms.content.contentsource.cmsContentSource)
 
 
@@ -678,16 +678,16 @@ class CardstackColorSource(zeit.cms.content.sources.SimpleDictSource):
 
     values = collections.OrderedDict((
         (color, color) for color in [
-            u'#D8D8D8',
-            u'#5E534F',
-            u'#E4DED8',
-            u'#69696C',
-            u'#FF7783',
-            u'#7C0E14',
-            u'#6FA6B9',
-            u'#085064',
-            u'#57C494',
-            u'#1E6847']
+            '#D8D8D8',
+            '#5E534F',
+            '#E4DED8',
+            '#69696C',
+            '#FF7783',
+            '#7C0E14',
+            '#6FA6B9',
+            '#085064',
+            '#57C494',
+            '#1E6847']
     ))
 
 

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -75,6 +75,10 @@ class ICenterPage(zeit.cms.content.interfaces.ICommonMetadata,
         source=zeit.content.cp.source.CPTypeSource(),
         default=u'centerpage')
 
+    caching_time = zope.schema.TextLine(
+        title=_('Caching time'),
+        required=False)
+
     header_image = zope.schema.Choice(
         title=_('Header image'),
         required=False,

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -75,12 +75,6 @@ class ICenterPage(zeit.cms.content.interfaces.ICommonMetadata,
         source=zeit.content.cp.source.CPTypeSource(),
         default='centerpage')
 
-    caching_time = zope.schema.Int(
-        title=_('Caching time'),
-        required=False,
-        min=60,
-        max=3600)
-
     header_image = zope.schema.Choice(
         title=_('Header image'),
         required=False,

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -75,9 +75,11 @@ class ICenterPage(zeit.cms.content.interfaces.ICommonMetadata,
         source=zeit.content.cp.source.CPTypeSource(),
         default='centerpage')
 
-    caching_time = zope.schema.TextLine(
+    caching_time = zope.schema.Int(
         title=_('Caching time'),
-        required=False)
+        required=False,
+        min=60,
+        max=3600)
 
     header_image = zope.schema.Choice(
         title=_('Header image'),


### PR DESCRIPTION
Um Cachingzeiten von Centerpages in Zukunft seitenspezifisch anpassen zu können, wird hier das Attribute `caching_time` analog zur `varnish_caching_time` in zeit.web eingeführt. Dieses Feature wird zunächst in Zappi verbaut, damit relative Zeitangaben von Teasern (vor 3 Minuten) nicht vom Cache ad absurdum geführt werden.