### PR TITLE
ZO-582: Use vivi API for volume toc, this correctly includes author names

### DIFF
--- a/core/docs/changelog/ZO-582.change
+++ b/core/docs/changelog/ZO-582.change
@@ -1,0 +1,1 @@
+ZO-582: Use vivi API for volume toc, this correctly includes author names

--- a/core/src/zeit/content/volume/browser/configure.zcml
+++ b/core/src/zeit/content/volume/browser/configure.zcml
@@ -8,17 +8,6 @@
 
   <grok:grok package="." />
 
-  <utility
-    zcml:condition="have zeit.content.volume.toc"
-    provides="zeit.content.volume.interfaces.ITocConnector"
-    factory=".toc.toc_connector_factory"
-    />
-  <utility
-    zcml:condition="not-have zeit.content.volume.toc"
-    provides="zeit.content.volume.interfaces.ITocConnector"
-    factory="zeit.connector.mock.connector_factory"
-    />
-
   <browser:page
      for="zeit.cms.repository.interfaces.IFolder"
      layer="zeit.cms.browser.interfaces.ICMSLayer"

--- a/core/src/zeit/content/volume/browser/tests/test_toc.py
+++ b/core/src/zeit/content/volume/browser/tests/test_toc.py
@@ -128,10 +128,6 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         excluder = Excluder()
         xml_template = u"""
         <article>
-            <head>
-                <attribute ns="http://namespaces.zeit.de/CMS/document"
-                name="jobname">{d[jobname]}</attribute>
-            </head>
             <body>
                  <title>{d[title]}</title>
                  <supertitle>{d[supertitle]}</supertitle>
@@ -139,8 +135,7 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         </article>
         """
         for values in [{'title': u'Heute 20.02.2016'},
-                       {'supertitle': u'WIR RATEN AB'},
-                       {'jobname': u'AS-Zahl'}]:
+                       {'supertitle': u'WIR RATEN AB'}]:
             xml = xml_template.format(d=defaultdict(str, **values))
             self.assertEqual(False,
                              excluder.is_relevant(lxml.etree.fromstring(xml)))

--- a/core/src/zeit/content/volume/browser/tests/test_toc.py
+++ b/core/src/zeit/content/volume/browser/tests/test_toc.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 from unittest import mock
 from zeit.content.article.testing import create_article
-from zeit.content.volume.browser.toc import Toc, Excluder
+from zeit.content.volume.browser.toc import Toc
 from zeit.content.volume.volume import Volume
 import lxml.etree
 import sys
@@ -124,21 +124,10 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
         assert sys.maxsize == result.get('Die Zeit').get('Politik')[-1].get(
             'page')
 
-    def test_article_excluder_excludes_blacklisted_property_values(self):
-        excluder = Excluder()
-        xml_template = u"""
-        <article>
-            <body>
-                 <title>{d[title]}</title>
-                 <supertitle>{d[supertitle]}</supertitle>
-            </body>
-        </article>
-        """
-        for values in [{'title': u'Heute 20.02.2016'},
-                       {'supertitle': u'WIR RATEN AB'}]:
-            xml = xml_template.format(d=defaultdict(str, **values))
-            self.assertEqual(False,
-                             excluder.is_relevant(lxml.etree.fromstring(xml)))
+    def test_excludes_given_property_values(self):
+        for toc in [{'title': 'Heute 20.02.2016'},
+                    {'supertitle': 'WIR RATEN AB'}]:
+            self.assertFalse(Toc._is_relevant(toc))
 
 
 class TocBrowserTest(zeit.content.volume.testing.BrowserTestCase):
@@ -163,6 +152,7 @@ class TocBrowserTest(zeit.content.volume.testing.BrowserTestCase):
                 article.year = 2015
                 article.volume = 1
                 article.title = self.article_title
