### PR TITLE
ZO-1049: Validate JSON against specific schema

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -41,6 +41,7 @@ setup(
         'markdown',
         'markdownify',
         'opentelemetry-api',
+        'openapi-schema-validator',
         'pendulum>=2.0.0.dev0',
         'persistent',
         'prometheus-client',

--- a/core/src/zeit/content/text/browser/configure.zcml
+++ b/core/src/zeit/content/text/browser/configure.zcml
@@ -91,6 +91,16 @@
     menu="zeit-context-views" title="View"
     />
 
+  <browser:page
+    for="zeit.content.text.interfaces.IJSON"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="validate.html"
+    class=".json.EditForm"
+    permission="zeit.EditContent"
+    menu="zeit-context-views"
+    title="Validate"
+    />
+
   <adapter
     for="zeit.content.text.interfaces.JSON
     zeit.cms.browser.interfaces.ICMSLayer"
@@ -98,6 +108,7 @@
     factory=".json.JSONInputWidget"
     permission="zope.Public"
     />
+
   <adapter
     for="zeit.content.text.interfaces.JSON
     zeit.cms.browser.interfaces.ICMSLayer"

--- a/core/src/zeit/content/text/browser/json.py
+++ b/core/src/zeit/content/text/browser/json.py
@@ -61,3 +61,9 @@ class JSONDisplayWidget(zope.formlib.widget.DisplayWidget):
         return pygments.highlight(
             content, pygments.lexers.JsonLexer(),
             pygments.formatters.HtmlFormatter(cssclass='pygments'))
+
+
+class EditForm(zeit.cms.browser.form.EditForm):
+
+    form_fields = zope.formlib.form.FormFields(
+        zeit.content.text.interfaces.IValidationSchema)

--- a/core/src/zeit/content/text/browser/tests/test_json.py
+++ b/core/src/zeit/content/text/browser/tests/test_json.py
@@ -1,3 +1,4 @@
+import jsonschema.validators
 import mock
 import urllib.error
 
@@ -60,7 +61,9 @@ class JSONValidationTest(zeit.content.text.testing.BrowserTestCase):
         browser.getControl('Apply').click()
         self.assertEllipsis('...Updated on...', browser.contents)
         with mock.patch('zeit.content.text.json.JSON.get_schema') as schema:
-            schema.return_value = self.schema_json
+            schema.return_value = (
+                self.schema_json, jsonschema.validators.RefResolver.from_schema(
+                    self.schema_json))
             browser.getLink('Checkin').click()
         self.assertEllipsis('...has been checked in...', browser.contents)
 
@@ -79,7 +82,9 @@ class JSONValidationTest(zeit.content.text.testing.BrowserTestCase):
         browser.getControl('Apply').click()
         self.assertEllipsis('...Updated on...', browser.contents)
         with mock.patch('zeit.content.text.json.JSON.get_schema') as schema:
-            schema.return_value = self.schema_json
+            schema.return_value = (
+                self.schema_json, jsonschema.validators.RefResolver.from_schema(
+                    self.schema_json))
             with self.assertRaises(urllib.error.HTTPError):
                 browser.getLink('Checkin').click()
                 self.assertEllipsis(

--- a/core/src/zeit/content/text/browser/tests/test_json.py
+++ b/core/src/zeit/content/text/browser/tests/test_json.py
@@ -1,5 +1,6 @@
 import zeit.cms.testing
 import zeit.content.text.embed
+import zeit.content.text.json
 import zeit.content.text.testing
 
 
@@ -27,3 +28,15 @@ class JSONBrowserTest(zeit.content.text.testing.BrowserTestCase):
 
         b.getLink('Checkin').click()
         self.assertEllipsis('...<pre>...changed...</pre>...', b.contents)
+
+    def test_validate_against_schema(self):
+        self.repository['foo'] = zeit.content.text.json.JSON()
+        b = self.browser
+        b.open('http://localhost/++skin++cms/repository/foo')
+        b.getLink('Checkout').click()
+        self.assertEllipsis('...Validate...', b.contents)
+        b.getLink('Validate').click()
+        b.getControl('url of schema').value = (
+            'http://testschema.zeit.de/schema.yaml')
+        b.getControl('Apply').click()
+        self.assertEllipsis('...Updated on...', b.contents)

--- a/core/src/zeit/content/text/configure.zcml
+++ b/core/src/zeit/content/text/configure.zcml
@@ -52,6 +52,18 @@
       />
   </class>
 
+
+  <class class=".json.ValidationSchema">
+  <require
+      interface=".interfaces.IValidationSchema"
+      permission="zope.View"
+      />
+    <require
+      set_schema=".interfaces.IValidationSchema"
+      permission="zeit.EditContent" />
+  </class>
+
+
   <class class=".embed.Embed">
     <implements interface="zope.annotation.interfaces.IAttributeAnnotatable" />
     <require

--- a/core/src/zeit/content/text/interfaces.py
+++ b/core/src/zeit/content/text/interfaces.py
@@ -104,6 +104,10 @@ class IValidationSchema(zope.interface.Interface):
         title=_('url of schema'),
         required=False)
 
+    field_name = zope.schema.Text(
+        title=_('specific schema to use for validation'),
+        required=False)
+
 
 class IEmbed(IText):
 

--- a/core/src/zeit/content/text/interfaces.py
+++ b/core/src/zeit/content/text/interfaces.py
@@ -98,6 +98,13 @@ class IJSON(IText):
     mimeType.default = 'application/json'
 
 
+class IValidationSchema(zope.interface.Interface):
+
+    schema_url = zope.schema.Text(
+        title=_('url of schema'),
+        required=False)
+
+
 class IEmbed(IText):
 
     render_as_template = zope.schema.Bool(title=_("Render as template?"))

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -22,3 +22,13 @@ class JSONType(zeit.content.text.text.TextType):
     title = _('JSON file')
     factory = JSON
     addform = zeit.cms.type.SKIP_ADD
+
+
+@zope.interface.implementer(
+    zeit.content.text.interfaces.IValidationSchema)
+class ValidationSchema(zeit.cms.content.dav.DAVPropertiesAdapter):
+
+    schema_url = zeit.cms.content.dav.DAVProperty(
+        zeit.content.text.interfaces.IValidationSchema['schema_url'],
+        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
+        'schema_url')

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -60,7 +60,6 @@ class ValidationSchema(zeit.cms.content.dav.DAVPropertiesAdapter):
     zeit.content.text.interfaces.IJSON,
     zeit.cms.checkout.interfaces.IAfterCheckinEvent)
 def validate_after_checkin(context, event):
