### PR TITLE
ZO-1858: Speed up bw-compat code for image group without master images

### DIFF
--- a/core/docs/changelog/masterimage.maint
+++ b/core/docs/changelog/masterimage.maint
@@ -1,0 +1,1 @@
+Speed up bw-compat code for image group without master images

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -502,13 +502,9 @@ def find_master_image(context):
         master_image = context.get(master_name)
         if master_image is not None:
             return master_image
-    master_image = None
-    for image in context.values():
-        if zeit.content.image.interfaces.IImage.providedBy(
-                image) and image.size > getattr(master_image, 'size', 0):
-            master_image = image
-            break
-    return master_image
+    for image in context.values():  # BBB
+        if zeit.content.image.interfaces.IImage.providedBy(image):
+            return image
 
 
 EXTERNAL_ID_PATTERN = re.compile(r'^[^\d]*([\d]+)[^\d]*$')


### PR DESCRIPTION
The code from a2954b2 wanted to get the largest image, but always had a bug and just took the first one. Since this does not seem to have mattered at all, we make that behaviour explicit, which now yields a
significant performance benefit, as we do not have to get the image body (separately from GCS) to determine the size -- once we store that information in properties, we should revert this (and implement it
properly of course).