### PR TITLE
ZO-488: Add article_id to volume toc

### DIFF
--- a/core/docs/changelog/ZO-488.change
+++ b/core/docs/changelog/ZO-488.change
@@ -1,0 +1,1 @@
+ZO-488: Include interred article-id in volume toc entries

--- a/core/src/zeit/content/volume/browser/tests/test_toc.py
+++ b/core/src/zeit/content/volume/browser/tests/test_toc.py
@@ -28,7 +28,9 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
                           'authors': 'Helmut Schmidt',
                           'volume': u'1',
                           'year': u'2015',
-                          'supertitle': 'Super'}]
+                          'supertitle': 'Super',
+                          'article_id': '1234567'
+                          }]
              }
         )
         self.toc_data['Anderer'] = OrderedDict(
@@ -41,6 +43,7 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
                  'supertitle': 'Super',
                  'volume': '1',
                  'year': '2015',
+                 'article_id': '0123456'
                  },
                 {'page': '3',
                  'access': u'frei verfügbar',
@@ -49,7 +52,8 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
                  'teaser': 'tease',
                  'volume': '1',
                  'year': '2015',
-                 'supertitle': 'Super'}
+                 'supertitle': 'Super',
+                 'article_id': '0123456'}
             ]}
         )
         self.article_xml_template = u"""
@@ -61,6 +65,8 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
                     name="access">free</attribute>
                     <attribute ns="http://namespaces.zeit.de/CMS/document"
                     name="author">Helmut Schmidt</attribute>
+                    <attribute ns="http://namespaces.zeit.de/CMS/interred"
+                    name="article_id">0123456</attribute>
                 </head>
                 <body>
                      <title>Titel</title>
@@ -91,13 +97,15 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         self.assertIn('politik', foldernames)
 
     def test_create_toc_element_should_flatten_linebreaks(self):
+        import pdb; pdb.set_trace()
         article_xml = self.article_xml_template.format(page='20-20')
         expected = {'page': 20,
                     'title': 'Titel',
                     'teaser': 'Das soll der Teaser sein',
                     'supertitle': '',
                     'access': u'frei verfügbar',
-                    'authors': 'Helmut Schmidt'
+                    'authors': 'Helmut Schmidt',
+                    'article_id': '0123456'
                     }
         article_element = lxml.etree.fromstring(article_xml)
         toc = Toc(mock.Mock(), mock.Mock())
@@ -105,9 +113,9 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         self.assertEqual(expected, result)
 
     def test_csv_is_created_from_toc_data(self):
-        expected = """1\ttitle tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tPolitik\t2015\t1\tDie Zeit\tHelmut Schmidt\r
-1\ttitle tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tDossier\t2015\t1\tAnderer\tHelmut Kohl\r
-3\ttitle2 tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tDossier\t2015\t1\tAnderer\tHelmut Schmidt, Helmut Kohl\r
+        expected = """1\ttitle tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tPolitik\t2015\t1\tDie Zeit\tHelmut Schmidt\t1234567\r
+1\ttitle tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tDossier\t2015\t1\tAnderer\tHelmut Kohl\t0123456\r
+3\ttitle2 tease\t\t\tfrei verfügbar\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tDossier\t2015\t1\tAnderer\tHelmut Schmidt, Helmut Kohl\t0123456\r
 """
         context = mock.Mock()
         context.year = 2015
@@ -204,6 +212,7 @@ class TocBrowserTest(zeit.content.volume.testing.BrowserTestCase):
                     'ZEI', '2015', '01', ressort_name)
             with zeit.cms.testing.interaction():
                 article = create_article()
+                article.ir_article_id = '0123456'
                 article.year = 2015
                 article.volume = 1
                 article.title = self.article_title

--- a/core/src/zeit/content/volume/browser/tests/test_toc.py
+++ b/core/src/zeit/content/volume/browser/tests/test_toc.py
@@ -97,7 +97,6 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         self.assertIn('politik', foldernames)
 
     def test_create_toc_element_should_flatten_linebreaks(self):
-        import pdb; pdb.set_trace()
         article_xml = self.article_xml_template.format(page='20-20')
         expected = {'page': 20,
                     'title': 'Titel',

--- a/core/src/zeit/content/volume/browser/toc.py
+++ b/core/src/zeit/content/volume/browser/toc.py
@@ -213,7 +213,7 @@ class Toc(zeit.cms.browser.view.Base):
         """
         :param article_element: lxml.etree Article element
         :return: {'page': int, 'title': str, 'teaser': str, 'supertitle':
-        str, 'access': bool, 'authors': str}
+        str, 'access': bool, 'authors': str, 'article_id': str}
         """
         toc_entry = self._get_metadata_from_article_xml(article_element)
         if self._is_sane(toc_entry) and self.excluder.is_relevant(
@@ -227,7 +227,7 @@ class Toc(zeit.cms.browser.view.Base):
         Get all relevant normalized metadata from article xml tree.
         :param atricle_tree: lxml.etree Element
         :return: {'page': int, 'title': str, 'teaser': str, 'supertitle': str,
-        'access': bool, 'authors': str}
+        'access': bool, 'authors': str, 'article_id': str}
         """
         xpaths = {
             'title': "body/title/text()",
@@ -235,7 +235,8 @@ class Toc(zeit.cms.browser.view.Base):
             'teaser': "body/subtitle/text()",
             'supertitle': "body/supertitle/text()",
             'access': "//attribute[@name='access']/text()",
-            'authors': "//attribute[@name='author']/text()"
+            'authors': "//attribute[@name='author']/text()",
+            'article_id': "//attribute[@name='article_id']/text()"
         }
         res = {}
         for key, xpath in xpaths.items():
@@ -377,7 +378,8 @@ class Toc(zeit.cms.browser.view.Base):
             [''] * 8 + [toc_entry.get('image_url', '')] +
             [''] * 5 + [toc_entry.get('preview_url', '')] +
             [ressort_name, str(self._context_year), str(self._context_volume),
-                product_name, toc_entry.get('authors', '')])
+                product_name, toc_entry.get('authors', ''),
+                toc_entry.get('article_id', '')])
 
 
 PRODUCTS = zeit.cms.content.sources.PRODUCT_SOURCE(None)


### PR DESCRIPTION
### Was gibts neues?

Eindeutige ID (`ir_article_id`) für Artikel im Inhaltsverzeichnis der Ausgabe um die Zuordnung bei Änderungen zu erleichtern.

### Wie testen

`$ bin/test vivi/core/src/zeit/content/volume/browser/tests/test_toc.py`
oder lokal 
`$ bin/serve`
und dann ein Ausgabenobjekt aufrufen, beispielsweise:
`http://localhost:8080/repository/2021/01/ausgabe/@@view.html`
und Inhaltsverzeichnis erzeugen. Am Ende der Zeile sollte bei Artikeln die  `article_id` im Format `1234567` stehen. Soweit ich sehen kann, sollen das sieben Ziffern sein.

### Ticket

https://zeit-online.atlassian.net/browse/ZO-488