### PR TITLE
FIX: Don't convert nonexistent pages

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,6 +5,7 @@ vivi.core changes
 -------------------
 
 - ZON-6301: Adds checkbox on CPs in SEO tab, to enable RSS-Feed single tracking
+- FIX: Do not fail to rerurn related topics if we receive a nonexisting one
 
 
 4.60.0 (2021-07-28)

--- a/core/src/zeit/contentquery/query.py
+++ b/core/src/zeit/contentquery/query.py
@@ -529,7 +529,17 @@ class TMSRelatedTopicsApiQuery(ContentQuery):
         tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
         topics = tms.get_related_topics(
             self.context.related_topicpage, rows=self.rows)
-        return [zeit.cms.interfaces.ICMSContent(topic) for topic in topics]
+        related_topics = []
+        # TMS seems to return non existent/ redirecting topicpages
+        for topic in topics:
+            try:
+                related_topics.append(zeit.cms.interfaces.ICMSContent(topic))
+            except TypeError:
+                log.warning(
+                    '%s: Could not adapt %s to ICMSContent',
+                    self.__class__.__name__, topic)
+                continue
+        return related_topics
 
 
 class ReachContentQuery(ContentQuery):


### PR DESCRIPTION
We seem to receive nonexistent/ redirect URLs from the TMS which cannot
be converted and therefore throw an error. We just catch it now...

`devstaging` auf http://localhost:9090/thema/gerhart-hauptmann