### PR TITLE
ZO-365: resize additional images in imagegroups while uploading

### DIFF
--- a/core/docs/changelog/ZO-365.fix
+++ b/core/docs/changelog/ZO-365.fix
@@ -1,0 +1,1 @@
+ZO-365: resize uploaded single images

--- a/core/src/zeit/content/image/browser/form.py
+++ b/core/src/zeit/content/image/browser/form.py
@@ -43,7 +43,7 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
             ','.join(zeit.content.image.interfaces.AVAILABLE_MIME_TYPES))
 
 
-class createImagePreprocess(zeit.cms.browser.form.AddForm):
+class Resize:
 
     def reduceToMaxImageSize(self, image):
         config = zope.app.appsetup.product.getProductConfiguration(
@@ -63,8 +63,7 @@ class createImagePreprocess(zeit.cms.browser.form.AddForm):
         return image
 
 
-class AddForm(ImageFormBase, createImagePreprocess,
-              zeit.cms.browser.form.AddForm):
+class AddForm(ImageFormBase, zeit.cms.browser.form.AddForm, Resize):
 
     form_fields = (zope.formlib.form.FormFields(
         zeit.content.image.browser.interfaces.IFileAddSchema) +

--- a/core/src/zeit/content/image/browser/form.py
+++ b/core/src/zeit/content/image/browser/form.py
@@ -1,4 +1,5 @@
 from zeit.cms.i18n import MessageFactory as _
+from zeit.content.image.transform import ImageTransform
 import gocept.form.grouped
 import zeit.cms.browser.form
 import zeit.cms.repository.browser.file
@@ -32,6 +33,9 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
         'acquire_metadata', 'origin')
 
     def __init__(self, *args, **kw):
+        config = zope.app.appsetup.product.getProductConfiguration(
+            'zeit.content.image')
+        self.max_size = config.get('max-image-size', 4000)
         self.form_fields['blob'].custom_widget = (
             zeit.cms.repository.browser.file.BlobWidget)
         super(ImageFormBase, self).__init__(*args, **kw)
@@ -51,10 +55,25 @@ class AddForm(ImageFormBase, zeit.cms.browser.form.AddForm):
     title = _("Add image")
     factory = zeit.content.image.image.LocalImage
 
+    def resize(self, image):
+        size = image.getImageSize()
+        largest = max(size)
+        if largest > self.max_size:
+            self.send_message(
+                _('Image was resized, ${size} exceeds ${max_size}',
+                  mapping={'size': largest, 'max_size': self.max_size}))
+            if size.index(largest) == 0:
+                resize = {'width': self.max_size}
+            else:
+                resize = {'height': self.max_size}
+            image = ImageTransform(image).resize(**resize)
+        return image
+
     def create(self, data):
         image = self.new_object
         blob = data.pop('blob')
         self.update_file(image, blob)
+        image = self.resize(image)
         name = data.pop('__name__')
         if not name:
             name = getattr(blob, 'filename', '')

--- a/core/src/zeit/content/image/browser/imagegroup.py
+++ b/core/src/zeit/content/image/browser/imagegroup.py
@@ -32,8 +32,9 @@ class FormBase(object):
 
 
 class AddForm(FormBase,
-              zeit.content.image.browser.form.createImagePreprocess,
-              zeit.cms.repository.browser.file.FormBase):
+              zeit.cms.repository.browser.file.FormBase,
+              zeit.cms.browser.form.AddForm,
+              zeit.content.image.browser.form.Resize):
 
     title = _('Add image group')
     factory = zeit.content.image.imagegroup.ImageGroup

--- a/core/src/zeit/content/image/browser/imagegroup.py
+++ b/core/src/zeit/content/image/browser/imagegroup.py
@@ -1,7 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
 from zeit.content.image.browser.interfaces import IMasterImageUploadSchema
 from zeit.content.image.browser.mdb import MDBImportWidget
-from zeit.content.image.transform import ImageTransform
 from zeit.content.image.interfaces import INFOGRAPHIC_DISPLAY_TYPE
 from zope.formlib.widget import CustomWidgetFactory
 import gocept.form.grouped
