### PR TITLE
BEM-54: Improve Error-Logging for not playable videos

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.52.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BEM-54: Improve Error-Logging for not playable videos
 
 
 4.52.2 (2021-05-18)

--- a/core/src/zeit/brightcove/connection.py
+++ b/core/src/zeit/brightcove/connection.py
@@ -207,9 +207,21 @@ class PlaybackAPI(object):
         try:
             data.update(self._request('GET /videos/%s' % id))
         except requests.exceptions.RequestException as e:
-            log.warning(
-                'Error while retrieving video %s: %s', id,
-                getattr(e.response, 'text', '<no message>'), exc_info=True)
+            """Error-Code: VIDEO_NOT_PLAYABLE
+
+            The policy key provided does not permit this account or video,
+            or the requested resource is inactive.
+            VIDEO_NOT_PLAYABLE can be returned by single video requests.
+            It indicates that the video does not pass the playable check
+            (ingested, active, in schedule).
+            * API-Error-Reference: <https://apis.support.brightcove.com
+                /playback/references/playback-api-error-reference.html>
+            """
+            if e.response.raw.headers[
+                    'Bcov-Error-Code'] != 'VIDEO_NOT_PLAYABLE':
+                log.warning(
+                    'Error while retrieving video %s: %s', id,
+                    getattr(e.response, 'text', '<no message>'), exc_info=True)
             return data
 
         data['video_still'] = data.get('poster')


### PR DESCRIPTION
Wenn auf ein Video zugegriffen wird, das nicht abspielbar bzw. nicht aktiv ist, soll dazu kein Log geschrieben werden.
Videos die bei Brightcove hochgeladen werden, sind standardmäßig immer "nicht aktiv".
Diese werden erst später manuell auf aktiv gestellt.
Solange diese nicht "active" sind, wird bei Zugriff eine Menge an "VIDEO_NOT_PLAYABLE" - Logs geschrieben.