### PR TITLE
ZO-1094: Validate json by specific schema

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -41,6 +41,7 @@ setup(
         'markdown',
         'markdownify',
         'opentelemetry-api',
+        'openapi-schema-validator',
         'pendulum>=2.0.0.dev0',
         'persistent',
         'prometheus-client',

--- a/core/src/zeit/content/text/browser/configure.zcml
+++ b/core/src/zeit/content/text/browser/configure.zcml
@@ -91,6 +91,16 @@
     menu="zeit-context-views" title="View"
     />
 
+  <browser:page
+    for="zeit.content.text.interfaces.IJSON"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="validate.html"
+    class=".json.EditForm"
+    permission="zeit.EditContent"
+    menu="zeit-context-views"
+    title="Validate"
+    />
+
   <adapter
     for="zeit.content.text.interfaces.JSON
     zeit.cms.browser.interfaces.ICMSLayer"
@@ -98,6 +108,7 @@
     factory=".json.JSONInputWidget"
     permission="zope.Public"
     />
+
   <adapter
     for="zeit.content.text.interfaces.JSON
     zeit.cms.browser.interfaces.ICMSLayer"

--- a/core/src/zeit/content/text/browser/json.py
+++ b/core/src/zeit/content/text/browser/json.py
@@ -61,3 +61,9 @@ class JSONDisplayWidget(zope.formlib.widget.DisplayWidget):
         return pygments.highlight(
             content, pygments.lexers.JsonLexer(),
             pygments.formatters.HtmlFormatter(cssclass='pygments'))
+
+
+class EditForm(zeit.cms.browser.form.EditForm):
+
+    form_fields = zope.formlib.form.FormFields(
+        zeit.content.text.interfaces.IValidationSchema)

--- a/core/src/zeit/content/text/browser/tests/test_json.py
+++ b/core/src/zeit/content/text/browser/tests/test_json.py
@@ -1,3 +1,5 @@
+import commentjson
+
 import zeit.cms.testing
 import zeit.content.text.embed
 import zeit.content.text.testing
@@ -27,3 +29,29 @@ class JSONBrowserTest(zeit.content.text.testing.BrowserTestCase):
 
         b.getLink('Checkin').click()
         self.assertEllipsis('...<pre>...changed...</pre>...', b.contents)
+
+
+class JSONValidationTest(zeit.content.text.testing.BrowserTestCase):
+
+    schema = commentjson.dumps({'uuid': {
+        'type': 'string',
+        'pattern':
+            "^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$"}
+    })
+
+    def test_validate_against_schema(self):
+        self.repository['foo'] = zeit.content.text.json.JSON()
+        browser = self.browser
+        browser.open('http://localhost/++skin++cms/repository/foo')
+        browser.getLink('Checkout').click()
+        self.assertEllipsis('...Validate...', browser.contents)
+        browser.getControl('Content').value = '"{urn:uuid:d995ba5a}"'
+        browser.getControl('Apply').click()
+        browser.getLink('Validate').click()
+        browser.getControl('json schema').value = self.schema
+        browser.getControl('specific schema to use for validation').value = (
+            'uuid')
+        browser.getControl('Apply').click()
+        self.assertEllipsis('...Updated on...', browser.contents)
+        browser.getLink('Checkin').click()
+        self.assertEllipsis('...has been checked in...', browser.contents)

--- a/core/src/zeit/content/text/configure.zcml
+++ b/core/src/zeit/content/text/configure.zcml
@@ -52,6 +52,16 @@
       />
   </class>
 
+  <class class=".json.ValidationSchema">
+  <require
+      interface=".interfaces.IValidationSchema"
+      permission="zope.View"
+      />
+    <require
+      set_schema=".interfaces.IValidationSchema"
+      permission="zeit.EditContent" />
+  </class>
+
   <class class=".embed.Embed">
     <implements interface="zope.annotation.interfaces.IAttributeAnnotatable" />
     <require

--- a/core/src/zeit/content/text/interfaces.py
+++ b/core/src/zeit/content/text/interfaces.py
@@ -98,6 +98,17 @@ class IJSON(IText):
     mimeType.default = 'application/json'
 
 
+class IValidationSchema(zope.interface.Interface):
+
+    json_schema = zope.schema.Text(
+        title=_('json schema'),
+        required=False)
+
+    field = zope.schema.Text(
+        title=_('specific schema to use for validation'),
+        required=False)
+
+
 class IEmbed(IText):
 
     render_as_template = zope.schema.Bool(title=_("Render as template?"))

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -1,5 +1,9 @@
 from zeit.cms.i18n import MessageFactory as _
+
 import commentjson
+import jsonschema.validators
+import openapi_schema_validator
+
 import zeit.cms.content.dav
 import zeit.cms.interfaces
 import zeit.content.text.interfaces
@@ -13,6 +17,17 @@ class JSON(zeit.content.text.text.Text):
     @property
     def data(self):
         return commentjson.loads(self.text)
+
+    def validate_data(self):
+        validation = zeit.content.text.interfaces.IValidationSchema(self)
+        if validation.schema:
+            schema = commentjson.loads(validation.schema)
+            ref_resolver = jsonschema.validators.RefResolver.from_schema(
+                schema)
+            openapi_schema_validator.validate(
+                self.data,
+                schema[validation.field],
+                resolver=ref_resolver)
 
 
 class JSONType(zeit.content.text.text.TextType):

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -23,8 +23,11 @@ class JSON(zeit.content.text.text.Text):
         validation = zeit.content.text.interfaces.IValidationSchema(self)
         if validation.json_schema:
             schema = commentjson.loads(validation.json_schema)
+            rooted_schemas = {
+                'components': {
+                    'schemas': schema}}
             ref_resolver = jsonschema.validators.RefResolver.from_schema(
-                schema)
+                rooted_schemas)
             openapi_schema_validator.validate(
                 self.data,
                 schema[validation.field],

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -22,3 +22,14 @@ class JSONType(zeit.content.text.text.TextType):
     title = _('JSON file')
     factory = JSON
     addform = zeit.cms.type.SKIP_ADD
+
+
+@zope.interface.implementer(
+    zeit.content.text.interfaces.IValidationSchema)
+class ValidationSchema(zeit.cms.content.dav.DAVPropertiesAdapter):
+
+    zeit.cms.content.dav.mapProperties(
+        zeit.content.text.interfaces.IValidationSchema,
+        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
+        ('json_schema', 'field')
+    )

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,0 +1,22 @@
+import commentjson
+
+import zeit.content.text.interfaces
+import zeit.content.text.testing
+
+
+class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
+
+    schema = commentjson.dumps({'uuid': {
+        'type': 'string',
+        'pattern':
+            "^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$"}
+    })
+
+    def test_provide_schema_for_validation(self):
+        json_content = zeit.content.text.json.JSON()
+        validation = zeit.content.text.interfaces.IValidationSchema(
+            json_content)
+        validation.json_schema = self.schema
+        validation.field = 'uuid'
+        self.assertEqual('uuid', validation.field)
+        self.assertEqual(self.schema, validation.json_schema)

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,3 +1,5 @@
+from jsonschema.exceptions import ValidationError
+
 import commentjson
 
 import zeit.content.text.interfaces
@@ -20,3 +22,15 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
         validation.field = 'uuid'
         self.assertEqual('uuid', validation.field)
         self.assertEqual(self.schema, validation.json_schema)
+
+    def test_validate_json_against_schema(self):
+        json_content = zeit.content.text.json.JSON()
+        json_content.text = '"{urn:uuid:!noid!}"'
+        validation = zeit.content.text.interfaces.IValidationSchema(
+            json_content)
+        validation.json_schema = self.schema
+        validation.field = 'uuid'
+        with self.assertRaises(ValidationError):
+            json_content.validate_data()
+        json_content.text = '"{urn:uuid:d995ba5a}"'
+        json_content.validate_data()

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -34,3 +34,22 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
             json_content.validate_data()
         json_content.text = '"{urn:uuid:d995ba5a}"'
         json_content.validate_data()
+
+    def test_schema_reference_resolver_should_work(self):
+        json_content = zeit.content.text.json.JSON()
+        json_content.text = '["{urn:uuid:d995ba5a}"]'
+        validation = zeit.content.text.interfaces.IValidationSchema(
+            json_content)
+        validation.json_schema = commentjson.dumps({
+            'overlord': {
+                'type': 'array',
+                'items': {
+                    '$ref': '#/components/schemas/uuid'
+                }
+            },
+            'uuid': {
+                'type': 'string',
+                'pattern':
+                    "^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$"}})
+        validation.field = 'overlord'
+        json_content.validate_data()


### PR DESCRIPTION
Alternative zu https://github.com/ZeitOnline/vivi/pull/325. Statt einer url zum Schema, gibt man einfach das ganze Schema an (ohne `/compontents/schemas/`) finde ich irgendwie sauberer. Kein Einchecken von Zugangsdaten, kein "try and error" für Requests. Kein Yaml nötig.

Hab irgendwie den Eindruck, die ganze Dependencies Geschichte ist eine Katastrophe 😭 😞 

JENKINS_BATOU_BRANCH=ZO-1094