@@ -140,17 +139,7 @@ class AddForm(FormBase,
     def create_image(self, blob, data):
         image = zeit.content.image.image.LocalImage()
         self.update_file(image, blob)
-        size = image.getImageSize()
-        largest = max(size)
-        if largest > self.max_size:
-            self.send_message(
-                _('Image was resized, ${size} exceeds ${max_size}',
-                  mapping={'size': largest, 'max_size': self.max_size}))
-            if size.index(largest) == 0:
-                resize = {'width': self.max_size}
-            else:
-                resize = {'height': self.max_size}
-            image = ImageTransform(image).resize(**resize)
+        image = zeit.content.image.browser.form.AddForm.resize(self, image)
         name = getattr(blob, 'filename', '')
         if name:
             image.__name__ = zeit.cms.interfaces.normalize_filename(name)

--- a/core/src/zeit/content/image/browser/imagegroup.py
+++ b/core/src/zeit/content/image/browser/imagegroup.py
@@ -32,8 +32,8 @@ class FormBase(object):
 
 
 class AddForm(FormBase,
-              zeit.cms.repository.browser.file.FormBase,
-              zeit.cms.browser.form.AddForm):
+              zeit.content.image.browser.form.createImagePreprocess,
+              zeit.cms.repository.browser.file.FormBase):
 
     title = _('Add image group')
     factory = zeit.content.image.imagegroup.ImageGroup
@@ -139,7 +139,7 @@ class AddForm(FormBase,
     def create_image(self, blob, data):
         image = zeit.content.image.image.LocalImage()
         self.update_file(image, blob)
-        image = zeit.content.image.browser.form.AddForm.resize(self, image)
+        image = self.reduceToMaxImageSize(image)
         name = getattr(blob, 'filename', '')
         if name:
             image.__name__ = zeit.cms.interfaces.normalize_filename(name)

--- a/core/src/zeit/content/image/browser/tests/test_image.py
+++ b/core/src/zeit/content/image/browser/tests/test_image.py
@@ -71,3 +71,49 @@ class TestImage(zeit.content.image.testing.BrowserTestCase):
             'image/webp', 'foo.webp')
         b.getControl(name='form.actions.add').click()
         self.assertEllipsis('...Unsupported image type...', b.contents)
+
+    def test_resizes_too_large_image_on_upload_width(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/2006/')
+        menu = b.getControl(name='add_menu')
+        menu.displayValue = ['Image (single)']
+        b.open(menu.value[0])
+        b.getControl(name='form.copyright.combination_00').value = (
+            'ZEIT ONLINE')
+        b.getControl(name='form.copyright.combination_01').displayValue = (
+            ['dpa'])
+        b.getControl(name='form.copyright.combination_03').value = (
+            'http://www.zeit.de/')
+
+        b.getControl(name='form.blob').add_file(
+            pkg_resources.resource_stream(
+                'zeit.content.image.browser',
+                'testdata/shoppingmeile_2251x4001px.jpg'),
+            'image/jpeg', u'föö.jpg'.encode('utf-8'))
+        b.getControl(name='form.actions.add').click()
+        img = zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/2006/foeoe.jpg')
+        assert(img.getImageSize()) == (2250, 4000)
+
+    def test_resizes_too_large_image_on_upload_height(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/2006/')
+        menu = b.getControl(name='add_menu')
+        menu.displayValue = ['Image (single)']
+        b.open(menu.value[0])
+        b.getControl(name='form.copyright.combination_00').value = (
+            'ZEIT ONLINE')
+        b.getControl(name='form.copyright.combination_01').displayValue = (
+            ['dpa'])
+        b.getControl(name='form.copyright.combination_03').value = (
+            'http://www.zeit.de/')
+
+        b.getControl(name='form.blob').add_file(
+            pkg_resources.resource_stream(
+                'zeit.content.image.browser',
+                'testdata/shoppingmeile_4001x2251px.jpg'),
+            'image/jpeg', u'bär.jpg'.encode('utf-8'))
+        b.getControl(name='form.actions.add').click()
+        img = zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/2006/baer.jpg')
+        assert(img.getImageSize()) == (4000, 2250)

--- a/core/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -103,6 +103,16 @@ class ImageGroupBrowserTest(
             'http://xml.zeit.de/imagegroup/shoppingmeile-2251x4001px.jpg')
         assert(img.getImageSize()) == (2250, 4000)
 
+    def test_resize_too_large_secondary_images_before_upload_height(self):
+        self.add_imagegroup()
+        self.add_motif()
+        self.upload_primary_image('opernball.jpg')
+        self.upload_secondary_image('shoppingmeile_2251x4001px.jpg')
+        self.save_imagegroup()
+        img = zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/imagegroup/shoppingmeile-2251x4001px.jpg')
+        assert(img.getImageSize()) == (2250, 4000)
+
     def test_traversing_thumbnail_yields_images(self):
         create_image_group_with_master_image()
         b = self.browser


### PR DESCRIPTION
In the 'file list' view of an image group is another upload field. And so there is a view for uploading single images. Uploaded too large images from there were not resized to max image size. Now they are.