### PR TITLE
ZO-496: Auto areas incident

### DIFF
--- a/core/docs/changelog/ZO-496.fix
+++ b/core/docs/changelog/ZO-496.fix
@@ -1,1 +1,1 @@
-Prevent reach from cache poisoning vivi cp-editor
+ZO-496: Prevent reach from cache poisoning vivi cp-editor

--- a/core/docs/changelog/ZO-496.fix
+++ b/core/docs/changelog/ZO-496.fix
@@ -1,0 +1,1 @@
+Prevent reach from cache poisoning vivi cp-editor

--- a/core/src/zeit/reach/reach.py
+++ b/core/src/zeit/reach/reach.py
@@ -45,13 +45,19 @@ class Reach:
         return result
 
     def _resolve(self, doc):
-        content = zeit.cms.interfaces.ICMSContent(doc['uniqueId'], None)
-        if content is None:
+        repository = zope.component.getUtility(
+            zeit.cms.repository.interfaces.IRepository)
+        try:
+            content = repository.getCopyOf(doc['uniqueId'])
+        except KeyError:
             log.warning('Not found %s', doc['uniqueId'])
             return None
+
         content._reach_data = doc
         zope.interface.alsoProvides(
-            content, zeit.reach.interfaces.IReachContent)
+            content,
+            zeit.cms.repository.interfaces.IRepositoryContent,
+            zeit.reach.interfaces.IReachContent)
         return content
 
 

--- a/core/src/zeit/reach/tests/test_reach.py
+++ b/core/src/zeit/reach/tests/test_reach.py
@@ -24,3 +24,18 @@ class ReachTest(zeit.reach.testing.FunctionalTestCase):
 
         (request,) = self.layer['request_handler'].requests
         self.assertEqual('/ranking/views?limit=3', request['path'])
+
+
+class ReachCacheTest(zeit.reach.testing.FunctionalTestCase):
+
+    def test_content_is_not_IReach_after_resolve(self):
+        uniqueId = 'http://xml.zeit.de/testcontent'
+
+        reach = Reach('http://localhost:%s' % self.layer['http_port'])
+        resolved_content = reach._resolve({'uniqueId': uniqueId})
+        content = zeit.cms.interfaces.ICMSContent(uniqueId)
+
+        self.assertTrue(zeit.reach.interfaces.IReachContent.providedBy(
+            resolved_content))
+        self.assertFalse(zeit.reach.interfaces.IReachContent.providedBy(
+            content))

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -1,7 +1,6 @@
 from zeit.cms.repository.interfaces import AfterObjectConstructedEvent
 import collections.abc
 import grokcore.component as grok
-import logging
 import lxml.objectify
 import os.path
 import zeit.cms.interfaces
@@ -13,9 +12,6 @@ import zeit.content.link.link
 import zeit.retresco.interfaces
 import zope.component
 import zope.schema.interfaces
-
-
-log = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(zeit.retresco.interfaces.ITMSContent)
@@ -189,13 +185,7 @@ class WebDAVProperties(grok.Adapter, collections.abc.MutableMapping):
             zeit.retresco.interfaces.DAV_NAMESPACE_BASE, '', 1)
         name = quote_es_field_name(name)
         namespace = quote_es_field_name(namespace)
-        try:
-            return self.context._tms_payload[namespace][name]
-        except AttributeError:
-            log.warning(
-                'Error during context tms payload lookup for '
-                '{}, {}, {}'.format(self.context.uniqueId, namespace, name))
-            return None
+        return self.context._tms_payload[namespace][name]
 
     def keys(self):
         for ns, values in self.context._tms_payload.items():


### PR DESCRIPTION
### Was gibts neues

Fix für den Autoflächen Incident in vivi. Autoflächen stiegen mit `AttributeError: 'Article' object has no attribute '_tms_payload'` Außerdem aufräumen des Logging Eintrags.

### Wie testen

`$ bin/serve$ und dann
`http://localhost:8080/repository/test/test-louisa/digital-index-production-kopie`
sowie
`$ bin/test vivi/core/src/zeit/reach/tests/test_reach.py`

### Relevantes Ticket

https://zeit-online.atlassian.net/browse/ZO-496