### PR TITLE
ZO-1576: Implement hostname denylist for link targets

### DIFF
--- a/core/docs/changelog/ZO-1576.change
+++ b/core/docs/changelog/ZO-1576.change
@@ -1,0 +1,1 @@
+ZO-1576: Implement hostname denylist for link targets

--- a/core/src/zeit/cms/interfaces.py
+++ b/core/src/zeit/cms/interfaces.py
@@ -1,9 +1,11 @@
 # coding: utf8
+from urllib.parse import urlparse
 from zeit.cms.i18n import MessageFactory as _
 import datetime
 import pyramid_dogpile_cache2
 import pytz
 import re
+import zope.app.appsetup.product
 import zope.i18nmessageid
 import zope.interface
 import zope.interface.common.sequence
@@ -52,6 +54,23 @@ valid_name_regex = re.compile(r'^[A-Za-z0-9\.\,\-_*()~]+$').match
 def valid_name(value):
     if not valid_name_regex(value):
         raise InvalidName(value)
+    return True
+
+
+class InvalidLinkTarget(zope.schema.ValidationError):
+    __doc__ = _('Invalid link target')
+
+
+def valid_link_target(value):
+    if not value:
+        return True
+    config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
+    if 'invalid-link-targets' not in config:
+        return True
+    host = urlparse(value).netloc
+    for invalid in config['invalid-link-targets'].split(' '):
+        if host == invalid:
+            raise InvalidLinkTarget()
     return True
 
 

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -626,9 +626,10 @@ class ITopicbox(IBlock,
         title=_("Title"),
         max_length=30)
 
-    link = zope.schema.TextLine(
+    link = zope.schema.URI(
         title=_('Link'),
-        required=False)
+        required=False,
+        constraint=zeit.cms.interfaces.valid_link_target)
 
     link_text = zope.schema.TextLine(
         title=_("Linktext"),

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -300,9 +300,10 @@ class IReadArea(
         title=_("Read more"),
         required=False)
 
-    read_more_url = zope.schema.TextLine(
+    read_more_url = zope.schema.URI(
         title=_("Read more URL"),
-        required=False)
+        required=False,
+        constraint=zeit.cms.interfaces.valid_link_target)
 
     image = zope.schema.Choice(
         title=_('Image'),
@@ -454,9 +455,10 @@ class IBlock(IElement, zeit.edit.interfaces.IBlock):
     read_more = zope.schema.TextLine(
         title=_("Read more"),
         required=False)
-    read_more_url = zope.schema.TextLine(
+    read_more_url = zope.schema.URI(
         title=_("Read more URL"),
-        required=False)
+        required=False,
+        constraint=zeit.cms.interfaces.valid_link_target)
     background_color = zope.schema.TextLine(
         title=_("Background color (ZMO only)"),
         required=False,

--- a/core/src/zeit/content/link/browser/tests/test_link.py
+++ b/core/src/zeit/content/link/browser/tests/test_link.py
@@ -1,6 +1,7 @@
 import lxml.etree
-import zeit.content.link.testing
 import zeit.content.link.link
+import zeit.content.link.testing
+import zope.app.appsetup
 
 
 class TestForm(zeit.content.link.testing.BrowserTestCase):
@@ -70,3 +71,16 @@ class TestForm(zeit.content.link.testing.BrowserTestCase):
                          block.get('ressort'))
         self.assertEqual('gocept homepage',
                          block.find('title').text)
+
+    def test_checks_for_invalid_hostnames(self):
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
+        config['invalid-link-targets'] = 'example.com other.com'
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/2006/')
+        menu = b.getControl(name='add_menu')
+        menu.displayValue = ['Link']
+        b.open(menu.value[0])
+        b.getControl('File name').value = 'mylink'
+        b.getControl('Link address').value = 'http://example.com/test'
+        b.getControl(name='form.actions.add').click()
+        self.assertEllipsis('...Invalid link target...', b.contents)

--- a/core/src/zeit/content/link/interfaces.py
+++ b/core/src/zeit/content/link/interfaces.py
@@ -2,6 +2,7 @@ from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.content.contentsource
 import zeit.cms.content.interfaces
 import zeit.cms.content.sources
+import zeit.cms.interfaces
 import zeit.content.link.sources
 import zope.schema
 
@@ -20,7 +21,9 @@ class ILink(zeit.cms.content.interfaces.ICommonMetadata,
             zeit.cms.content.interfaces.IXMLContent):
     """A type for managing links to non-local content."""
 
-    url = zope.schema.URI(title=_('Link address'))
+    url = zope.schema.URI(
+        title=_('Link address'),
+        constraint=zeit.cms.interfaces.valid_link_target)
 
     target = zope.schema.Choice(
         title=_('Target'),


### PR DESCRIPTION
Die Übersetzung muss noch eingetragen werden; vielleicht vorher am sinnvollsten zuerst #365 mergen wg merge conflicts.

Benötigt https://github.com/ZeitOnline/vivi-deployment/pull/294