### PR TITLE
TOPIC-9: Make TMS order overridable, since related API does not support it

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -6,6 +6,8 @@ vivi.core changes
 
 - OPS-2024: Handles invalid variant size
 
+- FIX: Adds 'order'-Parameter to Related-API
+
 
 4.57.3 (2021-07-05)
 -------------------

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -6,7 +6,7 @@ vivi.core changes
 
 - OPS-2024: Handles invalid variant size
 
-- FIX: Adds 'order'-Parameter to Related-API
+- TOPIC-9: Implement TMS order in a way that does not break the related API
 
 
 4.57.3 (2021-07-05)

--- a/core/src/zeit/content/article/edit/tests/test_topicbox.py
+++ b/core/src/zeit/content/article/edit/tests/test_topicbox.py
@@ -170,6 +170,20 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
         self.assertEqual('http://xml.zeit.de/video', values[1].uniqueId)
         self.assertEqual('http://xml.zeit.de/art2', values[2].uniqueId)
 
+    def test_topicbox_source_related_api_should_return_result(self):
+        box = self.get_topicbox()
+        box.automatic_type = 'related-api'
+        contentquery = zope.component.getAdapter(
+            box,
+            zeit.contentquery.interfaces.IContentQuery,
+            name=box.automatic_type)
+
+        result, hits = contentquery._get_documents(0, 3)
+
+        self.assertEqual(
+            list(result), [{'article1'}, {'article2'}, {'article3'}])
+        self.assertEqual(hits, 3)
+
     def test_topicbox_values_deduplication(self):
         box = self.get_topicbox()
         box.referenced_cp = self.get_cp(content=[

--- a/core/src/zeit/content/article/edit/tests/test_topicbox.py
+++ b/core/src/zeit/content/article/edit/tests/test_topicbox.py
@@ -1,4 +1,3 @@
-import mock
 import zeit.content.article.article
 import zeit.content.article.edit.interfaces
 import zeit.content.article.testing
@@ -29,6 +28,7 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
         result.hits = 4
         self.elastic.search.return_value = result
         self.tms.get_topicpage_documents.return_value = result
+        self.tms.get_related_documents.return_value = result
 
     def get_topicbox(self):
         from zeit.content.article.edit.topicbox import Topicbox
@@ -139,6 +139,12 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
         self.assertEqual('http://xml.zeit.de/video', values[1].uniqueId)
         self.assertEqual('http://xml.zeit.de/art2', values[2].uniqueId)
 
+    def test_topicbox_source_related_api(self):
+        box = self.get_topicbox()
+        box.automatic_type = 'related-api'
+        values = box.values()
+        self.assertEqual('http://xml.zeit.de/art1', values[0].uniqueId)
+
     def test_topicbox_source_preconfigured_query_complete_query(self):
         box = self.get_topicbox()
         box.automatic_type = 'preconfigured-query'
@@ -169,20 +175,6 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
         self.assertEqual('http://xml.zeit.de/art1', values[0].uniqueId)
         self.assertEqual('http://xml.zeit.de/video', values[1].uniqueId)
         self.assertEqual('http://xml.zeit.de/art2', values[2].uniqueId)
-
-    def test_topicbox_source_related_api_should_return_result(self):
-        box = self.get_topicbox()
-        box.automatic_type = 'related-api'
-        contentquery = zope.component.getAdapter(
-            box,
-            zeit.contentquery.interfaces.IContentQuery,
-            name=box.automatic_type)
-
-        result, hits = contentquery._get_documents(0, 3)
-
-        self.assertEqual(
-            list(result), [{'article1'}, {'article2'}, {'article3'}])
-        self.assertEqual(hits, 3)
 
     def test_topicbox_values_deduplication(self):
         box = self.get_topicbox()

--- a/core/src/zeit/content/article/testing.py
+++ b/core/src/zeit/content/article/testing.py
@@ -72,6 +72,12 @@ class ElasticsearchMockLayer(plone.testing.Layer):
         self['tms'] = mock.Mock()
         self['tms'].get_topicpage_documents.return_value = (
             zeit.cms.interfaces.Result())
+
+        result = zeit.cms.interfaces.Result([
+            {'article1'}, {'article2'}, {'article3'}
+        ])
+        result.hits = 3
+        self['tms'].get_related_documents.return_value = result
         zope.interface.alsoProvides(self['tms'],
                                     zeit.retresco.interfaces.ITMS)
         zope.component.getSiteManager().registerUtility(self['tms'])

--- a/core/src/zeit/content/article/testing.py
+++ b/core/src/zeit/content/article/testing.py
@@ -72,12 +72,9 @@ class ElasticsearchMockLayer(plone.testing.Layer):
         self['tms'] = mock.Mock()
         self['tms'].get_topicpage_documents.return_value = (
             zeit.cms.interfaces.Result())
+        self['tms'].get_related_documents.return_value = (
+            zeit.cms.interfaces.Result())
 
-        result = zeit.cms.interfaces.Result([
-            {'article1'}, {'article2'}, {'article3'}
-        ])
-        result.hits = 3
-        self['tms'].get_related_documents.return_value = result
         zope.interface.alsoProvides(self['tms'],
                                     zeit.retresco.interfaces.ITMS)
         zope.component.getSiteManager().registerUtility(self['tms'])


### PR DESCRIPTION
Fügt der Funktion `_get_documents` in der `TMSRelatedApiQuery` den Parameter `order` hinzu.
Diese wird in der deren Superklasse verwendet und muss demnach auch hier definiert werden.
Der `order`-Parameter hat in der Related-Api aber keine Funktion und wird standardmäßig auf `None` gesetzt.
Außerdem `order` zu einer Property gemacht. Dadurch kann `TMSRelatedApiQuery` `order=None` setzen um den `cache`-Key nicht zu verwirren. 