### PR TITLE
ZO-538: Separate search results from search function

### DIFF
--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -243,9 +243,9 @@ class Connector(zeit.connector.filesystem.Connector):
         return self._locked.get(id, (None, None, False))
 
     search_result_default = [
-            'http://xml.zeit.de/online/2007/01/Somalia',
-            'http://xml.zeit.de/online/2007/01/Saarland',
-            'http://xml.zeit.de/2006/52/Stimmts']
+        'http://xml.zeit.de/online/2007/01/Somalia',
+        'http://xml.zeit.de/online/2007/01/Saarland',
+        'http://xml.zeit.de/2006/52/Stimmts']
 
     def search(self, attributes, expression):
         log.debug("Searching: %s", expression._render())

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -250,7 +250,7 @@ class Connector(zeit.connector.filesystem.Connector):
     def search(self, attributes, expression):
         log.debug("Searching: %s", expression._render())
 
-        unique_ids = self.search_result_default
+        unique_ids = self.search_result
 
         metadata = ('pm', '07') + len(attributes) * (None,)
         metadata = metadata[:len(attributes)]

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -53,6 +53,7 @@ class Connector(zeit.connector.filesystem.Connector):
         self._paths = {}
         self._deleted = set()
         self._properties = {}
+        self.search_result_default = self.search_result_default
 
     def listCollection(self, id):
         """List the filenames of a collection identified by path. """
@@ -241,13 +242,15 @@ class Connector(zeit.connector.filesystem.Connector):
         id = self._get_cannonical_id(id)
         return self._locked.get(id, (None, None, False))
 
-    def search(self, attributes, expression):
-        log.debug("Searching: %s", expression._render())
-
-        unique_ids = [
+    search_result_default = [
             'http://xml.zeit.de/online/2007/01/Somalia',
             'http://xml.zeit.de/online/2007/01/Saarland',
             'http://xml.zeit.de/2006/52/Stimmts']
+
+    def search(self, attributes, expression):
+        log.debug("Searching: %s", expression._render())
+
+        unique_ids = self.search_result_default
 
         metadata = ('pm', '07') + len(attributes) * (None,)
         metadata = metadata[:len(attributes)]

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -53,7 +53,7 @@ class Connector(zeit.connector.filesystem.Connector):
         self._paths = {}
         self._deleted = set()
         self._properties = {}
-        self.search_result_default = self.search_result_default
+        self.search_result = self.search_result_default[:]
 
     def listCollection(self, id):
         """List the filenames of a collection identified by path. """


### PR DESCRIPTION
Not sure, if that works as intended, or just resets with the results that a test set up.