### PR TITLE
ZON-6655: Rework topicbox

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.52.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-6655: Fix related API, support multiple topicboxes per article
 
 
 4.52.2 (2021-05-18)

--- a/core/src/zeit/content/article/edit/browser/configure.zcml
+++ b/core/src/zeit/content/article/edit/browser/configure.zcml
@@ -847,6 +847,10 @@
     <implements interface="zeit.edit.interfaces.IFoldable" />
   </class>
 
+  <class class="..topicbox.Topicbox">
+    <implements interface="zeit.edit.interfaces.IFoldable" />
+  </class>
+
   <browser:page
     for="*"
     name="double-quote-characters"

--- a/core/src/zeit/content/article/edit/browser/resources.py
+++ b/core/src/zeit/content/article/edit/browser/resources.py
@@ -6,7 +6,6 @@ import zeit.edit.browser.resources
 lib = Library('zeit.content.article', 'resources')
 
 Resource('editor.css')
-Resource('topicbox.css')
 
 Resource('replace.js', depends=[
     zeit.cms.browser.resources.base,

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.css
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.css
@@ -1,8 +1,0 @@
-/*.type-article #edit-form-article-content .fieldname-elasticsearch_raw_query,
-.type-article #edit-form-article-content .fieldname-elasticsearch_raw_order,
-.type-article #edit-form-article-content .fieldname-referenced_cp,
-.type-article #edit-form-article-content .fieldname-referenced_topicpage,
-.type-article #edit-form-article-content .fieldname-topicpage_filter,
-.type-article #edit-form-article-content .fieldname-preconfigured_query {
-    display: none;
-}*/

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.css
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.css
@@ -1,8 +1,8 @@
-.type-article #edit-form-article-content .fieldname-elasticsearch_raw_query,
+/*.type-article #edit-form-article-content .fieldname-elasticsearch_raw_query,
 .type-article #edit-form-article-content .fieldname-elasticsearch_raw_order,
 .type-article #edit-form-article-content .fieldname-referenced_cp,
 .type-article #edit-form-article-content .fieldname-referenced_topicpage,
 .type-article #edit-form-article-content .fieldname-topicpage_filter,
 .type-article #edit-form-article-content .fieldname-preconfigured_query {
     display: none;
-}
+}*/

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -10,7 +10,7 @@ function getFieldClassNames() {
         'elasticsearch_raw_query': 'field fieldname-elasticsearch_raw_query fieldtype-text',
         'elasticsearch_raw_order': 'field fieldname-elasticsearch_raw_order fieldtype-text',
         'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text',
-    }
+    };
 }
 
 function getAllTopicboxIds() {
@@ -53,7 +53,7 @@ function getTopicboxFieldSetById(topicboxId) {
 }
 
 function hideShowElementsByAutomaticTypeValue(topicboxId) {
-    var topicboxFieldSet = getTopicboxFieldSetById(topicboxId)
+    var topicboxFieldSet = getTopicboxFieldSetById(topicboxId);
     var fieldClassNames = getFieldClassNames();
     var currentAutomaticTypeValue = getAutomaticTypeTextByTopicboxId(topicboxId);
 

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -1,103 +1,146 @@
-function display_elements(selected_automatic_type) {
+function getFieldClassNames() {
+    return {
+        'automatic_type': 'field fieldname-automatic_type fieldtype-text',
+        'first_reference': 'field fieldname-first_reference fieldtype-text',
+        'second_reference': 'field fieldname-second_reference fieldtype-text',
+        'third_reference': 'field fieldname-third_reference fieldtype-text',
+        'referenced_cp': 'field fieldname-referenced_cp fieldtype-text',
+        'referenced_topicpage': 'field fieldname-referenced_topicpage fieldtype-text',
+        'topicpage_filter': 'field fieldname-topicpage_filter fieldtype-text',
+        'elasticsearch_raw_query': 'field fieldname-elasticsearch_raw_query fieldtype-text',
+        'elasticsearch_raw_order': 'field fieldname-elasticsearch_raw_order fieldtype-text',
+        'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text',
+    }
+}
 
-    var cssClass = '.type-article #edit-form-article-content .fieldname-';
-    var cssClasses = [];
+function getAllTopicboxIds() {
+    var topicbox_ids = [];
 
-    var classes = [
-        'referenced_cp',
-        'referenced_topicpage',
-        'topicpage_filter',
-        'elasticsearch_raw_query',
-        'elasticsearch_raw_order',
-        'preconfigured_query',
-    ];
+    document.querySelectorAll('.type-topicbox').forEach((topicbox) => {
+        topicbox_ids.push(topicbox.id);
+    });
 
-    selected_automatic_type = selected_automatic_type.toLowerCase();
+    return topicbox_ids;
+}
 
-    switch (selected_automatic_type) {
+function getAutomaticTypeTextByTopicboxId(topicboxId) {
+    var automaticTypeElement = document.getElementById(`topicbox.${topicboxId}.automatic_type`);
+
+    if (automaticTypeElement !== null) {
+        return automaticTypeElement.selectedOptions[0].text;
+    }
+    return null;
+}
+
+function displayElements(event) {
+    // 'fragment-ready' is called, if the document is reloading
+    // 'changed' is called, if a automatic_type value is changed
+    var topicboxIds = getAllTopicboxIds();
+    if (event.type === 'fragment-ready') {
+        topicboxIds.forEach((topicboxId) => {
+            hideShowElementsByAutomaticTypeValue(topicboxId);
+        });
+    } else if (event.type === 'change') {
+        var topicboxId = (event.target.id.replace('topicbox.', '').replace('.automatic_type', ''));
+        hideShowElementsByAutomaticTypeValue(topicboxId);
+    } else {
+        console.log(`unhandled event: ${event.type}`);
+    }
+}
+
+function getTopicboxFieldSetById(topicboxId) {
+    return document.getElementById(`form-topicbox.${topicboxId}`);
+}
+
+function hideShowElementsByAutomaticTypeValue(topicboxId) {
+    var topicboxFieldSet = getTopicboxFieldSetById(topicboxId)
+    var fieldClassNames = getFieldClassNames();
+    var currentAutomaticTypeValue = getAutomaticTypeTextByTopicboxId(topicboxId);
+
+    if (currentAutomaticTypeValue === null) {
+        return;
+    }
+
+    // Hide all except automatic_type
+    Object.keys(fieldClassNames).filter((element) => {
+        return element.indexOf('automatic_type') == -1;
+    }).forEach((element) => {
+        hideElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+    });
+
+    switch(currentAutomaticTypeValue.toLowerCase()) {
         case 'klassisch':
-            hide_references(false);
+            Object.keys(fieldClassNames).filter((element) => {
+                return [
+                    'first_reference',
+                    'second_reference',
+                    'third_reference'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         case 'centerpage':
-            cssClasses.push('referenced_cp');
+            Object.keys(fieldClassNames).filter((element) => {
+                return ['referenced_cp'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         case 'themenseite':
-            cssClasses.push('referenced_topicpage');
-            cssClasses.push('topicpage_filter');
+            Object.keys(fieldClassNames).filter((element) => {
+                return [
+                    'referenced_topicpage',
+                    'topicpage_filter'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         case 'es-query':
-            cssClasses.push('elasticsearch_raw_query');
-            cssClasses.push('elasticsearch_raw_order');
+            Object.keys(fieldClassNames).filter((element) => {
+                return [
+                    'elasticsearch_raw_query',
+                    'elasticsearch_raw_order'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         case 'related-api':
-            cssClasses.push('topicpage_filter');
+            Object.keys(fieldClassNames).filter((element) => {
+                return ['topicpage_filter'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         case 'konfigurationsdatei':
-            cssClasses.push('preconfigured_query');
+            Object.keys(fieldClassNames).filter((element) => {
+                return ['preconfigured_query'].includes(element);
+            }).forEach((element) => {
+                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+            });
             break;
         default:
             break;
     }
-
-    if (selected_automatic_type != 'klassisch') {
-        hide_references(true);
-    }
-
-    classes.forEach((cls) => {
-        var el = document.querySelectorAll(cssClass + cls);
-        if (el.length > 0) {
-            el[0].style.display = 'none';
-        }
-    });
-
-    cssClasses.forEach((cls) => {
-        var el = document.querySelectorAll(cssClass + cls);
-        if (el.length > 0) {
-            el[0].style.display = 'block';
-        }
-    });
 }
 
-function hide_references(hide) {
-    var cssClassReferences = "[class*='fieldname-NAME_reference']";
-    ['first', 'second', 'third'].forEach((ref) => {
-        var reference = document.querySelectorAll(cssClassReferences.replace('NAME', ref));
-        if (reference.length > 0) {
-            reference[0].style.display = hide ? 'none' : 'block';
-        }
-    });
+function hideElementByTopicboxFieldSet(fieldset, className) {
+    fieldset.querySelectorAll(`[class="${className}"]`)[0].style.display = 'none';
 }
 
-function eval_automatic_type(el) {
-    if (el.length > 0) {
-        var sel_val = el[0].selectedOptions[0].text;
-        display_elements(sel_val);
-    }
+function showElementByTopicboxFieldSet(fieldset, className) {
+    fieldset.querySelectorAll(`[class="${className}"]`)[0].style.display = 'block';
 }
 
 (function ($) {
-    $(document).bind('fragment-ready', function(e) {
-        var current_automatic_type_value = document.querySelectorAll('[id$=automatic_type]');
-            if (current_automatic_type_value.length > 0) {
-                current_automatic_type_value.forEach((el) => {
-                    if(el.id.startsWith('topicbox.id') && el.id.endsWith('automatic_type')) {
-                        var val = el.selectedOptions[0].text;
-                    display_elements(val);
-                    return;
-                }
-            });
-        }
-        return;
+    $(document).bind('fragment-ready', function(event) {
+        getAllTopicboxIds().forEach(() => {
+            displayElements(event);
+        });
     });
 
-    $(document).bind('change', function(e) {
-        if (e.target && e.target.id.indexOf('automatic_type') > -1) {
-            var val = document.getElementById(e.target.id);
-            if (val == undefined) {
-                return;
-            }
-            val = val.selectedOptions[0].text;
-            display_elements(val);
+    $(document).bind('change', function(event) {
+        if (event.target && event.target.id.indexOf('automatic_type') > -1) {
+            displayElements(event);
         }
     });
  }(jQuery));

--- a/core/src/zeit/content/article/edit/browser/tests/test_topicbox.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_topicbox.py
@@ -109,8 +109,9 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
         b.open('@@edit-%s?show_form=1' % self.block_type)
         self.assertEqual('ES-Foo', b.getControl('Title').value)
         self.assertEqual('ES-Bar', b.getControl('Supertitle').value)
-        self.assertEqual([
-            'elasticsearch-query'], b.getControl('Automatic type').displayValue)
+        self.assertEqual(
+            ['elasticsearch-query'],
+            b.getControl('Automatic type').displayValue)
         self.assertEqual('https://queries-es.com', b.getControl('Link').value)
         self.assertEqual('ES-Baz', b.getControl('Linktext').value)
         self.assertEqual(
@@ -127,7 +128,7 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
         b.getControl('Link').value = 'https://related.com'
         b.getControl('Linktext').value = 'Related-Baz'
         b.getControl('Automatic type').displayValue = ['related-api']
-        b.getControl('Preconfigured-Query').displayValue = ['(nothing selected)']
+        b.getControl('Filter').displayValue = ['(nothing selected)']
         b.getControl('Topicpage filter').value = 'videos'
         b.getControl('Apply').click()
         b.open('@@edit-%s?show_form=1' % self.block_type)
@@ -138,7 +139,7 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
         self.assertEqual('https://related.com', b.getControl('Link').value)
         self.assertEqual('Related-Baz', b.getControl('Linktext').value)
         self.assertEqual(
-            ['(nothing selected)'], b.getControl('Preconfigured-Query').displayValue)
+            ['(nothing selected)'], b.getControl('Filter').displayValue)
         self.assertEqual(['videos'], b.getControl('Topicpage filter').value)
 
     def test_topicbox_source_config_form_saves_values(self):
@@ -151,14 +152,15 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
         b.getControl('Link').value = 'https://config.com'
         b.getControl('Linktext').value = 'Config-Baz'
         b.getControl('Automatic type').displayValue = ['preconfigured-query']
-        b.getControl('Preconfigured-Query').displayValue = ['(nothing selected)']
+        b.getControl('Filter').displayValue = ['(nothing selected)']
         b.getControl('Apply').click()
         b.open('@@edit-%s?show_form=1' % self.block_type)
         self.assertEqual('Config-Foo', b.getControl('Title').value)
         self.assertEqual('Config-Bar', b.getControl('Supertitle').value)
-        self.assertEqual([
-            'preconfigured-query'], b.getControl('Automatic type').displayValue)
+        self.assertEqual(
+            ['preconfigured-query'],
+            b.getControl('Automatic type').displayValue)
         self.assertEqual('https://config.com', b.getControl('Link').value)
         self.assertEqual('Config-Baz', b.getControl('Linktext').value)
         self.assertEqual(
-            ['(nothing selected)'], b.getControl('Preconfigured-Query').displayValue)
+            ['(nothing selected)'], b.getControl('Filter').displayValue)

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -665,7 +665,7 @@ class ITopicbox(IBlock,
         required=False)
 
     preconfigured_query = zope.schema.Choice(
-        title=_('Preconfigured-Query'),
+        title=_('Filter'),
         source=PreconfiguredQuerySource(),
         required=False)
 

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -432,14 +432,6 @@ class TMSRelatedApiQuery(TMSContentQuery):
     # additional teasers to replace previously filtered-out duplicates.
     hide_dupes = False
 
-    def __init__(self, context):
-        super().__init__(context)
-        self.filter_id = None
-        try:
-            self.filter_id = self.context.topicpage_filter
-        except Exception:
-            pass
-
     def _get_documents(self, start, rows):
         tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
         try:

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -435,16 +435,13 @@ class TMSRelatedApiQuery(TMSContentQuery):
     def _get_documents(self, start, rows):
         tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
         try:
-            current_article = zeit.content.article.interfaces.IArticle(
-                self.context)
-            uuid = ContentUUID(current_article)
+            content = zeit.cms.interfaces.ICMSContent(self)
             response = tms.get_related_documents(
-                uuid=uuid.id, filtername=self.filter_id, rows=rows)
+                content, filter=self.filter_id, rows=rows)
         except Exception as e:
             if e.status == 404:
                 log.warning(
-                    'TMSRelatedAPI error. No document with id %s',
-                    uuid.id)
+                    'TMS related API did not find %s', self.context.uniqueId)
             else:
                 log.warning(
                     'Error during TMSRelatedAPI for %s',

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -275,7 +275,7 @@ class TMSContentQuery(ContentQuery):
         """Extension point for zeit.web to do pagination and de-duping."""
 
         cache = content_cache(self.context.__parent__, 'topic_queries')
-        rows = self.context.count
+        rows = self._teaser_count + 5
         key = (self.topicpage, self.filter_id, start)
         if key in cache:
             response, start, _ = cache[key]
@@ -456,6 +456,15 @@ class TMSRelatedApiQuery(TMSContentQuery):
             return iter([]), 0
         else:
             return iter(response), response.hits
+
+
+class ArticleTMSRelatedApiQuery(TMSRelatedApiQuery):
+
+    grok.context(zeit.content.article.edit.interfaces.ITopicbox)
+
+    @property
+    def _teaser_count(self):
+        return self.context.count
 
 
 class PreconfiguredQuery(ElasticsearchContentQuery):

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -275,7 +275,7 @@ class TMSContentQuery(ContentQuery):
         """Extension point for zeit.web to do pagination and de-duping."""
 
         cache = content_cache(self.context.__parent__, 'topic_queries')
-        rows = self._teaser_count + 5  # total teasers + some spares
+        rows = self.context.count
         key = (self.topicpage, self.filter_id, start)
         if key in cache:
             response, start, _ = cache[key]
@@ -442,7 +442,7 @@ class TMSRelatedApiQuery(TMSContentQuery):
             uuid = ContentUUID(current_article)
             response = tms.get_related_documents(
                 uuid=uuid.id,
-                rows=self.context.teaser_amount,
+                rows=self.context.count,
                 filtername=self.filter_id)
         except Exception as e:
             if e.status == 404:
@@ -453,9 +453,9 @@ class TMSRelatedApiQuery(TMSContentQuery):
                 log.warning(
                     'Error during TMSRelatedAPI for %s',
                     self.context.uniqueId, exc_info=True)
-            return iter([])
+            return iter([]), 0
         else:
-            return iter(response)
+            return iter(response), response.hits
 
 
 class PreconfiguredQuery(ElasticsearchContentQuery):

--- a/core/src/zeit/retresco/connection.py
+++ b/core/src/zeit/retresco/connection.py
@@ -103,8 +103,9 @@ class TMS(object):
     def get_related_documents(self, uuid, rows=15, filtername=None):
         params = {'rows': rows}
         url = 'GET /content/{}/relateds'.format(uuid)
-        if filter:
+        if filtername:
             url = url + '?filter={}'.format(filtername)
+
         response = self._request(url, params=params)
         result = zeit.cms.interfaces.Result(response['docs'])
         result.hits = len(response['docs'])

--- a/core/src/zeit/retresco/connection.py
+++ b/core/src/zeit/retresco/connection.py
@@ -100,13 +100,14 @@ class TMS(object):
         result.hits = response['num_found']
         return result
 
-    def get_related_documents(self, uuid, rows=15, filtername=None):
+    def get_related_documents(self, content, rows=15, filter=None):
+        uuid = zeit.cms.content.interfaces.IUUID(content).id
         params = {'rows': rows}
-        url = 'GET /content/{}/relateds'.format(uuid)
-        if filtername:
-            url = url + '?filter={}'.format(filtername)
+        if filter:
+            params['filter'] = filter
 
-        response = self._request(url, params=params)
+        response = self._request(
+            'GET /content/{}/relateds'.format(uuid), params=params)
         result = zeit.cms.interfaces.Result(response['docs'])
         result.hits = len(response['docs'])
         return result

--- a/core/src/zeit/retresco/interfaces.py
+++ b/core/src/zeit/retresco/interfaces.py
@@ -116,7 +116,7 @@ class ITMS(zope.interface.Interface):
         already published content.
         """
 
-    def get_related_documents(uuid, rows=15, filtername=None):
+    def get_related_documents(content, rows=15, filter=None):
         """Returns a list of documents that relates to the given uuid
         and filtered by the filtername.
         """


### PR DESCRIPTION
- Topicboxen einklappbar
- Related-API repariert
- Mehrere Topicboxen können in einem Artikel verwendet werden
- Naming: 'Konfigurationsdatei'-Label in 'Filter' geändert