### PR TITLE
TOPIC-19: Be more defensive regarding sort order

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.59.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- TOPIC-19: Fix multiple sort order possibilities and be more defensive
 
 
 4.59.4 (2021-07-22)

--- a/core/src/zeit/content/cp/testing.py
+++ b/core/src/zeit/content/cp/testing.py
@@ -117,6 +117,17 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
         transaction.commit()
         return cp
 
+    def create_lead_teaser(self, order=None):
+        lead = self.repository['cp']['lead']
+        lead.automatic = True
+        lead.automatic_type = 'custom'
+        lead.count = 1
+        lead.query = (('channels', 'eq', 'International', 'Nahost'),)
+        if order:
+            lead.query_order = order
+        self.elasticsearch.search.return_value = zeit.cms.interfaces.Result()
+        return lead
+
 
 WSGI_LAYER = zeit.cms.testing.WSGILayer(
     name='WSGILayer', bases=(LAYER,))

--- a/core/src/zeit/content/cp/tests/test_automatic.py
+++ b/core/src/zeit/content/cp/tests/test_automatic.py
@@ -447,6 +447,17 @@ class AutomaticAreaElasticsearchTest(
             }}},
             self.elasticsearch.search.call_args[0][0])
 
+    def test_should_accept_multiple_orders(self):
+        lead = self.create_lead_teaser(
+            'payload.xml.lastname:asc,payload.xml.firstname:asc')
+        IRenderedArea(lead).values()
+
+        query = self.elasticsearch.search.call_args[0][0]
+        self.assertEqual(
+            [{'payload.xml.lastname': 'asc'},
+             {'payload.xml.firstname': 'asc'}],
+            query['sort'])
+
 
 class AutomaticAreaTopicpageTest(zeit.content.cp.testing.FunctionalTestCase):
 

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -69,8 +69,7 @@ class ElasticsearchContentQuery(ContentQuery):
             for item in order_list:
                 (field, order) = item.split(':')
                 sort_orders.append({field: order})
-
-        if not any(['random' in order for order in order_list]):
+        if not 'random' in self.order_default:
             return sort_orders
 
         random_order = {
@@ -80,7 +79,7 @@ class ElasticsearchContentQuery(ContentQuery):
                     'lang': 'painless',
                     'source': 'Math.random()'
                 },
-                'order': order
+                'order': 'desc'  # descending into chaos, randomly
             }}
         return random_order
 

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -61,7 +61,11 @@ class ElasticsearchContentQuery(ContentQuery):
 
     @property
     def order(self):
-        (field, order) = self.order_default.split(':')
+        if isinstance(self.order_default, str):
+            (field, order) = self.order_default.split(':')
+        else:
+            (field, order) = self.order_default
+
         if 'random' not in field:
             return [{field: order}]
 

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -64,12 +64,14 @@ class ElasticsearchContentQuery(ContentQuery):
         if not self.order_default:
             return None
         if isinstance(self.order_default, str):
-            (field, order) = self.order_default.split(':')
-        else:
-            (field, order) = self.order_default
+            order_list = self.order_default.split(',')
+            sort_orders = []
+            for item in order_list:
+                (field, order) = item.split(':')
+                sort_orders.append({field: order})
 
-        if 'random' not in field:
-            return [{field: order}]
+        if not any(['random' in order for order in order_list]):
+            return sort_orders
 
         random_order = {
             '_script': {

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -61,6 +61,8 @@ class ElasticsearchContentQuery(ContentQuery):
 
     @property
     def order(self):
+        if not self.order_default:
+            return None
         if isinstance(self.order_default, str):
             (field, order) = self.order_default.split(':')
         else:
@@ -133,7 +135,8 @@ class ElasticsearchContentQuery(ContentQuery):
             if self.hide_dupes_clause:
                 query['query']['bool']['must_not'].append(
                     self.hide_dupes_clause)
-        query['sort'] = self.order
+        if self.order:
+            query['sort'] = self.order
         return query
 
     _additional_clauses = [

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -63,25 +63,27 @@ class ElasticsearchContentQuery(ContentQuery):
     def order(self):
         if not self.order_default:
             return None
+
         if isinstance(self.order_default, str):
+            if 'random' in self.order_default:
+                random_order = {
+                    '_script': {
+                        'type': 'number',
+                        'script': {
+                            'lang': 'painless',
+                            'source': 'Math.random()'
+                        },
+                        'order': 'desc'  # descending into chaos, randomly
+                    }}
+                return random_order
+
             order_list = self.order_default.split(',')
             sort_orders = []
             for item in order_list:
                 (field, order) = item.split(':')
                 sort_orders.append({field: order})
-        if not 'random' in self.order_default:
-            return sort_orders
 
-        random_order = {
-            '_script': {
-                'type': 'number',
-                'script': {
-                    'lang': 'painless',
-                    'source': 'Math.random()'
-                },
-                'order': 'desc'  # descending into chaos, randomly
-            }}
-        return random_order
+            return sort_orders
 
     def __call__(self):
         self.total_hits = 0


### PR DESCRIPTION
Während der Implementierung der Veränderungen in zeit.web sind weitere Fälle von Sortierungsmöglichkeiten aufgetreten. Daher werden hier diese Fälle mit berücksichtigt und vor allem Tests aktualisiert und nachgezogen, um diese Fälle in Zukunft schon in vivi abzusichern.

Diese Fälle enthalten:
- fehlende Sortierung `''`
- mehrere Sortierungen `'payload.xml.lastname:asc,payload.xml.firstname:asc'`