### PR TITLE
TOPIC-39: UX Tweaks for reach as datasource

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,6 +4,8 @@ vivi.core changes
 4.59.5 (unreleased)
 -------------------
 
+- TOPIC-39: Hide hide_dupes checkbox for reach as automatic area source
+- TOPIC-39: Enable autopilot checkbox when automatic area source is changed
 - BUG-1437: Skip tests with non expected TechnicalErrors
 
 

--- a/core/src/zeit/content/cp/browser/resources/area.js
+++ b/core/src/zeit/content/cp/browser/resources/area.js
@@ -11,7 +11,7 @@ var FIELDS = {
 };
 
 
-var show_matching_field = function(container, current_type) {
+var show_matching_fieldset = function(container, current_type) {
     $(Object.keys(FIELDS)).each(
         function(i, key) {
             var field = FIELDS[key];
@@ -49,12 +49,12 @@ $(document).bind('fragment-ready', function(event) {
         }
     }
 
-    show_matching_field(event.__target, type_select.val());
+    show_matching_fieldset(event.__target, type_select.val());
     hide_hide_dupes_checkbox_for_reach(event.__target, type_select.val());
     type_select.on(
         'change', function() {
             var value = $(this).val();
-            show_matching_field(event.__target, value);
+            show_matching_fieldset(event.__target, value);
             enable_autopilot(event.__target);
             hide_hide_dupes_checkbox_for_reach(event.__target, value);
     });

--- a/core/src/zeit/content/cp/browser/resources/area.js
+++ b/core/src/zeit/content/cp/browser/resources/area.js
@@ -25,6 +25,14 @@ var enable_autopilot = function(container) {
     $('.fieldname-automatic .checkboxType', container).prop('checked', true);
 };
 
+var hide_hide_dupes_checkbox_for_reach = function(container, current_type) {
+    if (current_type === 'reach') {
+        $('.fieldname-hide_dupes', container).hide();
+    } else {
+        $('.fieldname-hide_dupes', container).show();
+    }
+};
+
 $(document).bind('fragment-ready', function(event) {
     var type_select = $('.fieldname-automatic_type select', event.__target);
     if (! type_select.length) {
@@ -42,10 +50,13 @@ $(document).bind('fragment-ready', function(event) {
     }
 
     show_matching_field(event.__target, type_select.val());
+    hide_hide_dupes_checkbox_for_reach(event.__target, type_select.val());
     type_select.on(
         'change', function() {
-            show_matching_field(event.__target, $(this).val());
+            var value = $(this).val();
+            show_matching_field(event.__target, value);
             enable_autopilot(event.__target);
+            hide_hide_dupes_checkbox_for_reach(event.__target, value);
     });
 });
 

--- a/core/src/zeit/content/cp/browser/resources/area.js
+++ b/core/src/zeit/content/cp/browser/resources/area.js
@@ -21,6 +21,9 @@ var show_matching_field = function(container, current_type) {
     });
 };
 
+var enable_autopilot = function(container) {
+    $('.fieldname-automatic .checkboxType', container).prop('checked', true);
+};
 
 $(document).bind('fragment-ready', function(event) {
     var type_select = $('.fieldname-automatic_type select', event.__target);
@@ -42,6 +45,7 @@ $(document).bind('fragment-ready', function(event) {
     type_select.on(
         'change', function() {
             show_matching_field(event.__target, $(this).val());
+            enable_autopilot(event.__target);
     });
 });
 

--- a/core/src/zeit/content/cp/browser/tests/test_automatic.py
+++ b/core/src/zeit/content/cp/browser/tests/test_automatic.py
@@ -130,14 +130,7 @@ class TestAutomaticArea(zeit.content.cp.testing.SeleniumTestCase):
         sel.click('css=a.CloseButton')
 
         # One area is unconfigured, the other could load content automatically
-        sel.waitForCssCount('css=.block-automatic-off', 1)
-        sel.assertCssCount('css=.block-automatic-on', 0)
-        sel.assertCssCount('css=.block-automatic-not-possible', 1)
-        sel.assertCssCount('css=.type-teaser', 0)
-        sel.assertCssCount('css=.type-auto-teaser', 0)
-
-        # Enable automatic mode, creates automatic teaser block
-        sel.click('css=.toggle-automatic-link')
+        # automatic mode is enabled per default, creates automatic teaser block
         sel.waitForCssCount('css=.block-automatic-off', 0)
         sel.assertCssCount('css=.block-automatic-on', 1)
         sel.assertCssCount('css=.block-automatic-not-possible', 1)

--- a/core/src/zeit/reach/reach.py
+++ b/core/src/zeit/reach/reach.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 class Reach:
 
     http = requests.Session()
-    timeout = 0.2
+    timeout = 1
 
     def __init__(self, url, freeze_now=None):
         self.url = url


### PR DESCRIPTION
Wenn reach als Datenquelle in Autoflächen ausgewählt wird soll die `Duplikate vermeiden` Checkbox ausgeblendet werden, sowie die `Autopilot` Checkbox per default angeklickt werden. Außerdem wird noch die Dauer zum timeout erhöht, weil sich gezeigt hat, dass 0.2s ein bisschen zu wenig sind!