### PR TITLE
MAINT: Include currently used vivi version as data-attribute on html

### DIFF
--- a/core/docs/changelog/vivi-version-include.maint
+++ b/core/docs/changelog/vivi-version-include.maint
@@ -1,0 +1,1 @@
+Include currently used vivi version as data-attribute on HTML tag

--- a/core/src/zeit/cms/browser/main_template.pt
+++ b/core/src/zeit/cms/browser/main_template.pt
@@ -31,7 +31,8 @@
     <html xmlns="http://www.w3.org/1999/xhtml"
       tal:define="view_title options/title|view/title|string:Zeit CMS;
       context_title context/@@standard_macros/context_title;
-      favicon string:${request/getApplicationURL}/fanstatic/zeit.cms/icons/favicon.png">
+      favicon string:${request/getApplicationURL}/fanstatic/zeit.cms/icons/favicon.png"
+      tal:attributes="data-vivi-version context/@@standard_macros/vivi_version">
       <head>
         <script type="text/javascript" tal:content="string:
           var application_url = '${request/getApplicationURL}';

--- a/core/src/zeit/cms/browser/standardmacros.py
+++ b/core/src/zeit/cms/browser/standardmacros.py
@@ -9,6 +9,7 @@ import zope.app.basicskin.standardmacros
 import zope.component
 import zope.location.interfaces
 import zope.security.proxy
+import pkg_resources
 
 
 class StandardMacros(zope.app.basicskin.standardmacros.StandardMacros):
@@ -62,3 +63,9 @@ class StandardMacros(zope.app.basicskin.standardmacros.StandardMacros):
     def environment(self):
         config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
         return config['environment']
+
+    @property
+    def vivi_version(self):
+        if pkg_resources.get_distribution('vivi.core'):
+            return pkg_resources.get_distribution('vivi.core').version
+        return 'version not found'


### PR DESCRIPTION
Ich fand es cool zu wissen, welche vivi-version wir gerade verwenden. Da ich es nicht als HTML Kommentar hinbekommen habe, hab ich es als `data-vivi-version` angehängt. So kann man sehen, ob man wirklich die Version sieht, die man sehen möchte.