-    breakpoint()
     schema = context.get_schema()
     if schema:
         validation = zeit.content.text.interfaces.IValidationSchema(context)

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -49,10 +49,11 @@ class JSONType(zeit.content.text.text.TextType):
     zeit.content.text.interfaces.IValidationSchema)
 class ValidationSchema(zeit.cms.content.dav.DAVPropertiesAdapter):
 
-    schema_url = zeit.cms.content.dav.DAVProperty(
-        zeit.content.text.interfaces.IValidationSchema['schema_url'],
+    zeit.cms.content.dav.mapProperties(
+        zeit.content.text.interfaces.IValidationSchema,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        'schema_url')
+        ('schema_url', 'field_name')
+    )
 
 
 @grok.subscribe(
@@ -62,9 +63,10 @@ def validate_after_checkin(context, event):
     breakpoint()
     schema = context.get_schema()
     if schema:
+        validation = zeit.content.text.interfaces.IValidationSchema(context)
         ref_resolver = jsonschema.validators.RefResolver.from_schema(
             schema)
         openapi_schema_validator.validate(
             context.data,
-            schema['components']['schemas']['Structure'],
+            schema['components']['schemas'][validation.field_name],
             resolver=ref_resolver)

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -1,10 +1,18 @@
 from zeit.cms.i18n import MessageFactory as _
+
 import commentjson
+import logging
+import openapi_schema_validator
+import requests
+import yaml
+
 import zeit.cms.content.dav
 import zeit.cms.interfaces
 import zeit.content.text.interfaces
 import zeit.content.text.text
 import zope.interface
+
+log = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(zeit.content.text.interfaces.IJSON)
@@ -13,6 +21,15 @@ class JSON(zeit.content.text.text.Text):
     @property
     def data(self):
         return commentjson.loads(self.text)
+
+    def get_schema(self):
+        info = zeit.content.text.interfaces.IValidationSchema(self)
+        try:
+            schema = requests.get(info.schema_url)  # yaml schema file expected
+            return yaml.safe_load(schema.text)
+        except requests.exceptions.RequestException as err:
+            status = getattr(err.response, 'status_code', None)
+            log.error('%s returned %s', info.schema_url, status, exc_info=True)
 
 
 class JSONType(zeit.content.text.text.TextType):

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -1,6 +1,7 @@
 from zeit.cms.i18n import MessageFactory as _
 
 import commentjson
+import jsonschema
 import logging
 import openapi_schema_validator
 import requests
@@ -30,6 +31,15 @@ class JSON(zeit.content.text.text.Text):
         except requests.exceptions.RequestException as err:
             status = getattr(err.response, 'status_code', None)
             log.error('%s returned %s', info.schema_url, status, exc_info=True)
+
+    def validate_data_against_schema(
+            self, field='components/schemas/Structure'):
+        schema = self.get_schema()
+        ref_resolver = jsonschema.validators.RefResolver.from_schema(schema)
+        openapi_schema_validator.validate(
+            self.data,
+            schema['components']['schemas']['Structure'],
+            resolver=ref_resolver)
 
 
 class JSONType(zeit.content.text.text.TextType):

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,0 +1,33 @@
+import requests_mock
+import yaml
+
+import zeit.content.text.interfaces
+import zeit.content.text.json
+import zeit.content.text.testing
+
+
+class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
+
+    schema_json = {'components': {
+        'schemas': {
+            'UUID': {
+                'type': 'string',
+                'pattern':
+                    "^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$"}
+        }
+    }}
+
+    def test_get_schema_from_url(self):
+        json_content = zeit.content.text.json.JSON()
+        validation = zeit.content.text.interfaces.IValidationSchema(
+            json_content)
+        validation.schema_url = (
+            'https://testschema.zeit.de/openapi.yaml')
+
+        with requests_mock.Mocker() as r_mock:
+            r_mock.register_uri(
+                'GET', 'https://testschema.zeit.de/openapi.yaml',
+                text=yaml.safe_dump(self.schema_json))
+            schema = json_content.get_schema()
+
+        self.assertEqual(self.schema_json, schema)

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,4 +1,5 @@
 from jsonschema.exceptions import ValidationError
+from jsonschema.validators import RefResolver
 
 import mock
 import requests_mock
@@ -26,14 +27,16 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
             json_content)
         validation.schema_url = (
             'https://testschema.zeit.de/openapi.yaml')
