### PR TITLE
MAINT: Add base KPI Implementation to ensure adapting it never fails

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.59.3 (unreleased)
 -------------------
 
-- FIX: Ensure TMSArticle and ReachContent can be adapted by z.cms.content.interfaces.IKPI
+- MAINT: Add base KPI Implementation to ensure adapting it never fails
 
 
 4.59.2 (2021-07-20)

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.59.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- FIX: Ensure TMSArticle and ReachContent can be adapted by z.cms.content.interfaces.IKPI
 
 
 4.59.2 (2021-07-20)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -1,18 +1,20 @@
-from zeit.cms.i18n import MessageFactory as _
+import grokcore.component as grok
 import zc.form.field
 import zc.form.interfaces
-import zeit.cms.content.field
-import zeit.cms.content.sources
-import zeit.cms.interfaces
-import zeit.cms.repository.interfaces
-import zeit.cms.tagging.interfaces
-import zeit.wochenmarkt.sources
 import zope.container.interfaces
 import zope.interface
 import zope.interface.common.sequence
 import zope.interface.interfaces
 import zope.schema
 import zope.schema.interfaces
+
+from zeit.cms.i18n import MessageFactory as _
+import zeit.cms.content.field
+import zeit.cms.content.sources
+import zeit.cms.interfaces
+import zeit.cms.repository.interfaces
+import zeit.cms.tagging.interfaces
+import zeit.wochenmarkt.sources
 
 
 # XXX There is too much, too unordered in here, clean this up.
@@ -735,3 +737,14 @@ class IKPI(zope.interface.Interface):
     visits = zope.schema.Int(default=0, readonly=True)
     comments = zope.schema.Int(default=0, readonly=True)
     subscriptions = zope.schema.Int(default=0, readonly=True)
+
+
+@grok.implementer(IKPI)
+class KPI(grok.Adapter):
+
+    grok.context(zeit.cms.interfaces.ICMSContent)
+
+    def __init__(self, context):
+        super().__init__(context)
+        for name in list(IKPI):
+            setattr(self, name, None)

--- a/core/src/zeit/cms/content/interfaces.py
+++ b/core/src/zeit/cms/content/interfaces.py
@@ -1,20 +1,19 @@
+from zeit.cms.i18n import MessageFactory as _
 import grokcore.component as grok
 import zc.form.field
 import zc.form.interfaces
-import zope.container.interfaces
-import zope.interface
-import zope.interface.common.sequence
-import zope.interface.interfaces
-import zope.schema
-import zope.schema.interfaces
-
-from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.content.field
 import zeit.cms.content.sources
 import zeit.cms.interfaces
 import zeit.cms.repository.interfaces
 import zeit.cms.tagging.interfaces
 import zeit.wochenmarkt.sources
+import zope.container.interfaces
+import zope.interface
+import zope.interface.common.sequence
+import zope.interface.interfaces
+import zope.schema
+import zope.schema.interfaces
 
 
 # XXX There is too much, too unordered in here, clean this up.

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -124,10 +124,11 @@ def gallery_entry_count(context):
     return context._tms_payload_head.get('visible_entry_count', 0)
 
 
-@grok.implementer(zeit.retresco.interfaces.IKPI)
+@grok.implementer(zeit.cms.content.interfaces.IKPI)
 class KPI(grok.Adapter):
 
     grok.context(zeit.retresco.interfaces.ITMSContent)
+    grok.provides(zeit.cms.content.interfaces.IKPI)
 
     FIELDS = {
         'visits': 'kpi_visits',

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -128,7 +128,6 @@ def gallery_entry_count(context):
 class KPI(grok.Adapter):
 
     grok.context(zeit.retresco.interfaces.ITMSContent)
-    grok.provides(zeit.cms.content.interfaces.IKPI)
 
     FIELDS = {
         'visits': 'kpi_visits',

--- a/core/src/zeit/retresco/interfaces.py
+++ b/core/src/zeit/retresco/interfaces.py
@@ -197,15 +197,6 @@ class ITMSContent(zeit.cms.interfaces.ICMSContent):
     """
 
 
-class IKPI(zope.interface.Interface):
-    """Provides access to kpi fields (visits, comments, etc.) on ITMSContent.
-    """
-
-    visits = zope.schema.Int(default=0, readonly=True)
-    comments = zope.schema.Int(default=0, readonly=True)
-    subscriptions = zope.schema.Int(default=0, readonly=True)
-
-
 class IElasticDAVProperties(zeit.connector.interfaces.IWebDAVProperties):
     """Marker interface so we can register special IDAVPropertyConverter
     variants for ITMSContent objects.

--- a/core/src/zeit/retresco/tests/test_content.py
+++ b/core/src/zeit/retresco/tests/test_content.py
@@ -2,6 +2,7 @@ from zeit.cms.checkout.helper import checked_out
 from zeit.content.article.interfaces import IArticle
 import zeit.cms.content.sources
 import zeit.cms.tagging.tag
+import zeit.cms.content.interfaces
 import zeit.content.article.article
 import zeit.content.author.author
 import zeit.content.image.interfaces
@@ -199,7 +200,7 @@ class ContentTest(zeit.retresco.testing.FunctionalTestCase):
         data['kpi_comments'] = 2
         data['kpi_subscriptions'] = 3
         content = zeit.retresco.interfaces.ITMSContent(data)
-        kpi = zeit.retresco.interfaces.IKPI(content)
+        kpi = zeit.cms.content.interfaces.IKPI(content)
         self.assertEqual(1, kpi.visits)
         self.assertEqual(2, kpi.comments)
         self.assertEqual(3, kpi.subscriptions)


### PR DESCRIPTION
Es fiel auf, dass https://github.com/ZeitOnline/zeit.web/blob/8a520135c8e9c26c6f8ecc96c953b4ee2defd5fd/src/zeit/web/core/template.py#L1947 für TMSArticle nicht klappte. Deshalb musste ich die Stellen hier nochmal ein wenig anpassen. Außerdem hab ich den Test so angepasst, wie die Verwendung in zeitweb ist :)