### PR TITLE
ZO-859: Update tests to lxml serialization changes

### DIFF
--- a/core/src/zeit/content/author/README.txt
+++ b/core/src/zeit/content/author/README.txt
@@ -87,8 +87,8 @@ It takes precedence over the freetext authors:
 >>> print(zeit.cms.testing.xmltotext(repository['testcontent'].xml))
 <testtype...>
   <head>
-    <author ... href="http://xml.zeit.de/shakespeare" ...>
-      <image base-id="http://xml.zeit.de/2007/03/group/" ...>
+    <author...href="http://xml.zeit.de/shakespeare"...>
+      <image...base-id="http://xml.zeit.de/2007/03/group/"...>
       ...
       </image>
       <display_name>William Shakespeare</display_name>

--- a/core/src/zeit/content/modules/tests/test_recipelist.py
+++ b/core/src/zeit/content/modules/tests/test_recipelist.py
@@ -53,8 +53,8 @@ class RecipeListTest(
         milk = ingredients['milk']
         self.module.ingredients = [banana, milk]
         self.assertEllipsis(
-            '<ingredient... amount="2" code="banana" '
-            'details="sautiert" unit="g"/>',
+            '<ingredient... code="banana" amount="2" '
+            'unit="g" details="sautiert"/>',
             zeit.cms.testing.xmltotext(self.module.xml.ingredient))
 
     def test_removing_all_ingredients_should_leave_no_trace(self):

--- a/core/src/zeit/content/volume/browser/tests/test_form.py
+++ b/core/src/zeit/content/volume/browser/tests/test_form.py
@@ -65,8 +65,8 @@ class VolumeBrowserTest(zeit.content.volume.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2010/02/ausgabe')
-        cover = '...<cover href="http://xml.zeit.de/imagegroup/" ' \
-                'id="landscape" product_id="ZMLB"/>...'
+        cover = '...<cover id="landscape" product_id="ZMLB" ' \
+                'href="http://xml.zeit.de/imagegroup/"/>...'
         self.assertEllipsis(cover, zeit.cms.testing.xmltotext(volume.xml))
 
     def test_displays_warning_if_volume_with_same_name_already_exists(self):

--- a/core/src/zeit/content/volume/tests/test_volume.py
+++ b/core/src/zeit/content/volume/tests/test_volume.py
@@ -48,8 +48,8 @@ class TestVolumeCovers(zeit.content.volume.testing.FunctionalTestCase):
         self.volume.set_cover('ipad', 'ZEI', self.repository['imagegroup'])
         self.assertEqual(
             '<covers xmlns:py="http://codespeak.net/lxml/objectify/pytype">'
-            '<cover href="http://xml.zeit.de/imagegroup/" id="ipad" '
-            'product_id="ZEI"/>'
+            '<cover id="ipad" product_id="ZEI" '
+            'href="http://xml.zeit.de/imagegroup/"/>'
             '</covers>',
             lxml.etree.tostring(
                 self.volume.xml.covers, encoding=six.text_type))


### PR DESCRIPTION
JENKINS_BATOU_BRANCH=ZO-859

Benötigt https://github.com/ZeitOnline/vivi-deployment/pull/264