### PR TITLE
ZO-920: sync twitter field with teaser for genre=news

### DIFF
--- a/core/src/zeit/content/article/edit/browser/resources/sync.js
+++ b/core/src/zeit/content/article/edit/browser/resources/sync.js
@@ -3,12 +3,14 @@
 var copy_to = function(target) {
     return function() {
         var src = $(this).val();
-        if (! $(target).val()) {
-            $(target).val(src).focusout();
+        if ((! $(target).val()) &&
+            (target != '#social\\.short_text' ||
+            $('#metadata-genre\\.genre option:selected').text() == 'Nachricht')) {
+                $(target).val(src).focusout();
+                text_color();
         }
     };
 };
-
 
 $(document).bind('fragment-ready', function(event) {
     $('#teaser-supertitle\\.teaserSupertitle', event.__target).bind(
@@ -19,6 +21,9 @@ $(document).bind('fragment-ready', function(event) {
 
     $('#teaser-text\\.teaserText', event.__target).bind(
         'change', copy_to('#article-content-head\\.subtitle'));
+
+    $('#teaser-text\\.teaserText', event.__target).bind(
+        'change', copy_to('#social\\.short_text'));
 });
 
 }(jQuery));

--- a/core/src/zeit/content/article/edit/browser/resources/sync.js
+++ b/core/src/zeit/content/article/edit/browser/resources/sync.js
@@ -24,6 +24,14 @@ $(document).bind('fragment-ready', function(event) {
 
     $('#teaser-text\\.teaserText', event.__target).bind(
         'change', copy_to('#social\\.short_text'));
+    $('#social\\.short_text', event.__target).bind(
+        'change', text_color());
 });
+
+// NOTE: maybe sync.js is not the best place to manage text colors
+var text_color = function() {
+    var color = ($('#social\\.twitter_main_enabled').is( ":checked" )) ?  '#000' : '#9c9';
+    $('#social\\.short_text').css('color', color);
+};
 
 }(jQuery));

--- a/core/src/zeit/content/article/edit/browser/tests/test_sync.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_sync.py
@@ -6,6 +6,9 @@ class Supertitle(zeit.content.article.edit.browser.testing.EditorTestCase):
 
     supertitle = 'article-content-head.supertitle'
     teaser_supertitle = 'teaser-supertitle.teaserSupertitle'
+    teaser_teaser = 'teaser-text.teaserText'
+    tweet_main = 'social.short_text'
+    genre_news = 'metadata-genre.genre'
 
     def setUp(self):
         super(Supertitle, self).setUp()
@@ -22,3 +25,46 @@ class Supertitle(zeit.content.article.edit.browser.testing.EditorTestCase):
         # The sync triggers an inlineform save
         s.waitForElementNotPresent('css=.field.dirty')
         s.assertValue('id=%s' % self.supertitle, 'super')
+
+    def test_teaser_teaser_for_no_news_is_not_copied_to_twitter(self):
+        s = self.selenium
+        self.execute(
+            'document.getElementById("%s").value = ""' % self.teaser_teaser)
+        s.click('//a[@href="edit-form-teaser"]')
+        s.type('id=%s' % self.teaser_teaser, 'teaser and tweet')
+        s.keyPress('id=%s' % self.teaser_teaser, Keys.TAB)
+        # The sync triggers an inlineform save
+        s.waitForElementNotPresent('css=.field.dirty')
+        s.assertValue('id=%s' % self.tweet_main, '')
+        s.assertAttribute('css=#social\\.short_text @style',
+                          'color: rgb(153, 204, 153);')
+
+    def test_teaser_teaser_for_news_is_copied_to_twitter_main_with_color(self):
+        s = self.selenium
+        s.click('id=edit-form-metadata')
+        s.click('id=metadata-genre.genre')
+        s.click('//option[@value="65199f22690d5ad5313ff54f56c1d8cb"]')
+        # XXX This is tricky, but we somehow need to lose focus on the whole
+        # widget and blur does not work this time. Maybe there is another way?
+        s.clickAt('id=metadata-genre.genre', '-20,0')
+        self.execute(
+            'document.getElementById("%s").value = ""' % self.teaser_teaser)
+        s.click('//a[@href="edit-form-teaser"]')
+        s.type('id=%s' % self.teaser_teaser, 'teaser and tweet')
+        s.keyPress('id=%s' % self.teaser_teaser, Keys.TAB)
+        # The sync triggers an inlineform save
+        s.waitForElementNotPresent('css=.field.dirty')
+        s.assertValue('id=%s' % self.tweet_main, 'teaser and tweet')
+        s.assertAttribute('css=#social\\.short_text @style',
+                          'color: rgb(153, 204, 153);')
+
+    def test_main_twitter_color_changes_with_changing_checkbox(self):
+        s = self.selenium
+        s.click('//a[@href="edit-form-socialmedia"]')
+        s.assertAttribute('css=#social\\.short_text @style',
+                          'color: rgb(153, 204, 153);')
+        s.click('id=social.twitter_main_enabled')
+        s.waitForElementNotPresent('css=.field.dirty')
+        s.assertAttribute('css=#social\\.short_text @style',
+                          'color: rgb(0, 0, 0);')
+        s.click('id=social.twitter_main_enabled')


### PR DESCRIPTION
Ich bin mit dem Javascript nicht zufrieden. Aber es tut, was es tun soll (modulo Betriebsblindheit): Für Nachrichten das Twitter-Feld mit dem Teaser-Feld syncen und farblich blass darstellen, sofern der Haken nicht gesetzt ist.

Das Ticket ist https://zeit-online.atlassian.net/browse/ZO-920 (92NULL und nicht 92NEUN)