### PR TITLE
OPS-2024: Handles invalid variant size

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.57.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- OPS-2024: Handles invalid variant size
 
 
 4.57.1 (2021-06-30)

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -224,3 +224,11 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
             ' rrrrrr ',
             '        ',
         ], transform.create_variant_image(variant, fill_color='ff0000'))
+
+    def test_invalid_variant_size_should_not_raise_pil_systemerror(self):
+        variant = Variant(
+            id='wide', focus_x=0.5, focus_y=0.5, zoom=1, aspect_ratio='1:1')
+        image = self.transform.create_variant_image(
+            variant, size=(0, 0), fill_color='ffffff')
+        self.assertEqual((8, 8), image.getImageSize())
+

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -59,6 +59,8 @@ class ImageTransform(object):
         enhancements, so it can be used as a high quality preview of image
         enhancements in the frontend.
         """
+        size = None if type(size) == tuple and 0 in size else size
+
         if not variant.is_default:
             image = self._crop_variant_image(variant, size=size)
         else:

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -59,7 +59,6 @@ class ImageTransform(object):
         enhancements, so it can be used as a high quality preview of image
         enhancements in the frontend.
         """
-        size = None if type(size) == tuple and 0 in size else size
 
         if not variant.is_default:
             image = self._crop_variant_image(variant, size=size)
@@ -120,9 +119,10 @@ class ImageTransform(object):
             zoomed_width, zoomed_height, target_ratio)
         if size:
             w, h = size
-            override_ratio = (float(w) / float(h)) if h != 0 else 0
-            target_width, target_height = self._fit_ratio_to_image(
-                target_width, target_height, override_ratio)
+            if w > 0 and h > 0:
+                override_ratio = (float(w) / float(h))
+                target_width, target_height = self._fit_ratio_to_image(
+                    target_width, target_height, override_ratio)
 
         x, y = self._determine_crop_position(
             variant, target_width, target_height)


### PR DESCRIPTION
Wenn ein Bildzuschnitt den Parameter `size=(0,0)` bekommt, wirft PIL einen SystemError (tile cannot extend outside image).
Es wird versucht ein Bereich aus einem Bild herauszuschneiden, der über die Größe des Bildes geht.
Dieser PR setzt `size = None`, wenn min. ein Wert aus `size` 0 ist.