### PR TITLE
ZO-1324: provide animation as filter for content types

### DIFF
--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -76,6 +76,7 @@ class SearchForm(JSONView):
 
     CONTENT_TYPES = [
         'advertisement',
+        'animation',
         'article',
         'author',
         'centerpage-2009',


### PR DESCRIPTION
Hmm, ich hab für die anderen Typen in den Tests nichts explizit gefunden (wenn "article" ausgewählt ist, dann werden nur Artikel gefunden). Oder habe ich nicht richtig geschaut?

Macht jedenfalls im Browser, was es soll.
