### PR TITLE
OPS-1852: Markdown blocks must not be empty

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,6 +5,7 @@ vivi.core changes
 -------------------
 
 - MAINT: Use own converter for RecipeArticles
+- OPS-1852: Markdown modules must not be empty
 
 
 4.53.1 (2021-05-31)

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -661,7 +661,7 @@ class IMarkupBlock(IBlock):
     text = zope.schema.Text(
         title=_('Contents'),
         description=_('Use Markdown'),
-        required=False)
+        required=True)
     markdown = zope.interface.Attribute('Text in markdown format')
     alignment = zope.schema.Choice(
         title=_('Alignment'),


### PR DESCRIPTION
### Was ändert sich?
Führt eine Regel ein, die leere Markdown module auf Centerpages verhindert.

### Testen: 
`$ bin/test vivi/core/src/zeit/content/cp/tests/test_rule.py -sk test_markup_block_must_not_be_empty`

### ToDo:
- Regel in staging und production nachziehen