### PR TITLE
ZO-114: UI tweaks for Animation object

### DIFF
--- a/core/docs/changelog/ZO-114.change
+++ b/core/docs/changelog/ZO-114.change
@@ -1,0 +1,1 @@
+ZO-114: UI tweaks for Animation object

--- a/core/src/zeit/content/animation/animation.py
+++ b/core/src/zeit/content/animation/animation.py
@@ -15,7 +15,7 @@ import zope.interface
 
 @zope.interface.implementer(
     zeit.content.animation.interfaces.IAnimation,
-    zeit.cms.interfaces.IEditorialContent,
+    zeit.cms.interfaces.IAsset,
 )
 class Animation(zeit.cms.content.xmlsupport.XMLContentBase):
     """A type for managing animations made from existing media."""

--- a/core/src/zeit/content/animation/browser/configure.zcml
+++ b/core/src/zeit/content/animation/browser/configure.zcml
@@ -50,4 +50,6 @@
     layer="zeit.cms.browser.interfaces.ICMSStyles"
     />
 
+  <adapter factory=".form.ListRepresentation" />
+
 </configure>

--- a/core/src/zeit/content/animation/browser/form.py
+++ b/core/src/zeit/content/animation/browser/form.py
@@ -1,10 +1,14 @@
 from zeit.cms.i18n import MessageFactory as _
+from zope.cachedescriptors.property import Lazy as cachedproperty
 import gocept.form.grouped
 import zeit.cms.browser.form
+import zeit.cms.browser.interfaces
 import zeit.content.animation.interfaces
 import zeit.content.image.interfaces
 import zeit.push.browser.form
+import zope.component
 import zope.formlib.form
+import zope.interface
 
 
 class Base:
@@ -41,3 +45,14 @@ class Edit(Base, zeit.cms.browser.form.EditForm):
 
 class Display(Base, zeit.cms.browser.form.DisplayForm):
     pass
+
+
+@zope.component.adapter(
+    zeit.content.animation.interfaces.IAnimation,
+    zeit.cms.browser.interfaces.ICMSLayer)
+@zope.interface.implementer(zeit.cms.browser.interfaces.IListRepresentation)
+class ListRepresentation(zeit.cms.browser.listing.CommonListRepresentation):
+
+    @cachedproperty
+    def title(self):
+        return self.context.__name__

--- a/core/src/zeit/content/animation/interfaces.py
+++ b/core/src/zeit/content/animation/interfaces.py
@@ -40,7 +40,7 @@ class IAnimation(
     images = zope.schema.Tuple(
         title=_("Images"),
         default=(),
-        max_length=3,
+        max_length=5,
         required=False,
         value_type=zope.schema.Choice(
             source=zeit.content.image.interfaces.ImageSource()


### PR DESCRIPTION
Der vierten Bulletpoint aus dem Ticket ("Podcast+Slideshow") wird hier erstmal ignoriert; ist nämlich noch nicht klar, was oder ob überhaupt dafür viviseitig etwas zu tun ist.