### PR TITLE
ZO-1375: read list of fields for fulltext search from config

### DIFF
--- a/core/docs/changelog/ZO-1375_vivi-find-search-fields.change
+++ b/core/docs/changelog/ZO-1375_vivi-find-search-fields.change
@@ -1,0 +1,1 @@
+ZO-1375: search in configurable fields only to simplify result set 

--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -30,7 +30,7 @@ class JSONView(zeit.cms.browser.view.JSON):
 
 class FieldsList(zeit.cms.content.sources.SimpleXMLSourceBase):
 
-    default_filename = 'search_in_fields_list.xml'
+    default_filename = 'vivi-find-search-fields.xml'
 
 
 class SearchForm(JSONView):

--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -1,4 +1,3 @@
-from zeit.cms.content.sources import FEATURE_TOGGLES
 import datetime
 import logging
 import pendulum
@@ -458,11 +457,10 @@ def form_query(request, filter_terms=None):
         return None
     form['filter_terms'] = filter_terms
     fields = []
-    if not FEATURE_TOGGLES.find('ignore_search_in_fields_list'):
-        try:
-            fields = FieldsList().getValues()
-        except Exception:
-            log.info('XML source for FieldsList not found')
+    try:
+        fields = FieldsList().getValues()
+    except Exception:
+        log.info('Source for FieldsList vivi-find-search-fields.xml not found')
     form['fields'] = fields
     return zeit.find.search.query(**form)
 

--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -1,3 +1,4 @@
+from zeit.cms.content.sources import FEATURE_TOGGLES
 import datetime
 import logging
 import pendulum
@@ -25,6 +26,11 @@ class JSONView(zeit.cms.browser.view.JSON):
     def url(self, view, uniqueId):
         return super().url(
             self.context, '%s?uniqueId=%s' % (view, uniqueId))
+
+
+class FieldsList(zeit.cms.content.sources.SimpleXMLSourceBase):
+
+    default_filename = 'search_in_fields_list.xml'
 
 
 class SearchForm(JSONView):
@@ -451,6 +457,13 @@ def form_query(request, filter_terms=None):
     if form is None:
         return None
     form['filter_terms'] = filter_terms
+    fields = []
+    if not FEATURE_TOGGLES.find('ignore_search_in_fields_list'):
+        try:
+            fields = FieldsList().getValues()
+        except Exception:
+            log.info('XML source for FieldsList not found')
+    form['fields'] = fields
     return zeit.find.search.query(**form)
 
 

--- a/core/src/zeit/find/search.py
+++ b/core/src/zeit/find/search.py
@@ -84,7 +84,8 @@ def query(fulltext=None, **conditions):
     # handle fulltext
     if fulltext:
         must.append(dict(query_string=dict(
-            query=fulltext, default_operator='AND')))
+            query=fulltext, fields=conditions.pop('fields', []),
+            default_operator='AND')))
     # handle from_, until
     from_ = conditions.pop('from_', None)
     until = conditions.pop('until', None)

--- a/core/src/zeit/find/tests/test_query.py
+++ b/core/src/zeit/find/tests/test_query.py
@@ -6,10 +6,13 @@ from zeit.find.search import query
 def test_simple_queries():
     assert query() == {
         'query': {'match_all': {}}}
-    assert query(fulltext='Foo') == {
-        'query': {'query_string': {'query': 'Foo', 'default_operator': 'AND'}}}
+    assert query(fulltext='Foo', fields=['title', 'paragraph']) == {
+        'query': {'query_string': {'query': 'Foo',
+                  'fields': ['title', 'paragraph'],
+                  'default_operator': 'AND'}}}
     assert query('Bar') == {
-        'query': {'query_string': {'query': 'Bar', 'default_operator': 'AND'}}}
+        'query': {'query_string': {'query': 'Bar',
+                  'fields': [], 'default_operator': 'AND'}}}
     assert query(authors='Foo Bar') == {
         'query': {'match': {'payload.document.author': 'Foo Bar'}}}
     assert query(from_=datetime(2009, 12, 19, 19, 9)) == {
@@ -50,7 +53,7 @@ def test_combined_queries():
     assert query(fulltext='Foo', authors='Bar') == {
         'query': {'bool': {
             'must': [{'query_string': {
-                'query': 'Foo', 'default_operator': 'AND'}}],
+                'query': 'Foo', 'fields': [], 'default_operator': 'AND'}}],
             'filter': [{'match': {'payload.document.author': 'Bar'}}],
         }}}
     assert query(
@@ -61,7 +64,7 @@ def test_combined_queries():
     assert query(show_news=False, fulltext='Foo') == {
         'query': {'bool': {
             'must': [{'query_string': {
-                'query': 'Foo', 'default_operator': 'AND'}}],
+                'query': 'Foo', 'fields': [], 'default_operator': 'AND'}}],
             'must_not': [
                 {'match': {'payload.document.ressort': 'News'}},
                 {'match': {'payload.workflow.product-id': 'News'}},


### PR DESCRIPTION
Hier müssen noch ein paar Sachen geklärt werden. Angeschaut wird sich das auch schon auf vivi.devel.