### PR TITLE
ZO-1603: Add "last indexed" field to TMS

### DIFF
--- a/core/docs/changelog/ZO-1603.change
+++ b/core/docs/changelog/ZO-1603.change
@@ -1,0 +1,1 @@
+ZO-1603: Add "last indexed" field to TMS

--- a/core/src/zeit/retresco/convert.py
+++ b/core/src/zeit/retresco/convert.py
@@ -10,6 +10,7 @@ import logging
 import lxml.builder
 import lxml.etree
 import os.path
+import pendulum
 import pytz
 import re
 import zeit.cms.browser.interfaces
@@ -114,6 +115,8 @@ class CMSContent(Converter):
             'body': lxml.etree.tostring(body, encoding=str),
         }
         result['payload'] = self.collect_dav_properties()
+        result['payload'].setdefault('meta', {})[
+            'tms_last_indexed'] = pendulum.now('UTC').isoformat()
         return result
 
     DUMMY_ES_PROPERTIES = zeit.retresco.content.WebDAVProperties(None)

--- a/core/src/zeit/retresco/tests/test_convert.py
+++ b/core/src/zeit/retresco/tests/test_convert.py
@@ -150,6 +150,9 @@ class ConvertTest(zeit.retresco.testing.FunctionalTestCase):
             data['payload']['document'].pop('date_last_checkout'))
         self.assertStartsWith(
             str(datetime.date.today().year),
+            data['payload']['meta'].pop('tms_last_indexed'))
+        self.assertStartsWith(
+            str(datetime.date.today().year),
             data['payload']['document'].pop(
                 'date-last-modified',
                 # Only IXMLContent has this


### PR DESCRIPTION
Die nötige [Typdeklaration](https://github.com/ZeitOnline/tms-deployment/commit/68e367d647182d65d8edb594f81fc4564707e561) habe ich bereits eingetragen (staging+production).