### PR TITLE
ZO-1212: Background color field for areas

### DIFF
--- a/core/ZO-1212.change
+++ b/core/ZO-1212.change
@@ -1,0 +1,1 @@
+ZO-1212: Background color for areas

--- a/core/src/zeit/content/cp/area.py
+++ b/core/src/zeit/content/cp/area.py
@@ -75,8 +75,7 @@ class ReferencedCpFallbackProperty(
     """
 
     def __get__(self, instance, class_):
-        value = super(ReferencedCpFallbackProperty, self).__get__(
-            instance, class_)
+        value = super().__get__(instance, class_)
         if value == self.field.missing_value and instance.referenced_cp:
             value = getattr(instance.referenced_cp,
                             self.field.__name__,
@@ -299,7 +298,7 @@ class Area(zeit.content.cp.blocks.block.VisibleMixin,
             return
 
         # We want the configured blocks here, not the rendered ones.
-        filter_values = super(Area, self).filter_values
+        filter_values = super().filter_values
 
         to_adjust = len(list(filter_values(ITeaserBlock))) - (self.count or 0)
         if to_adjust == 0:

--- a/core/src/zeit/content/cp/area.py
+++ b/core/src/zeit/content/cp/area.py
@@ -173,6 +173,9 @@ class Area(zeit.content.cp.blocks.block.VisibleMixin,
         zeit.cms.content.property.ObjectPathAttributeProperty(
             '.', 'area_color_theme'))
 
+    background_color = ObjectPathAttributeProperty(
+        '.', 'background_color')
+
     @property
     def image(self):
         if self._image:

--- a/core/src/zeit/content/cp/browser/area.py
+++ b/core/src/zeit/content/cp/browser/area.py
@@ -48,7 +48,7 @@ class EditCommon(zeit.content.cp.browser.view.EditBox):
         'topiclink_label_1', 'topiclink_url_1',
         'topiclink_label_2', 'topiclink_url_2',
         'topiclink_label_3', 'topiclink_url_3',
-        'visible_mobile', 'area_color_theme')
+        'visible_mobile', 'area_color_theme', 'background_color')
 
 
 class EditOverflow(zeit.content.cp.browser.view.EditBox):

--- a/core/src/zeit/content/cp/browser/tests/test_area.py
+++ b/core/src/zeit/content/cp/browser/tests/test_area.py
@@ -8,14 +8,14 @@ import zeit.content.cp.testing
 import zope.testbrowser.browser
 
 
-class ElementTestHelper(object):
+class ElementTestHelper:
     """Helper class to test creation and deletion of IRegion and IArea"""
 
     name = NotImplemented
     starting_count = NotImplemented
 
     def setUp(self):
-        super(ElementTestHelper, self).setUp()
+        super().setUp()
         self.open_centerpage()
 
     def test_add_element_creates_new_element(self):
@@ -36,7 +36,7 @@ class ElementTestHelper(object):
         s.assertCssCount('css=.type-{}'.format(self.name), self.starting_count)
         s.click('css=.type-{} > .block-inner > .edit-bar > .delete-link'
                 .format(self.name))
-        s.waitForConfirmation(u'Wirklich löschen?')
+        s.waitForConfirmation('Wirklich löschen?')
         s.waitForCssCount('css=.type-{}'.format(self.name),
                           self.starting_count - 1)
 
@@ -64,8 +64,8 @@ class RegionTest(
     def make_one(self, kind='Empty'):
         selector = 'css=.action-cp-body-module-droppable'
         module = self.get_module('body', kind)
-        self.selenium.click(u'link=Struktur')
-        self.selenium.click(u'link=Regionen')
+        self.selenium.click('link=Struktur')
+        self.selenium.click('link=Regionen')
         self.selenium.waitForElementPresent(module)
         self.selenium.dragAndDropToObject(
             module, selector, '10,10')
@@ -83,19 +83,19 @@ class AreaTest(
             parent_selector)
 
         module = self.get_module('region', kind)
-        self.selenium.click(u'link=Struktur')
-        self.selenium.click(u'link=Flächen')
+        self.selenium.click('link=Struktur')
+        self.selenium.click('link=Flächen')
         self.selenium.waitForElementPresent(module)
         self.selenium.dragAndDropToObject(
             module, selector, '10,10')
 
 
-class ElementBrowserTestHelper(object):
+class ElementBrowserTestHelper:
 
     name = NotImplemented
 
     def setUp(self):
-        super(ElementBrowserTestHelper, self).setUp()
+        super().setUp()
         self.browser = zeit.cms.testing.Browser(self.layer['wsgi_app'])
         self.browser.login('user', 'userpw')
         zeit.content.cp.browser.testing.create_cp(self.browser)
@@ -235,13 +235,13 @@ class AreaBrowserTest(
             '000000', browser.getControl('Area background color').value)
 
 
-class TooltipFixture(object):
+class TooltipFixture:
 
     def setUp(self):
-        super(TooltipFixture, self).setUp()
+        super().setUp()
         cp = zeit.content.cp.centerpage.CenterPage()
-        cp['lead'].kind = u'major'
-        cp['informatives'].kind = u'minor'
+        cp['lead'].kind = 'major'
+        cp['informatives'].kind = 'minor'
         self.repository['cp'] = cp
         self.repository['data'] = zeit.cms.repository.folder.Folder()
         self.repository['data']['cp-area-schemas'] = \
@@ -309,8 +309,8 @@ class ConfiguredRegionTest(zeit.content.cp.testing.SeleniumTestCase):
 
     def make_one(self):
         s = self.selenium
-        s.click(u'link=Struktur')
-        s.click(u'link=Regionen')
+        s.click('link=Struktur')
+        s.click('link=Regionen')
         module = self.get_module('body', 'Duo')
         s.waitForElementPresent(module)
         s.dragAndDropToObject(
@@ -333,7 +333,7 @@ class ConfiguredRegionTest(zeit.content.cp.testing.SeleniumTestCase):
 class AreaConfigurationTest(zeit.content.cp.testing.BrowserTestCase):
 
     def setUp(self):
-        super(AreaConfigurationTest, self).setUp()
+        super().setUp()
         zeit.content.cp.browser.testing.create_cp(self.browser)
         self.browser.open('contents')
 

--- a/core/src/zeit/content/cp/browser/tests/test_area.py
+++ b/core/src/zeit/content/cp/browser/tests/test_area.py
@@ -228,6 +228,18 @@ class AreaBrowserTest(
         with self.assertRaises(zope.testbrowser.browser.ItemNotFoundError):
             theme.displayValue = 'Beere'
 
+    def test_area_bg_color_is_set(self):
+        browser = self.browser
+        browser.open(self.content_url)
+        browser.getLink('Edit block common', index=1).click()
+        browser.getControl('Area background color').value = 'xyz'
+        browser.getControl('Apply').click()
+        self.assertEllipsis('...Invalid hex literal...', browser.contents)
+        browser.getControl('Area background color').value = '000000'
+        browser.getControl('Apply').click()
+        self.assertEqual(
+            '000000', browser.getControl('Area background color').value)
+
 
 class TooltipFixture(object):
 

--- a/core/src/zeit/content/cp/browser/tests/test_area.py
+++ b/core/src/zeit/content/cp/browser/tests/test_area.py
@@ -205,13 +205,7 @@ class AreaBrowserTest(
 
     def test_area_color_themes_should_be_available_for_product(self):
         b = self.browser
-        zeit.content.cp.browser.testing.create_cp(b)
-        b.open('contents')
-        contents_url = b.url
-        b.open(
-            'lead/@@landing-zone-drop?uniqueId=http://xml.zeit.de/'
-            'testcontent&order=top')
-        b.open(contents_url)
+        b.open(self.content_url)
         # Open area settings (index=1)
         b.getLink('Edit block common', index=1).click()
 

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -402,6 +402,13 @@ class IReadArea(
         source=AREA_COLOR_THEMES_SOURCE,
         required=False)
 
+    background_color = zope.schema.TextLine(
+        title=_('Area background color'),
+        description=_('Hex value of background color for area'),
+        required=False,
+        max_length=6,
+        constraint=zeit.cms.content.interfaces.hex_literal)
+
     @zope.interface.invariant
     def automatic_type_required_arguments(data):
         if (data.automatic and

--- a/core/src/zeit/content/cp/tests/test_area.py
+++ b/core/src/zeit/content/cp/tests/test_area.py
@@ -352,6 +352,10 @@ class AreaDelegateTest(zeit.content.cp.testing.FunctionalTestCase):
         self.assertEqual('bar', self.area.topiclink_label_1)
         self.assertEqual('https://foo.bar', self.area.topiclink_url_1)
 
+    def test_set_area_background_color(self):
+        self.area.background_color = '#000000'
+        self.assertEqual('#000000', self.area.background_color)
+
 
 class CustomQueryTest(zeit.content.cp.testing.FunctionalTestCase):
 

--- a/core/src/zeit/content/cp/tests/test_area.py
+++ b/core/src/zeit/content/cp/tests/test_area.py
@@ -1,6 +1,5 @@
 import lxml.etree
 import lxml.objectify
-import six
 import zeit.cms.testing
 import zeit.content.cp.testing
 import zope.lifecycleevent
@@ -9,7 +8,7 @@ import zope.lifecycleevent
 class OverflowBlocks(zeit.content.cp.testing.FunctionalTestCase):
 
     def setUp(self):
-        super(OverflowBlocks, self).setUp()
+        super().setUp()
         self.cp = zeit.content.cp.centerpage.CenterPage()
         self.region = self.cp.create_item('region')
         self.area1 = self.region.create_item('area')
@@ -107,7 +106,7 @@ class OverflowBlocks(zeit.content.cp.testing.FunctionalTestCase):
 class AutomaticAreaTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def setUp(self):
-        super(AutomaticAreaTest, self).setUp()
+        super().setUp()
         self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
 
     def test_fills_with_placeholders_when_set_to_automatic(self):
@@ -300,7 +299,7 @@ class AutomaticAreaTest(zeit.content.cp.testing.FunctionalTestCase):
 class AreaDelegateTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def setUp(self):
-        super(AreaDelegateTest, self).setUp()
+        super().setUp()
         self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
         self.area = self.repository['cp']['feature'].create_item('area')
         other = zeit.content.cp.centerpage.CenterPage()
@@ -360,7 +359,7 @@ class AreaDelegateTest(zeit.content.cp.testing.FunctionalTestCase):
 class CustomQueryTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def setUp(self):
-        super(CustomQueryTest, self).setUp()
+        super().setUp()
         self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
 
     def test_serializes_via_dav_converter(self):
@@ -373,5 +372,5 @@ class CustomQueryTest(zeit.content.cp.testing.FunctionalTestCase):
         self.assertEllipsis(
             '<query...><condition...type="serie"...>Autotest'
             '</condition></query>',
-            lxml.etree.tostring(area.xml.query, encoding=six.text_type))
+            lxml.etree.tostring(area.xml.query, encoding=str))
         self.assertEqual((('serie', 'eq', autotest),), area.query)


### PR DESCRIPTION
Dieser PR erlaubt nun eine obtionale Hintergrundfarbe für Areas.

![friday](https://media.giphy.com/media/9T8AWWk5RXmzDfuNZn/giphy.gif)