### PR TITLE
ZO-1108: Support kicker in newsletter signup configuration, too

### DIFF
--- a/core/docs/changelog/ZO-1108.change
+++ b/core/docs/changelog/ZO-1108.change
@@ -1,0 +1,1 @@
+ZO-1108: Support kicker in newslettersignup configuration, too

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -89,13 +89,14 @@ class Newsletter(zeit.cms.content.sources.AllowedBase):
 
     def __init__(
             self, id, title, image, abo_text, anon_text, redirect_link,
-            legal_text):
+            legal_text, kicker):
         super().__init__(id, title, available=None)
         self.image = image
         self.abo_text = abo_text
         self.anon_text = anon_text
         self.redirect_link = redirect_link
         self.legal_text = legal_text
+        self.kicker = kicker
 
 
 @grok.implementer(zeit.content.image.interfaces.IImages)
@@ -129,7 +130,8 @@ class NewsletterSource(zeit.cms.content.sources.ObjectSource,
                 self.child(node, 'text'),
                 self.child(node, 'text_anonymous'),
                 self.child(node, 'redirect_link'),
-                self.child(node, 'legal_text')
+                self.child(node, 'legal_text'),
+                self.child(node, 'kicker')
             )
             result[newsletter.id] = newsletter
         return result


### PR DESCRIPTION
Aus der Kategorie ich wollt doch nur mal kurz gucken...
Habe festgestellt, dass wir für https://zeit-online.atlassian.net/browse/ZO-1108 auch den Vivi Code anpassen müssen und wollte ihn dann doch nicht komplett refactoren, deshalb schrieb ich's jetzt noch obendrauf.