+                article.subtitle = 'required'
                 article.page = self.article_page
                 article.printRessort = 'ressort %s' % ressort
                 self.repository['2015']['01'][

--- a/core/src/zeit/content/volume/browser/toc.py
+++ b/core/src/zeit/content/volume/browser/toc.py
@@ -4,15 +4,9 @@ from collections import OrderedDict, defaultdict
 from six import StringIO, ensure_str
 from zeit.cms.browser.interfaces import IPreviewURL
 from zeit.cms.i18n import MessageFactory as _
-from zeit.cms.repository.interfaces import IFolder
-from zeit.connector.interfaces import IConnector
-from zeit.content.article.interfaces import IArticle
-from zeit.content.volume.interfaces import ITocConnector
-import contextlib
 import csv
 import os.path
 import re
-import six.moves.urllib.parse
 import sys
 import zeit.cms.browser.view
 import zeit.cms.content.sources
@@ -24,54 +18,13 @@ import zope.site.site
 
 
 class Toc(zeit.cms.browser.view.Base):
-    """
-    View for creating a Table of Content as a csv file.
-    The dav url to the articles generally looks like
-    ARCHIVE_ROOT/PRODUCT_ID/RESSORT_NAME/ARTICLE.xml
-    E.g.
-    cms-backend.zeit.de/cms/archiv-wf/archiv/ZEI/2016/23/entdecken/03-Normalo
-    """
+
     CSV_DELIMITER = '\t'
 
     def __init__(self, context, request):
         self.context = context
         self.request = request
-        config = zope.app.appsetup.product \
-            .getProductConfiguration('zeit.content.volume')
-        self.dav_archive_url = config.get('dav-archive-url')
-        self.dav_archive_url_parsed = six.moves.urllib.parse.urlparse(
-            self.dav_archive_url)
         self.excluder = Excluder()
-        # We need to remember our context DAV properties, as we can't get to
-        # them after we change IConnector to ITocConnector. But since we only
-        # need year+volume (for fill_template), we can get away with this.
-        self._context_year = self.context.year
-        self._context_volume = self.context.volume
-        self.connector = zope.component.getUtility(ITocConnector)
-
-    @contextlib.contextmanager
-    def _register_archive_connector(self):
-        """
-        Due to the need of using another section of the WebDAV-Server(
-        /cms/wf-archiv...) a new
-        IConnector has to be registered, otherwise the
-        cms.repository.Repository could not be used afterwards.
-        """
-        default_registry = zope.component.getSiteManager()
-        site = zope.site.site.SiteManagerContainer()
-        registry = zope.site.site.LocalSiteManager(site, default_folder=False)
-        registry.__bases__ = (default_registry,)
-        # New registry has to removed as a sub from the base registry,
-        # because otherwise the base registry has a reference on the new one.
-        # This would make the new registry persistent.
-        default_registry.removeSub(registry)
-        site.setSiteManager(registry)
-        registry.registerUtility(self.connector, IConnector)
-
-        old_site = zope.component.hooks.getSite()
-        zope.component.hooks.setSite(site)
-        yield
-        zope.component.hooks.setSite(old_site)
 
     def __call__(self):
         filename = self._generate_file_name()
@@ -82,8 +35,8 @@ class Toc(zeit.cms.browser.view.Base):
 
     def _fill_template(self, text):
         dummy = zeit.content.volume.volume.Volume()
-        dummy.year = self._context_year
-        dummy.volume = self._context_volume
+        dummy.year = self.context.year
+        dummy.volume = self.context.volume
         return dummy.fill_template(text)
 
     def _generate_file_name(self):
@@ -92,49 +45,9 @@ class Toc(zeit.cms.browser.view.Base):
         return "{}_{}.csv".format(toc_file_string, volume_formatted)
 
     def _create_toc_content(self):
-        """
-        Create Table of Contents for the given Volume as a csv.
-        :return: str - Table of content csv string
-        """
-        with self._register_archive_connector():
-            toc_data = self._get_k4_content()
-        ir_data = self._get_ir_content()
-        self._merge_ir_into_k4(toc_data, ir_data)
+        toc_data = self._get_ir_content()
         sorted_toc_data = self._sort_toc_data(toc_data)
         return self._create_csv(sorted_toc_data)
-
-    def _get_k4_content(self):
-        """
-        Get and parse xml form webdav und create toc entries.
-        :return: OrderedDict of Toc entries.
-        Sorted like toc-product-ids given list in the product config.
-        {
-        'Product Name':
-            {
-            'Ressort' :
-                [{'page': int, 'title': str, 'teaser': str, 'supertitle':
-                str, 'access': bool},
-                ...]
-            }
-        }
-        """
-        results = OrderedDict()
-        for product in self.product_ids:
-            result_for_product = {}
-            product_folder = self._fill_template(
-                'http://xml.zeit.de/%s/{year}/{name}/' % product)
-            for ressort_folder in self.list_relevant_ressort_folders(
-                    product_folder):
-                result_for_ressort = []
-                for article in self._get_all_article_elements(ressort_folder):
-                    toc_entry = self._create_toc_element(article)
-                    if toc_entry:
-                        result_for_ressort.append(toc_entry)
-                ressort_folder_name = ressort_folder.__name__ \
-                    .replace('-', ' ').title()
-                result_for_product[ressort_folder_name] = result_for_ressort
-            results[self._full_product_name(product)] = result_for_product
-        return results
 
     MEDIASYNC_ID = ('mediasync_id', 'http://namespaces.zeit.de/CMS/interred')
 
@@ -167,13 +80,6 @@ class Toc(zeit.cms.browser.view.Base):
             results[product.title] = result_for_product
         return results
 
-    def _merge_ir_into_k4(self, k4_data, ir_data):
-        for product, ir_product in ir_data.items():
-            k4_product = k4_data[product]
-            for name, ir_ressort in ir_product.items():
-                k4_ressort = k4_product.setdefault(name, [])
-                k4_ressort.extend(ir_ressort)
-
     @property
     def product_ids(self):
         """ List [First Product ID, Second ...] """
@@ -181,33 +87,6 @@ class Toc(zeit.cms.browser.view.Base):
             .getProductConfiguration('zeit.content.volume')
         ids_as_string = config.get('toc-product-ids')
         return [product_id.strip() for product_id in ids_as_string.split(' ')]
-
-    def list_relevant_ressort_folders(self, product_uid):
-        """
-        :param product_uid: uid to product for the volume
-        :return: [zeit.cms.repository.folder.Folder, ...]
-        """
-        try:
-            product_folder = \
-                zeit.cms.interfaces.ICMSContent(self.connector[product_uid])
-            return [item[1] for item in product_folder.items()
-                    if self._is_relevant_folder_item(item)]
-        except KeyError:
-            return []
-
-    def _is_relevant_folder_item(self, item):
-        return (IFolder.providedBy(item[1]) and
-                self.excluder.is_relevant_folder(item[0]))
-
-    def _get_all_article_elements(self, ressort_folder):
-        """
-        Returns lxml-Objects for all Articles in ressort_folder.
-        Using the adapted IArticle doesn't work due to some difference in
-        the page xml element, which can't be parsed the normal way.
-        :return: [lxml.etree Article element, ...]
-        """
-        return [resource.xml for resource in ressort_folder.values()
-                if IArticle.providedBy(resource)]
 
     def _create_toc_element(self, article_element):
         """
@@ -377,7 +256,7 @@ class Toc(zeit.cms.browser.view.Base):
             [str(page), title_teaser, '', '', toc_entry.get('access')] +
             [''] * 8 + [toc_entry.get('image_url', '')] +
             [''] * 5 + [toc_entry.get('preview_url', '')] +
-            [ressort_name, str(self._context_year), str(self._context_volume),
+            [ressort_name, str(self.context.year), str(self.context.volume),
                 product_name, toc_entry.get('authors', ''),
                 toc_entry.get('article_id', '')])
 
@@ -454,19 +333,3 @@ class Excluder(object):
              for jobname_pattern in self._compiled_jobname_regexs]
         )
         return not(title_exclude or supertitle_exclude or jobname_exclude)
-
-    def is_relevant_folder(self, folder_path):
-        """Checks if a folder is on the blacklist."""
-        folders_to_exclude = {'images', 'leserbriefe'}
-        folders_to_exclude = set.union(
-            folders_to_exclude,
-            {ele.title() for ele in folders_to_exclude})
-        return not any(folder in folder_path for folder in folders_to_exclude)
-
-
-def toc_connector_factory():
-    config = zope.app.appsetup.product.getProductConfiguration(
-        'zeit.content.volume')
-    dav_archive_url = config.get('dav-archive-url')
-    return zeit.connector.connector.TransactionBoundCachingConnector(
-        {'default': dav_archive_url})

--- a/core/src/zeit/content/volume/browser/toc.py
+++ b/core/src/zeit/content/volume/browser/toc.py
@@ -272,7 +272,6 @@ class Excluder(object):
     # otherwise the wrong article might get excluded
     TITLE_XPATH = "body/title/text()"
     SUPERTITLE_XPATH = "body/supertitle/text()"
-    JOBNAME_XPATH = "//attribute[@name='jobname']/text()"
     _title_exclude = [
         u"Heute \\d+.\\d+",
         u"Damals \\d+.\\d+",
@@ -297,28 +296,20 @@ class Excluder(object):
         u"(LESE|BASTEL)-TIPP"
     ]
 
-    _jobname_exclude = [
-        u'(Mail |AS-Zahl|Impressum)'
-    ]
-
     def __init__(self):
         self._compiled_title_regexs = [re.compile(r, re.IGNORECASE)
                                        for r in self._title_exclude]
         self._compiled_supertitle_regexs = [re.compile(r, re.IGNORECASE)
                                             for r in self._supertitle_exclude]
-        self._compiled_jobname_regexs = [re.compile(r, re.IGNORECASE)
-                                         for r in self._jobname_exclude]
 
     def is_relevant(self, article_lxml_tree):
         title_values = article_lxml_tree.xpath(self.TITLE_XPATH)
         supertitle_values = article_lxml_tree.xpath(self.SUPERTITLE_XPATH)
-        jobname_values = article_lxml_tree.xpath(self.JOBNAME_XPATH)
 
         title_value = title_values[0] \
             if len(title_values) > 0 else ''
         supertitle_value = supertitle_values[0] \
             if len(supertitle_values) > 0 else ''
-        jobname_value = jobname_values[0] if len(jobname_values) > 0 else ''
 
         title_exclude = any(
             [re.match(title_pattern, title_value)
@@ -328,8 +319,4 @@ class Excluder(object):
             [re.match(supertitle_pattern, supertitle_value)
              for supertitle_pattern in self._compiled_supertitle_regexs]
         )
-        jobname_exclude = any(
-            [re.match(jobname_pattern, jobname_value)
-             for jobname_pattern in self._compiled_jobname_regexs]
-        )
-        return not(title_exclude or supertitle_exclude or jobname_exclude)
+        return not(title_exclude or supertitle_exclude)

--- a/core/src/zeit/content/volume/ftesting.zcml
+++ b/core/src/zeit/content/volume/ftesting.zcml
@@ -14,6 +14,8 @@
 
   <include package="zeit.content.article" />
   <include package="zeit.content.article.browser" />
+  <include package="zeit.content.author" />
+  <includeOverrides package="zeit.content.author" file="mock.zcml" />
   <include package="zeit.content.infobox" />
   <include package="zeit.content.portraitbox" />
 

--- a/core/src/zeit/content/volume/testing.py
+++ b/core/src/zeit/content/volume/testing.py
@@ -9,7 +9,6 @@ import zeit.content.image.testing
 product_config = """
 <product-config zeit.content.volume>
     volume-cover-source file://{here}/tests/fixtures/volume-covers.xml
-    dav-archive-url test
     toc-product-ids ZEI BAD
     default-teaser-text Teäser {{name}}/{{year}}
     access-control-config file://{here}/tests/fixtures/access-control.xml


### PR DESCRIPTION
Nach dem Release kann `vivi_zeit.content.volume_dav-archive-url` aus dem vivi-deployment entfernt werden.