### PR TITLE
ZON-6316: FIX: change form name for autoreload with genre

### DIFF
--- a/core/src/zeit/content/article/edit/browser/form.py
+++ b/core/src/zeit/content/article/edit/browser/form.py
@@ -297,7 +297,7 @@ class MetadataGenre(zeit.edit.browser.form.InlineForm):
 
     def _success_handler(self):
         self.signal('reload-inline-form', 'recipe-categories')
-        self.signal('reload-inline-form', 'audio-speechbert')
+        self.signal('reload-inline-form', 'options-audio-speechbert')
 
 
 class MetadataComments(zeit.edit.browser.form.InlineForm):


### PR DESCRIPTION
Ich habe (aus irgendwelchen Gründen) nach dem lokal Testen den Namen für das Formular geändert und es nicht nachgezogen, wo die Events registriert werden. Mit dieser Änderung hier ist es nun lokal getestet.