### PR TITLE
MAINT: Declare pytest markers in code instead of external configuration

### DIFF
--- a/core/src/zeit/conftest.py
+++ b/core/src/zeit/conftest.py
@@ -2,6 +2,12 @@ import os
 
 
 def pytest_configure(config):
+    config.addinivalue_line(
+        'markers', 'slow: This is a non-unit test and thus is not run by '
+        'default. Use ``-m slow`` to run these, or ``-m 1`` to run all tests.')
+    config.addinivalue_line(
+        'markers', 'selenium: Selenium tests are not run by default.')
+
     os.environ.setdefault('GOCEPT_WEBDRIVER_BROWSER', 'firefox')
 
     if config.getoption('visible'):


### PR DESCRIPTION
We also _use_ them in code, so this makes way more sense.