### PR TITLE
ZO-165: Repair publish dynamic folder

### DIFF
--- a/core/docs/changelog/ZO-165.change
+++ b/core/docs/changelog/ZO-165.change
@@ -1,0 +1,1 @@
+ZO-165: Publish dynamic folders without virtual content

--- a/core/src/zeit/cms/repository/configure.zcml
+++ b/core/src/zeit/cms/repository/configure.zcml
@@ -1,6 +1,9 @@
 <configure
   xmlns="http://namespaces.zope.org/zope"
-  xmlns:zcml="http://namespaces.zope.org/zcml">
+  xmlns:zcml="http://namespaces.zope.org/zcml"
+  xmlns:grok="http://namespaces.zope.org/grok">
+
+  <grok:grok package="." exclude="browser tests" />
 
   <include file="file.zcml" />
 

--- a/core/src/zeit/cms/repository/folder.py
+++ b/core/src/zeit/cms/repository/folder.py
@@ -1,9 +1,12 @@
+import grokcore.component as grok
+
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.content.interfaces
 import zeit.cms.repository.interfaces
 import zeit.cms.repository.repository
 import zeit.cms.type
 import zeit.cms.util
+import zeit.workflow.dependency
 import zope.interface
 
 
@@ -38,3 +41,14 @@ def folder_sort_key(context):
     weight = -5  # folders first
     key = context.__name__.lower()
     return (weight, key)
+
+
+class FolderDependencies(zeit.workflow.dependency.DependencyBase):
+
+    grok.context(zeit.cms.repository.interfaces.ICollection)
+    grok.name('zeit.cms.repository.folder')
+
+    retract_dependencies = True
+
+    def get_dependencies(self):
+        return self.context.values()

--- a/core/src/zeit/cms/repository/tests/test_folder.py
+++ b/core/src/zeit/cms/repository/tests/test_folder.py
@@ -1,4 +1,6 @@
 import zeit.cms.testing
+import zeit.cms.interfaces
+import zeit.workflow.interfaces
 import zope.copypastemove.interfaces
 
 
@@ -10,3 +12,16 @@ class RenameFolderTest(zeit.cms.testing.ZeitCmsTestCase):
         renamer.renameItem('online', 'offline')
         self.assertNotIn('online', self.repository)
         self.assertIn('offline', self.repository)
+
+
+class FolderDependenciesTest(zeit.cms.testing.ZeitCmsTestCase):
+
+    def test_folder_dependencies(self):
+        folder = zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/online/2007')
+        dependencies = list(zeit.workflow.interfaces.IPublicationDependencies(
+            folder).get_dependencies())
+        self.assertEqual(
+            'http://xml.zeit.de/online/2007/01/', dependencies[0].uniqueId)
+        self.assertEqual(
+            'http://xml.zeit.de/online/2007/02/', dependencies[1].uniqueId)

--- a/core/src/zeit/cms/repository/tests/test_folder.py
+++ b/core/src/zeit/cms/repository/tests/test_folder.py
@@ -1,7 +1,9 @@
+import zope.copypastemove.interfaces
+
 import zeit.cms.testing
 import zeit.cms.interfaces
 import zeit.workflow.interfaces
-import zope.copypastemove.interfaces
+import zeit.workflow.testing
 
 
 class RenameFolderTest(zeit.cms.testing.ZeitCmsTestCase):
@@ -15,6 +17,8 @@ class RenameFolderTest(zeit.cms.testing.ZeitCmsTestCase):
 
 
 class FolderDependenciesTest(zeit.cms.testing.ZeitCmsTestCase):
