### PR TITLE
MAINT: Check availability of article template header

### DIFF
--- a/core/docs/changelog/article-template-header.maint
+++ b/core/docs/changelog/article-template-header.maint
@@ -1,0 +1,1 @@
+Make `available` work for article template header and header color

--- a/core/src/zeit/content/article/source.py
+++ b/core/src/zeit/content/article/source.py
@@ -146,6 +146,10 @@ class ArticleHeaderSource(zeit.cms.content.sources.ParentChildSource):
     def _get_title_for(self, node):
         return six.text_type(node['title'])
 
+    def isAvailable(self, node, context):
+        article = zeit.content.article.interfaces.IArticle(context, None)
+        return super().isAvailable(node, article)
+
 
 class ArticleHeaderColorSource(ArticleHeaderSource):
 


### PR DESCRIPTION
Es geht darum, dass [article template header](https://vivi.zeit.de/repository/data/article-templates.xml) für die verschiedenen Verticals konfiguriert/eingeschränkt werden können. Explizit für `visual-article`, das für alle Verticals (außer ze.tt 😬) funktioniert, allerdings sind die vollbreiten Header bisher nur für ZON + ZCO umgesetzt. Den Header `embed` können alle Verticals nutzen.

Eigentlich wollen wir verhindern, dass die Redaktion _visual articles_ nutzt (nutzen muss), nur um vollbreite Header zu erhalten. Der Einsatz im _normalen_ Artikel-Template wird für einige Verticals gerade umgesetzt.

So sähe eine _korrekte_ Config von der Idee her aus: 

```xml
  <template name="visual-article">
    <title>Visual Article</title>
    <header name="embed" allow_header_module="true">
      <title>Header-Modul oben</title>
    </header>
    <header name="fullwidth-classic" available="zeit.cms.section.interfaces.IZONContent">
      <title>Vollbreit, classic</title>
    </header>
    <header name="fullwidth-alternative" available="zeit.cms.section.interfaces.IZONContent">
      <title>Vollbreit, alternative</title>
    </header>
    <header name="fullwidth-split" available="zeit.cms.section.interfaces.IZONContent zeit.campus.interfaces.IZCOContent">
      <title>Vollbreit, split</title>
      <color name="#252525" available="zeit.cms.section.interfaces.IZONContent">
        <title>ZON Dark</title>
      </color>
      <color name="#085064" available="zeit.cms.section.interfaces.IZONContent">
        <title>ZON Blue</title>
      </color>
      <color name="#33333C" available="zeit.cms.section.interfaces.IZONContent">
        <title>ZON Graphite</title>
      </color>
      <color name="#005AFF" available="zeit.campus.interfaces.IZCOContent">
        <title>Campus Blue</title>
      </color>
      <color name="#F54A2B" available="zeit.campus.interfaces.IZCOContent">
        <title>Campus Red</title>
      </color>
      <color name="#E81C72" available="zeit.campus.interfaces.IZCOContent">
        <title>Campus Pink</title>
      </color>
    </header>
  </template>

  <!--
    ZAR-Templates
  -->

  <template name="zar-article" available="zeit.arbeit.interfaces.IZARContent">
    <title>Artikel</title>
    <header name="default" default_for="zeit.arbeit.interfaces.IZARContent">
      <title>Standard</title>
    </header>
    …
    <header name="fullwidth-classic">
      <title>Vollbreit mit Rand</title>
    </header>
    <header name="fullwidth-alternative">
      <title>Vollbreit randlos</title>
    </header>
    <header name="fullwidth-split">
      <title>Vollbreit, split</title>
      <color name="#ffe52c">
          <title>Sun Yellow</title>
      </color>
      <color name="#e15561">
          <title>Darkish Pink</title>
      </color>
      <color name="#4f4f57">
          <title>Darkslate Grey</title>
      </color>
    </header>
  </template>
```

Ich habe keine Ahnung, ob die Umsetzung korrekt ist.