### PR TITLE
BUG-1430: gracefully handle locked images during brightcove import

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -4,7 +4,7 @@ vivi.core changes
 4.60.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-1430: gracefully handle locked images during brightcove import
 
 
 4.60.1 (2021-08-02)

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -255,6 +255,19 @@ class TestDownloadTeasers(zeit.brightcove.testing.StaticBrowserTestCase):
         group = self.repository['foo-thumbnail']
         assert group.master_image is None
 
+    def test_download_teaser_for_locked_image_ignored(self):
+        with mock.patch(
+            'zeit.brightcove.convert.image_group_from_image'
+        ) as patched:
+            patched.side_effect = zope.app.locking.interfaces.LockingError()
+            assert zeit.brightcove.update.download_teaser_image(
+                self.repository,
+                dict(
+                    id="foo",
+                    images=dict(
+                        thumbnail=dict(src="foo"))),
+                "thumbnail") is None
+
     def test_download_teaser_image_error_uses_existing(self):
         from zeit.content.image.testing import create_image_group_with_master_image
         self.repository['foo-thumbnail'] = create_image_group_with_master_image()

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -169,10 +169,15 @@ def download_teaser_image(folder, bcdata, ttype='still'):
     except Exception as exc:
         log.error(exc)
         image = None
-    return zeit.brightcove.convert.image_group_from_image(
-        folder,
-        name,
-        image)
+    try:
+        return zeit.brightcove.convert.image_group_from_image(
+            folder,
+            name,
+            image)
+    except zope.app.locking.interfaces.LockingError:
+        # don't bother to try to overwrite an image, that's
+        # obviously being edited.
+        pass
 
 
 # Triggered by BC notification webhook, which we receive in


### PR DESCRIPTION
Nachfolger von #224 

Hier wird tatsaechlich nur ein fehlschlagen des updates von images (teaser und/oder still) im konkreten Fall eines vorhandenen Locks behandelt, in der annahme, dass das bild bearbeitet wird und deshalb sowieso nicht ueberschrieben werden sollte.