+        validation.field_name = 'uuid'
 
         with requests_mock.Mocker() as r_mock:
             r_mock.register_uri(
                 'GET', 'https://testschema.zeit.de/openapi.yaml',
                 text=yaml.safe_dump(self.schema_json))
-            schema = json_content.get_schema()
+            schema, ref_resolver = json_content.get_schema()
 
         self.assertEqual(self.schema_json, schema)
+        self.assertEqual(self.schema_json, ref_resolver.referrer)
 
     def test_validate_data_against_schema(self):
         json_content = zeit.content.text.json.JSON()

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,3 +1,6 @@
+from jsonschema.exceptions import ValidationError
+
+import mock
 import requests_mock
 import yaml
 
@@ -31,3 +34,16 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
             schema = json_content.get_schema()
 
         self.assertEqual(self.schema_json, schema)
+
+    def test_validate_data_against_schema(self):
+        json_content = zeit.content.text.json.JSON()
+        json_content.text = '{"UUID": "{urn:uuid:!noid!}"}'
+
+        with mock.patch('zeit.content.text.json.JSON.get_schema') as schema:
+            schema.return_value = self.schema_json
+
+            with self.assertRaises(ValidationError):
+                json_content.validate_data_against_schema()
+
+            json_content.text = '{"UUID": "{urn:uuid:d995ba5a}"}'
+            json_content.validate_data_against_schema()

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -33,7 +33,8 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
             r_mock.register_uri(
                 'GET', 'https://testschema.zeit.de/openapi.yaml',
                 text=yaml.safe_dump(self.schema_json))
-            schema, ref_resolver = json_content.get_schema()
+            schema, ref_resolver = json_content.get_schema(
+                validation.schema_url)
 
         self.assertEqual(self.schema_json, schema)
         self.assertEqual(self.schema_json, ref_resolver.referrer)

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -14,7 +14,7 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
 
     schema_json = {'components': {
         'schemas': {
-            'UUID': {
+            'uuid': {
                 'type': 'string',
                 'pattern':
                     "^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$"}
@@ -40,13 +40,18 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
 
     def test_validate_data_against_schema(self):
         json_content = zeit.content.text.json.JSON()
-        json_content.text = '{"UUID": "{urn:uuid:!noid!}"}'
+        json_content.text = '"{urn:uuid:!noid!}"'
+        validation = zeit.content.text.interfaces.IValidationSchema(
+            json_content)
+        validation.schema_url = (
+            'https://testschema.zeit.de/openapi.yaml')
+        validation.field_name = 'uuid'
 
         with mock.patch('zeit.content.text.json.JSON.get_schema') as schema:
-            schema.return_value = self.schema_json
-
+            schema.return_value = (
+                self.schema_json, RefResolver.from_schema(
+                    self.schema_json))
             with self.assertRaises(ValidationError):
-                json_content.validate_data_against_schema()
-
-            json_content.text = '{"UUID": "{urn:uuid:d995ba5a}"}'
-            json_content.validate_data_against_schema()
+                json_content.validate_data()
+            json_content.text = '"{urn:uuid:d995ba5a}"'
+            json_content.validate_data()


### PR DESCRIPTION
Dieser PR liefert die Option eine JSON Datei gegen ein spezifisches Schema zu validieren. 

WIP, da ich hier noch nicht fertig bin. Speziell, wie kann das ganze Dependencies Chaos gelöst werden? und ich finde es nicht optimal, dass bei Zappi die Zugangsdaten ins Feld geschrieben werden, sodass sie im DAV stehen. Ist das berechtigt?

JENKINS_BATOU_BRANCH=ZO-1094
