### PR TITLE
ZON-6377: Fixes that fill_color=None does not render image

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,8 @@ vivi.core changes
 4.50.7 (unreleased)
 -------------------
 
-ZON-6377: Fixes that fill_color=None
+- ZON-6377: Fix rendering of teaser images with `fill_color=None` parameters
+
 
 4.50.6 (2021-04-21)
 -------------------

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,8 +4,7 @@ vivi.core changes
 4.50.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+ZON-6377: Fixes that fill_color=None
 
 4.50.6 (2021-04-21)
 -------------------

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -171,7 +171,7 @@ class ImageGroupBase(object):
         else:
             url = u'{path}/{name}__{width}x{height}'.format(
                 path=path, name=name, width=width, height=height)
-        if fill_color is not None:
+        if fill_color not in [None, 'None']:
             url += u'__{fill}'.format(fill=fill_color)
         return url
 
@@ -238,6 +238,8 @@ class VariantTraverser(object):
                 raise KeyError(path)
         if result['variant'] is None:
             raise KeyError(url)
+        if result['fill'] == 'None':
+            result['fill'] = None
         result['url'] = path
         return result
 

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -128,6 +128,14 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
             '/group/square__200x200__0000ff', self.group.variant_url(
                 'square', 200, 200, '0000ff'))
 
+        self.assertEqual(
+            '/group/square__300x300', self.group.variant_url(
+                'square', 300, 300, 'None'))
+
+        self.assertEqual(
+            '/group/square__400x400', self.group.variant_url(
+                'square', 400, 400, None))
+
     def test_dav_content_with_same_name_is_preferred(self):
         self.assertEqual((1536, 1536), self.traverse('square').getImageSize())
         self.group['square'] = zeit.content.image.testing.create_local_image(
@@ -255,6 +263,13 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
         assert result['size'] == [300, 160]
         assert result['scale'] == 3.0
         assert result['fill'] == '000000'
+        assert result['viewport'] is None
+
+    def test_parse_fill_None_should_return_NoneType(self):
+        result = self.traverser.parse_url('cinema__200x80__scale_2.25__0000ff?scale=3.0&width=300&height=160&fill=None')
+        assert result['size'] == [300, 160]
+        assert result['scale'] == 3.0
+        assert result['fill'] == None
         assert result['viewport'] is None
 
     def test_parse_url_variant_params_only(self):

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -81,7 +81,7 @@ class ImageTransform(object):
                 variant.sharpness)
 
         # Optionally fill the background of transparent images
-        if fill_color is not None and self._color_mode == 'RGBA':
+        if fill_color not in [None, 'None'] and self._color_mode == 'RGBA':
             fill_color = PIL.ImageColor.getrgb('#' + fill_color)
             opaque = PIL.Image.new('RGB', image.size, fill_color)
             opaque.paste(image, (0, 0), image)


### PR DESCRIPTION
Behebt den Fehler das Bildergruppen nicht gerendert werden, wenn die Hintergrundfarbe auf 'None' steht.
Wenn eine Url den Parameter _'...&fill=None'_ beinhaltet, ist dieser Wert ein _string_.
Es wurde beim setzen der Hintergrundfarbe aber nur auf _NoneType_ geprüft.
Dieser PR prüft ebenso, ob dieser Wert ein 'None'-string ist.

Siehe [ZON-6377](https://zeit-online.atlassian.net/browse/ZON-6377).