### PR TITLE
ZO-680: add intersection type choice field for liveblog module

### DIFF
--- a/core/docs/changelog/ZO-680.change
+++ b/core/docs/changelog/ZO-680.change
@@ -1,0 +1,1 @@
+ZO-680: Add z.c.article module ITickarooLiveblog.intersection

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -323,6 +323,12 @@ class ITickarooLiveblog(zeit.edit.interfaces.IBlock):
         default='default',
         required=True)
 
+    intersection_type = zope.schema.Choice(
+        title=_('Intersections'),
+        source=LiveblogSource('*//intersection_type'),
+        default='chapter',
+        required=True)
+
 
 class PodigeeProvidersSource(zeit.cms.content.sources.SearchableXMLSource):
     """A source for podigee providers config. API keys must be configured

--- a/core/src/zeit/content/modules/liveblog.py
+++ b/core/src/zeit/content/modules/liveblog.py
@@ -19,3 +19,6 @@ class TickarooLiveblog(zeit.edit.block.Element):
 
     theme = ObjectPathAttributeProperty(
         '.', 'theme', ITickarooLiveblog['theme'])
+
+    intersection_type = ObjectPathAttributeProperty(
+        '.', 'intersection_type', ITickarooLiveblog['intersection_type'])


### PR DESCRIPTION
Hat etwas gedauert, bis ich gefunden habe, wo die einzelnen Felder angelegt werden... 🙄 (vlt für Louisa interessant: nämlich in `data/liveblog.xml`)