+
+    layer = zeit.workflow.testing.CELERY_LAYER
 
     def test_folder_dependencies(self):
         folder = zeit.cms.interfaces.ICMSContent(

--- a/core/src/zeit/cms/repository/tests/test_folder.py
+++ b/core/src/zeit/cms/repository/tests/test_folder.py
@@ -16,9 +16,7 @@ class RenameFolderTest(zeit.cms.testing.ZeitCmsTestCase):
         self.assertIn('offline', self.repository)
 
 
-class FolderDependenciesTest(zeit.cms.testing.ZeitCmsTestCase):
-
-    layer = zeit.workflow.testing.CELERY_LAYER
+class FolderDependenciesTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_folder_dependencies(self):
         folder = zeit.cms.interfaces.ICMSContent(

--- a/core/src/zeit/content/dynamicfolder/folder.py
+++ b/core/src/zeit/content/dynamicfolder/folder.py
@@ -312,3 +312,14 @@ class ConfigDependency(zeit.workflow.dependency.DependencyBase):
             if config is not None:
                 result.append(config)
         return result
+
+
+class FolderDependencies(zeit.workflow.dependency.DependencyBase):
+
+    grok.context(zeit.content.dynamicfolder.interfaces.IDynamicFolder)
+    grok.name('zeit.cms.repository.folder')
+
+    retract_dependencies = True
+
+    def get_dependencies(self):
+        return []

--- a/core/src/zeit/content/dynamicfolder/tests/test_folder.py
+++ b/core/src/zeit/content/dynamicfolder/tests/test_folder.py
@@ -270,6 +270,16 @@ class TestDynamicFolder(
         self.assertNotIn('http://xml.zeit.de/dynamicfolder/xinjiang', calls)
         self.assertNotIn('http://xml.zeit.de/dynamicfolder/überlingen', calls)
 
+    def test_folder_dependencies(self):
+        dependencies = list(zeit.workflow.interfaces.IPublicationDependencies(
+            self.folder).get_dependencies())
+        self.assertEqual(
+            'http://xml.zeit.de/data/config.xml',
+            dependencies[0].uniqueId)
+        self.assertEqual(
+            'http://xml.zeit.de/data/template.xml',
+            dependencies[1].uniqueId)
+
 
 class MaterializeDynamicFolder(
         zeit.cms.testing.FunctionalTestCase):

--- a/core/src/zeit/content/dynamicfolder/tests/test_folder.py
+++ b/core/src/zeit/content/dynamicfolder/tests/test_folder.py
@@ -9,6 +9,7 @@ import lxml.etree
 import pkg_resources
 import six
 import transaction
+import zope.component
 import zeit.cms.repository.folder
 import zeit.cms.testcontenttype.testcontenttype
 import zeit.cms.testing
@@ -245,6 +246,29 @@ class TestDynamicFolder(
         transaction.commit()
         with self.assertNothingRaised():
             self.repository['brokenfolder'].values()
+
+    def test_publish_dynamic_folder(self):
+        calls = []
+
+        def check_publish(context, event):
+            calls.append(context.uniqueId)
+
+        zope.component.getGlobalSiteManager().registerHandler(
+            check_publish, (
+                zeit.cms.repository.interfaces.IRepositoryContent,
+                zeit.cms.workflow.interfaces.IPublishedEvent
+            )
+        )
+        zeit.cms.workflow.interfaces.IPublish(
+            self.folder).publish(background=False)
+        self.assertIn('http://xml.zeit.de/dynamicfolder/', calls)
+        self.assertIn('http://xml.zeit.de/data/config.xml', calls)
+        self.assertIn('http://xml.zeit.de/data/template.xml', calls)
+        self.assertNotIn('http://xml.zeit.de/dynamicfolder/art-déco', calls)
+        self.assertNotIn('http://xml.zeit.de/dynamicfolder/xaernten', calls)
+        self.assertNotIn('http://xml.zeit.de/dynamicfolder/xanten', calls)
+        self.assertNotIn('http://xml.zeit.de/dynamicfolder/xinjiang', calls)
+        self.assertNotIn('http://xml.zeit.de/dynamicfolder/überlingen', calls)
 
 
 class MaterializeDynamicFolder(

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -243,7 +243,6 @@ class PublishRetractTask(object):
             deps = zeit.workflow.interfaces.IPublicationDependencies(new_obj)
             if self.mode == MODE_PUBLISH:
                 stack.extend(deps.get_dependencies())
-                timer.mark('Recursed into %s' % (new_obj.uniqueId,))
             elif self.mode == MODE_RETRACT:
                 stack.extend(deps.get_retract_dependencies())
             else:

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -239,15 +239,11 @@ class PublishRetractTask(object):
                 # should not count towards the limit
                 break
 
-            # Dive into folders
-            if zeit.cms.repository.interfaces.ICollection.providedBy(new_obj):
-                stack.extend(new_obj.values())
-                timer.mark('Recursed into %s' % (new_obj.uniqueId,))
-
             # Dive into dependent objects
             deps = zeit.workflow.interfaces.IPublicationDependencies(new_obj)
             if self.mode == MODE_PUBLISH:
                 stack.extend(deps.get_dependencies())
+                timer.mark('Recursed into %s' % (new_obj.uniqueId,))
             elif self.mode == MODE_RETRACT:
                 stack.extend(deps.get_retract_dependencies())
             else:


### PR DESCRIPTION
This gif says it all ...

Dieser PR repariert das Veröffentlichen von dynamischen Ordnern. Virtuelle Inhalte welche im DAV nicht existieren werden beim Veröffentlichen nicht mehr berücksichtigt.

![mad](https://media.giphy.com/media/ws4pzeC916KRO/giphy.gif)