### PR TITLE
FIX: Hide Topicpage sort option when anything else is selected

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.57.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- FIX: Hide Topicpage sort option when anything else is selected
 
 
 4.57.1 (2021-06-30)

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -45,7 +45,6 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
     }
 
     var allAutomaticFields = [
-        'automatic_type',
         'first_reference', 'second_reference', 'third_reference',
         'referenced_cp',
         'referenced_topicpage', 'topicpage_filter', 'topicpage_order',
@@ -54,9 +53,7 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
     ];
 
     // Hide all except automatic_type
-    allAutomaticFields.filter((element) => {
-        return element != 'automatic_type';
-    }).forEach((element) => {
+    allAutomaticFields.forEach((element) => {
         hideElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${element}`);
     });
 

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -69,61 +69,51 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
         hideElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
     });
 
+    var automaticFields = [];
     switch(currentAutomaticTypeValue.toLowerCase()) {
         case 'klassisch':
-            Object.keys(fieldClassNames).filter((element) => {
-                return [
-                    'first_reference',
-                    'second_reference',
-                    'third_reference'].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'first_reference',
+                'second_reference',
+                'third_reference'];
             break;
         case 'centerpage':
-            Object.keys(fieldClassNames).filter((element) => {
-                return ['referenced_cp'].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'referenced_cp'
+            ];
             break;
         case 'themenseite':
-            Object.keys(fieldClassNames).filter((element) => {
-                return [
-                    'referenced_topicpage',
-                    'topicpage_filter',
-                    'topicpage_order'
-                ].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'referenced_topicpage',
+                'topicpage_filter',
+                'topicpage_order'
+            ];
             break;
         case 'es-query':
-            Object.keys(fieldClassNames).filter((element) => {
-                return [
-                    'elasticsearch_raw_query',
-                    'elasticsearch_raw_order'].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'elasticsearch_raw_query',
+                'elasticsearch_raw_order'
+            ];
             break;
         case 'related-api':
-            Object.keys(fieldClassNames).filter((element) => {
-                return ['topicpage_filter'].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'topicpage_filter'
+            ];
             break;
         case 'filter':
-            Object.keys(fieldClassNames).filter((element) => {
-                return ['preconfigured_query'].includes(element);
-            }).forEach((element) => {
-                showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
-            });
+            automaticFields = [
+                'preconfigured_query'
+            ];
             break;
         default:
             break;
     }
+
+    Object.keys(fieldClassNames).filter((element) => {
+        return automaticFields.includes(element);
+    }).forEach((element) => {
+        showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+    });
 }
 
 function hideElementByTopicboxFieldSet(fieldset, className) {

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -10,6 +10,7 @@ function getFieldClassNames() {
         'elasticsearch_raw_query': 'field fieldname-elasticsearch_raw_query fieldtype-text',
         'elasticsearch_raw_order': 'field fieldname-elasticsearch_raw_order fieldtype-text',
         'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text',
+        'topicpage_order': 'field fieldname-topicpage_order required fieldtype-text',
     };
 }
 
@@ -90,7 +91,9 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
             Object.keys(fieldClassNames).filter((element) => {
                 return [
                     'referenced_topicpage',
-                    'topicpage_filter'].includes(element);
+                    'topicpage_filter',
+                    'topicpage_order'
+                ].includes(element);
             }).forEach((element) => {
                 showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
             });

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -1,3 +1,12 @@
+var AUTOMATIC_FIELDS = {
+    'manual': ['first_reference', 'second_reference', 'third_reference'],
+    'centerpage': ['referenced_cp'],
+    'topicpage': ['referenced_topicpage', 'topicpage_filter', 'topicpage_order'],
+    'elasticsearch-query': ['elasticsearch_raw_query', 'elasticsearch_raw_order'],
+    'preconfigured-query': ['preconfigured_query'],
+    'related-api': ['topicpage_filter']
+};
+
 function getAllTopicboxIds() {
     var topicbox_ids = [];
 
@@ -44,63 +53,14 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
         return;
     }
 
-    var allAutomaticFields = [
-        'first_reference', 'second_reference', 'third_reference',
-        'referenced_cp',
-        'referenced_topicpage', 'topicpage_filter', 'topicpage_order',
-        'elasticsearch_raw_query', 'elasticsearch_raw_order',
-        'preconfigured_query'
-    ];
-
-    // Hide all except automatic_type
-    allAutomaticFields.forEach((element) => {
-        hideElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${element}`);
+    Object.values(AUTOMATIC_FIELDS).forEach((fields) => {
+        fields.forEach((field) => {
+            hideElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${field}`);
+        });
     });
 
-    var automaticFields = [];
-    switch(currentAutomaticTypeValue.toLowerCase()) {
-        case 'manual':
-            automaticFields = [
-                'first_reference',
-                'second_reference',
-                'third_reference'];
-            break;
-        case 'centerpage':
-            automaticFields = [
-                'referenced_cp'
-            ];
-            break;
-        case 'topicpage':
-            automaticFields = [
-                'referenced_topicpage',
-                'topicpage_filter',
-                'topicpage_order'
-            ];
-            break;
-        case 'elasticsearch-query':
-            automaticFields = [
-                'elasticsearch_raw_query',
-                'elasticsearch_raw_order'
-            ];
-            break;
-        case 'related-api':
-            automaticFields = [
-                'topicpage_filter'
-            ];
-            break;
-        case 'preconfigured-query':
-            automaticFields = [
-                'preconfigured_query'
-            ];
-            break;
-        default:
-            break;
-    }
-
-    allAutomaticFields.filter((element) => {
-        return automaticFields.includes(element);
-    }).forEach((element) => {
-        showElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${element}`);
+    AUTOMATIC_FIELDS[currentAutomaticTypeValue].forEach((field) => {
+        showElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${field}`);
     });
 }
 

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -1,19 +1,3 @@
-function getFieldClassNames() {
-    return {
-        'automatic_type': 'field fieldname-automatic_type fieldtype-text',
-        'first_reference': 'field fieldname-first_reference fieldtype-text',
-        'second_reference': 'field fieldname-second_reference fieldtype-text',
-        'third_reference': 'field fieldname-third_reference fieldtype-text',
-        'referenced_cp': 'field fieldname-referenced_cp fieldtype-text',
-        'referenced_topicpage': 'field fieldname-referenced_topicpage fieldtype-text',
-        'topicpage_filter': 'field fieldname-topicpage_filter fieldtype-text',
-        'topicpage_order': 'field fieldname-topicpage_order required fieldtype-text',
-        'elasticsearch_raw_query': 'field fieldname-elasticsearch_raw_query fieldtype-text',
-        'elasticsearch_raw_order': 'field fieldname-elasticsearch_raw_order fieldtype-text',
-        'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text'
-    };
-}
-
 function getAllTopicboxIds() {
     var topicbox_ids = [];
 
@@ -55,18 +39,25 @@ function getTopicboxFieldSetById(topicboxId) {
 
 function hideShowElementsByAutomaticTypeValue(topicboxId) {
     var topicboxFieldSet = getTopicboxFieldSetById(topicboxId);
-    var fieldClassNames = getFieldClassNames();
     var currentAutomaticTypeValue = getAutomaticTypeTextByTopicboxId(topicboxId);
-
     if (currentAutomaticTypeValue === null) {
         return;
     }
 
+    var allAutomaticFields = [
+        'automatic_type',
+        'first_reference', 'second_reference', 'third_reference',
+        'referenced_cp',
+        'referenced_topicpage', 'topicpage_filter', 'topicpage_order',
+        'elasticsearch_raw_query', 'elasticsearch_raw_order',
+        'preconfigured_query'
+    ];
+
     // Hide all except automatic_type
-    Object.keys(fieldClassNames).filter((element) => {
-        return element.indexOf('automatic_type') == -1;
+    allAutomaticFields.filter((element) => {
+        return element != 'automatic_type';
     }).forEach((element) => {
-        hideElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+        hideElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${element}`);
     });
 
     var automaticFields = [];
@@ -109,19 +100,19 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
             break;
     }
 
-    Object.keys(fieldClassNames).filter((element) => {
+    allAutomaticFields.filter((element) => {
         return automaticFields.includes(element);
     }).forEach((element) => {
-        showElementByTopicboxFieldSet(topicboxFieldSet, fieldClassNames[element]);
+        showElementByTopicboxFieldSet(topicboxFieldSet, `fieldname-${element}`);
     });
 }
 
 function hideElementByTopicboxFieldSet(fieldset, className) {
-    fieldset.querySelectorAll(`[class="${className}"]`)[0].style.display = 'none';
+    fieldset.querySelectorAll(`.${className}`)[0].style.display = 'none';
 }
 
 function showElementByTopicboxFieldSet(fieldset, className) {
-    fieldset.querySelectorAll(`[class="${className}"]`)[0].style.display = 'block';
+    fieldset.querySelectorAll(`.${className}`)[0].style.display = 'block';
 }
 
 (function ($) {

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -7,10 +7,10 @@ function getFieldClassNames() {
         'referenced_cp': 'field fieldname-referenced_cp fieldtype-text',
         'referenced_topicpage': 'field fieldname-referenced_topicpage fieldtype-text',
         'topicpage_filter': 'field fieldname-topicpage_filter fieldtype-text',
+        'topicpage_order': 'field fieldname-topicpage_order required fieldtype-text',
         'elasticsearch_raw_query': 'field fieldname-elasticsearch_raw_query fieldtype-text',
         'elasticsearch_raw_order': 'field fieldname-elasticsearch_raw_order fieldtype-text',
-        'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text',
-        'topicpage_order': 'field fieldname-topicpage_order required fieldtype-text',
+        'preconfigured_query': 'field fieldname-preconfigured_query fieldtype-text'
     };
 }
 

--- a/core/src/zeit/content/article/edit/browser/resources/topicbox.js
+++ b/core/src/zeit/content/article/edit/browser/resources/topicbox.js
@@ -8,11 +8,11 @@ function getAllTopicboxIds() {
     return topicbox_ids;
 }
 
-function getAutomaticTypeTextByTopicboxId(topicboxId) {
+function getAutomaticTypeByTopicboxId(topicboxId) {
     var automaticTypeElement = document.getElementById(`topicbox.${topicboxId}.automatic_type`);
 
     if (automaticTypeElement !== null) {
-        return automaticTypeElement.selectedOptions[0].text;
+        return automaticTypeElement.selectedOptions[0].value;
     }
     return null;
 }
@@ -39,7 +39,7 @@ function getTopicboxFieldSetById(topicboxId) {
 
 function hideShowElementsByAutomaticTypeValue(topicboxId) {
     var topicboxFieldSet = getTopicboxFieldSetById(topicboxId);
-    var currentAutomaticTypeValue = getAutomaticTypeTextByTopicboxId(topicboxId);
+    var currentAutomaticTypeValue = getAutomaticTypeByTopicboxId(topicboxId);
     if (currentAutomaticTypeValue === null) {
         return;
     }
@@ -59,7 +59,7 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
 
     var automaticFields = [];
     switch(currentAutomaticTypeValue.toLowerCase()) {
-        case 'klassisch':
+        case 'manual':
             automaticFields = [
                 'first_reference',
                 'second_reference',
@@ -70,14 +70,14 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
                 'referenced_cp'
             ];
             break;
-        case 'themenseite':
+        case 'topicpage':
             automaticFields = [
                 'referenced_topicpage',
                 'topicpage_filter',
                 'topicpage_order'
             ];
             break;
-        case 'es-query':
+        case 'elasticsearch-query':
             automaticFields = [
                 'elasticsearch_raw_query',
                 'elasticsearch_raw_order'
@@ -88,7 +88,7 @@ function hideShowElementsByAutomaticTypeValue(topicboxId) {
                 'topicpage_filter'
             ];
             break;
-        case 'filter':
+        case 'preconfigured-query':
             automaticFields = [
                 'preconfigured_query'
             ];

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -597,6 +597,10 @@ class TopicboxTypeSource(zeit.cms.content.sources.SimpleDictSource):
         ('preconfigured-query', _('preconfigured-query'))
     ])
 
+    def getToken(self, value):
+        # JS needs to use these values, don't MD5 them.
+        return value
+
 
 class TopicReferenceSource(zeit.cms.content.contentsource.CMSContentSource):
 


### PR DESCRIPTION
Die Themenseiten-Sortieroption soll nur bei Auswahl von Themenseiten in Topicboxen im Artikel angezeigt werden.