### PR TITLE
ZO-1255: Remove possibility to hide regions/areas/modules on mobile devices

### DIFF
--- a/core/docs/changelog/ZO-1255.change
+++ b/core/docs/changelog/ZO-1255.change
@@ -1,0 +1,1 @@
+ZO-1255: Remove visible_mobile from vivi

--- a/core/src/zeit/content/cp/blocks/block.py
+++ b/core/src/zeit/content/cp/blocks/block.py
@@ -26,18 +26,11 @@ class VisibleMixin(object):
         '.', 'visible', zeit.content.cp.interfaces.IElement[
             'visible'])
 
-    visible_mobile = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'visible_mobile', zeit.content.cp.interfaces.IElement[
-            'visible_mobile'])
-
     def __init__(self, context, xml):
         super(VisibleMixin, self).__init__(context, xml)
         if 'visible' not in self.xml.attrib:
             self.visible = zeit.content.cp.interfaces.IElement[
                 'visible'].default
-        if 'visible_mobile' not in self.xml.attrib:
-            self.visible_mobile = zeit.content.cp.interfaces.IElement[
-                'visible_mobile'].default
 
 
 class Block(VisibleMixin, zeit.edit.block.SimpleElement):

--- a/core/src/zeit/content/cp/browser/area.py
+++ b/core/src/zeit/content/cp/browser/area.py
@@ -47,8 +47,8 @@ class EditCommon(zeit.content.cp.browser.view.EditBox):
         'supertitle', 'title', 'read_more', 'read_more_url', 'image',
         'topiclink_label_1', 'topiclink_url_1',
         'topiclink_label_2', 'topiclink_url_2',
-        'topiclink_label_3', 'topiclink_url_3',
-        'visible_mobile', 'area_color_theme', 'background_color')
+        'topiclink_label_3', 'topiclink_url_3', 'area_color_theme',
+        'background_color')
 
 
 class EditOverflow(zeit.content.cp.browser.view.EditBox):

--- a/core/src/zeit/content/cp/browser/blocks/block.py
+++ b/core/src/zeit/content/cp/browser/blocks/block.py
@@ -21,8 +21,7 @@ class EditCommon(zeit.content.cp.browser.view.EditBox):
         zeit.content.cp.interfaces.IBlock).select(
             'supertitle', 'title',
             'read_more', 'read_more_url',
-            'background_color',
-            'visible_mobile')
+            'background_color')
     form_fields['background_color'].custom_widget = (
         zeit.cms.browser.widget.ColorpickerWidget)
 

--- a/core/src/zeit/content/cp/browser/blocks/localteaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/localteaser.py
@@ -7,5 +7,4 @@ class EditCommon(zeit.content.cp.browser.blocks.teaser.EditCommon):
     form_fields = zope.formlib.form.FormFields(
         zeit.content.cp.interfaces.ILocalTeaserBlock).select(
             'teaserSupertitle', 'teaserTitle', 'teaserText',
-            'image', 'fill_color',
-            'visible_mobile', 'force_mobile_image')
+            'image', 'fill_color', 'force_mobile_image')

--- a/core/src/zeit/content/cp/browser/region.py
+++ b/core/src/zeit/content/cp/browser/region.py
@@ -5,4 +5,4 @@ import zope.formlib.form
 class EditCommon(zeit.content.cp.browser.view.EditBox):
 
     form_fields = zope.formlib.form.Fields(
-        zeit.content.cp.interfaces.IRegion).select('title', 'visible_mobile')
+        zeit.content.cp.interfaces.IRegion).select('title')

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -161,10 +161,6 @@ class IElement(zeit.edit.interfaces.IElement):
         title=_('Visible in frontend'),
         default=True)
 
-    visible_mobile = zope.schema.Bool(
-        title=_('Visible on mobile'),
-        default=True)
-
 
 class IBody(zeit.edit.interfaces.IArea, IElement):
     """Container of the CenterPage that actually contains the children."""
@@ -187,9 +183,6 @@ class IReadRegion(zeit.edit.interfaces.IReadContainer):
     # XXX We need to repeat these from IElement for security declarations.
     visible = zope.schema.Bool(
         title=_('Visible in frontend'),
-        default=True)
-    visible_mobile = zope.schema.Bool(
-        title=_('Visible on mobile'),
         default=True)
 
     kind = zope.schema.TextLine(
@@ -351,11 +344,6 @@ class IReadArea(
         description=_("Drag an image group here"),
         required=False,
         source=zeit.content.image.interfaces.imageGroupSource)
-
-    # XXX We need to repeat this from IElement for security declarations.
-    visible_mobile = zope.schema.Bool(
-        title=_('Visible on mobile'),
-        default=True)
 
     block_max = zope.schema.Int(
         title=_("Maximum block count"),


### PR DESCRIPTION
Ich entferne nicht mehr notwendigen Code, weil wir dieses Feld als Tausch für das Hex-Farbwert an Areas Feld entfernen dürfen.

Erstmal als draft, bis der Friedbert Part durch ist, damit wir nicht irgendwo auf die Nase fallen...

- [x] Außerdem ist noch die Frage offen, was wir mit dem Content machen, der das bisher dranstehen hat (was quasi jede Seite ist)....
- [x] Hab ich zu viel/ zu wenig entfernt?