### PR TITLE
ZO-355, ZO-358: Set up product config and zodb from settings/environ

### DIFF
--- a/core/docs/changelog/ZO-355.change
+++ b/core/docs/changelog/ZO-355.change
@@ -1,0 +1,1 @@
+ZO-355: Support configuring product config and zodb via environment

--- a/core/setup.py
+++ b/core/setup.py
@@ -59,6 +59,7 @@ setup(
         'zc.relation',
         'zc.set',
         'zc.sourcefactory',
+        'zodburi',
         'zope.annotation',
         'zope.app.appsetup',
         'zope.app.file',

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -52,9 +52,7 @@ class Application:
         settings = os.environ.copy()
         settings.update(local_conf)
         zeit.cms.cli.configure(settings)
-
-        zeit.cms.zope.load_zcml(settings['site_zcml'])
-        db = zeit.cms.zope.zodb_connection(settings['zodbconn.uri'])
+        db = zeit.cms.zope.bootstrap(settings)
 
         debug = zope.app.wsgi.paste.asbool(settings.get('debug'))
         app = zope.app.wsgi.WSGIPublisherApplication(

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -2,8 +2,6 @@ from zope.app.publication.httpfactory import HTTPPublicationRequestFactory
 import fanstatic
 import grokcore.component as grok
 import os
-import pyramid_dogpile_cache2
-import re
 import webob.cookies
 import zeit.cms.cli
 import zeit.cms.wsgi
@@ -94,19 +92,6 @@ class ClearFanstaticOnError:
 
 def clear_fanstatic(app, global_conf, **local_conf):
     return ClearFanstaticOnError(app)
-
-
-@grok.subscribe(zope.app.appsetup.interfaces.IDatabaseOpenedWithRootEvent)
-def configure_dogpile_cache(event):
-    config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
-    settings = {
-        'dogpile_cache.regions': config['cache-regions']
-    }
-    for region in re.split(r'\s*,\s*', config['cache-regions']):
-        settings['dogpile_cache.%s.backend' % region] = 'dogpile.cache.memory'
-        settings['dogpile_cache.%s.expiration_time' % region] = config[
-            'cache-expiration-%s' % region]
-    pyramid_dogpile_cache2.configure_dogpile_cache(settings)
 
 
 class BrowserRequest(zope.publisher.browser.BrowserRequest):

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -2,7 +2,6 @@ from zope.app.publication.httpfactory import HTTPPublicationRequestFactory
 import fanstatic
 import grokcore.component as grok
 import os
-import pendulum
 import pyramid_dogpile_cache2
 import re
 import webob.cookies
@@ -16,7 +15,6 @@ import zope.app.wsgi
 import zope.app.wsgi.paste
 import zope.component.hooks
 import zope.publisher.browser
-import zope.security.checker
 
 
 FANSTATIC_SETTINGS = {
@@ -30,11 +28,6 @@ FANSTATIC_SETTINGS = {
     'recompute_hashes': False,
     'publisher_signature': fanstatic.DEFAULT_SIGNATURE,
 }
-
-# Make pendulum a rock, just like datetime.datetime.
-for cls in ['DateTime', 'Date', 'Time']:
-    zope.security.checker.BasicTypes[getattr(pendulum, cls)] = (
-        zope.security.checker.NoProxy)
 
 
 class Application:

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -53,7 +53,7 @@ class Application:
         settings.update(local_conf)
         zeit.cms.cli.configure(settings)
 
-        zope.app.appsetup.config(settings['site_zcml'])
+        zeit.cms.zope.load_zcml(settings['site_zcml'])
         db = zeit.cms.zope.zodb_connection(settings['zodbconn.uri'])
 
         debug = zope.app.wsgi.paste.asbool(settings.get('debug'))

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -1,3 +1,4 @@
+from zope.app.publication.httpfactory import HTTPPublicationRequestFactory
 import fanstatic
 import grokcore.component as grok
 import os
@@ -7,6 +8,7 @@ import re
 import webob.cookies
 import zeit.cms.cli
 import zeit.cms.wsgi
+import zeit.cms.zope
 import zope.app.appsetup.interfaces
 import zope.app.appsetup.product
 import zope.app.publication.interfaces
@@ -51,9 +53,12 @@ class Application:
         settings.update(local_conf)
         zeit.cms.cli.configure(settings)
 
+        zope.app.appsetup.config(settings['site_zcml'])
+        db = zeit.cms.zope.zodb_connection(settings['zodbconn.uri'])
+
         debug = zope.app.wsgi.paste.asbool(settings.get('debug'))
-        app = zope.app.wsgi.getWSGIApplication(
-            settings['zope_conf'], handle_errors=not debug)
+        app = zope.app.wsgi.WSGIPublisherApplication(
+            db, HTTPPublicationRequestFactory, handle_errors=not debug)
 
         for key, value in FANSTATIC_SETTINGS.items():
             settings['fanstatic.' + key] = value

--- a/core/src/zeit/cms/browser/resources/lightbox.css
+++ b/core/src/zeit/cms/browser/resources/lightbox.css
@@ -210,13 +210,6 @@
   background-color: transparent;
 }
 
-.lightbox .suggest-keyword {
-    width: 17em;
-    float: right;
-    margin-right: 1em;
-}
-
-
 
 /*
  * delete screen

--- a/core/src/zeit/cms/celery.py
+++ b/core/src/zeit/cms/celery.py
@@ -55,15 +55,17 @@ else:
                 self.on_worker_process_init()
 
         def on_worker_process_init(self):
+            import zeit.cms.zope
+
             conf = self.app.conf
-            configfile = conf.get('ZOPE_CONF')
+            configfile = conf.get('LOGGING_INI')
             if not configfile:
                 raise ValueError(
-                    'Celery setting ZOPE_CONF not set, '
+                    'Celery setting LOGGING_INI not set, '
                     'check celery worker config.')
 
-            import zope.app.wsgi
-            db = zope.app.wsgi.config(configfile)
+            settings = zeit.cms.cli._parse_paste_ini(configfile)
+            db = zeit.cms.zope.bootstrap(settings)
             conf['ZODB'] = db
 
         def on_worker_shutdown(self):

--- a/core/src/zeit/cms/celery.py
+++ b/core/src/zeit/cms/celery.py
@@ -43,11 +43,12 @@ else:
             paste_ini = self.app.conf.get('LOGGING_INI')
             if not paste_ini:
                 return
+            zeit.cms.cli._parse_paste_ini(paste_ini)
 
             @celery.signals.setup_logging.connect(weak=False)
             def setup_logging(*args, **kw):
-                """Make the loglevel finely configurable via a config file."""
-                zeit.cms.cli._parse_paste_ini(paste_ini)
+                # Logging was already set up by parse_paste_ini above.
+                pass
 
             if self.app.conf.get('DEBUG_WORKER'):
                 assert self.app.conf.get('worker_pool') == 'solo'

--- a/core/src/zeit/cms/security_patch.py
+++ b/core/src/zeit/cms/security_patch.py
@@ -1,4 +1,5 @@
 import abc
+import pendulum
 import zope.security.checker
 import zope.security.proxy
 
@@ -41,3 +42,9 @@ zope.security.checker.BasicTypes[
     type(mydict.values())] = zope.security.checker.NoProxy
 zope.security.checker.BasicTypes[
     type(mydict.items())] = zope.security.checker.NoProxy
+
+
+# Treat pendulum like datetime.datetime.
+for cls in ['DateTime', 'Date', 'Time']:
+    zope.security.checker.BasicTypes[getattr(pendulum, cls)] = (
+        zope.security.checker.NoProxy)

--- a/core/src/zeit/cms/testing.py
+++ b/core/src/zeit/cms/testing.py
@@ -507,11 +507,6 @@ cms_product_config = """\
   live-prefix http://localhost/live-prefix/
   friebert-wc-preview-prefix /wcpreview
 
-  suggest-keyword-email-address none@testing
-  suggest-keyword-real-name Dr. No
-  whitelist-url file://{base}/tagging/tests/fixtures/whitelist.xml
-  trisolute-url file://{base}/tagging/tests/fixtures/googleNewsTopics.json
-  trisolute-ressort-url file://{base}/tagging/tests/fixtures/tris-ressorts.xml
   breadcrumbs-use-common-metadata true
 
   cache-regions config, feature, newsimport, dav

--- a/core/src/zeit/cms/ui.zcml
+++ b/core/src/zeit/cms/ui.zcml
@@ -144,6 +144,7 @@
 
   <include package="grokcore.component" file="meta.zcml" />
   <grok:grok package="zeit.cms.application" />
+  <grok:grok package="zeit.cms.zope" />
 
   <include package="zeit.connector" />
   <include package="zeit.objectlog" />

--- a/core/src/zeit/cms/zope.py
+++ b/core/src/zeit/cms/zope.py
@@ -2,8 +2,21 @@ from ZODB.ActivityMonitor import ActivityMonitor
 import ZODB
 import zodburi
 import zope.component
+import zope.component.hooks
+import zope.configuration.config
+import zope.configuration.xmlconfig
 import zope.event
 import zope.processlifetime
+
+
+def load_zcml(filename):
+    # Modelled after zope.app.appsetup:config
+    zope.component.hooks.setHooks()
+    context = zope.configuration.config.ConfigurationMachine()
+    zope.configuration.xmlconfig.registerCommonDirectives(context)
+    zope.configuration.xmlconfig.include(context, file=filename)
+    context.execute_actions()
+    return context
 
 
 def zodb_connection(uri):

--- a/core/src/zeit/cms/zope.py
+++ b/core/src/zeit/cms/zope.py
@@ -17,7 +17,7 @@ import zope.processlifetime
 def bootstrap(settings):
     configure_product_config(settings)
     load_zcml(settings['site_zcml'])
-    db = zodb_connection(settings['zodbconn.uri'])
+    db = create_zodb_database(settings['zodbconn.uri'])
     return db
 
 
@@ -51,7 +51,7 @@ def load_zcml(filename):
     return context
 
 
-def zodb_connection(uri):
+def create_zodb_database(uri):
     # Cobbled together from pyramid_zodbconn:includeme,
     # zope.app.appsetup:multi_database, zope.app.wsgi:config.
     dbmap = {}  # XXX We don't currently support multiple DBs.

--- a/core/src/zeit/cms/zope.py
+++ b/core/src/zeit/cms/zope.py
@@ -1,0 +1,18 @@
+from ZODB.ActivityMonitor import ActivityMonitor
+import ZODB
+import zodburi
+import zope.component
+import zope.event
+import zope.processlifetime
+
+
+def zodb_connection(uri):
+    # Cobbled together from pyramid_zodbconn:includeme,
+    # zope.app.appsetup:multi_database, zope.app.wsgi:config.
+    dbmap = {}  # XXX We don't currently support multiple DBs.
+    storage_factory, db_kw = zodburi.resolve_uri(uri)
+    db = ZODB.DB(storage_factory(), databases=dbmap, **db_kw)
+    db.setActivityMonitor(ActivityMonitor())
+    zope.component.provideUtility(db, ZODB.interfaces.IDatabase)
+    zope.event.notify(zope.processlifetime.DatabaseOpened(db))
+    return db


### PR DESCRIPTION
Basiert auf #260, den daher zuerst mergen.

JENKINS_BATOU_BRANCH=ZO-355

Ich würde glaub ich gern noch div. Module (wsgi, zope, logging etc) in ein Unterpaket zeit.cms.deploy o.ä. verschieben, damit besser klar wird, was wohingehört; hab das jetzt noch nicht getan, weil sonst die Diffs schwer lesbar wären. (Anschließend muss man zeit.ldap auf die geänderte API für dogpile.cache setup anpassen.)