### PR TITLE
ZO-2132: Change normalisation of quotation marks

### DIFF
--- a/core/docs/changelog/ZO-2132.change
+++ b/core/docs/changelog/ZO-2132.change
@@ -1,0 +1,1 @@
+ZO-2132: Normalize quotes to angled instead of inch if toggle `normalize_quotes` is set

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -367,8 +367,8 @@ def ensure_block_ids(context, event):
 
 
 QUOTE_CHARACTERS = re.compile('[\u201c\u201d\u201e\u201f\u00ab\u00bb]')
-QUOTE_CHARACTERS_OPEN = re.compile('[\u201e\u201f]')
-QUOTE_CHARACTERS_CLOSE = re.compile('[\u201c\u201d]')
+QUOTE_CHARACTERS_OPEN = re.compile('[\u201c\u201e]')
+QUOTE_CHARACTERS_CLOSE = re.compile('[\u201d\u201f]')
 
 
 @grok.subscribe(

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -376,7 +376,6 @@ QUOTE_CHARACTERS_CLOSE = re.compile('[\u201d\u201f]')
     zeit.cms.checkout.interfaces.IAfterCheckoutEvent)
 def normalize_quotation_marks(context, event):
     # XXX objectify has immutable text/tail. le sigh.
-
     normalize = normalize_quotes if FEATURE_TOGGLES.find(
         'normalize_quotes') else normalize_quotes_to_inch_sign
     context.xml.body = lxml.objectify.fromstring(lxml.etree.tostring(

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -1,5 +1,6 @@
 from io import StringIO
 from zeit.cms.content.cache import writeabledict
+from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_ERROR
 import gocept.cache.property
@@ -365,7 +366,9 @@ def ensure_block_ids(context, event):
     body.ensure_division()
 
 
-DOUBLE_QUOTE_CHARACTERS = re.compile('[\u201c\u201d\u201e\u201f\u00ab\u00bb]')
+QUOTE_CHARACTERS = re.compile('[\u201c\u201d\u201e\u201f\u00ab\u00bb]')
+QUOTE_CHARACTERS_OPEN = re.compile('[\u201e\u201f]')
+QUOTE_CHARACTERS_CLOSE = re.compile('[\u201c\u201d]')
 
 
 @grok.subscribe(
@@ -373,24 +376,39 @@ DOUBLE_QUOTE_CHARACTERS = re.compile('[\u201c\u201d\u201e\u201f\u00ab\u00bb]')
     zeit.cms.checkout.interfaces.IAfterCheckoutEvent)
 def normalize_quotation_marks(context, event):
     # XXX objectify has immutable text/tail. le sigh.
+
+    normalize = normalize_quotes if FEATURE_TOGGLES.find(
+        'normalize_quotes') else normalize_quotes_to_inch_sign
     context.xml.body = lxml.objectify.fromstring(lxml.etree.tostring(
-        normalize_quotes(
+        normalize(
             lxml.etree.fromstring(lxml.etree.tostring(context.xml.body)))))
 
     if context.xml.find('teaser') is not None:
         context.xml.teaser = lxml.objectify.fromstring(lxml.etree.tostring(
-            normalize_quotes(
+            normalize(
                 lxml.etree.fromstring(
                     lxml.etree.tostring(context.xml.teaser)))))
 
 
 def normalize_quotes(node):
     if node.text:
-        node.text = DOUBLE_QUOTE_CHARACTERS.sub('"', node.text)
+        node.text = QUOTE_CHARACTERS_OPEN.sub('»', node.text)
+        node.text = QUOTE_CHARACTERS_CLOSE.sub('«', node.text)
     if node.tail:
-        node.tail = DOUBLE_QUOTE_CHARACTERS.sub('"', node.tail)
+        node.tail = QUOTE_CHARACTERS_OPEN.sub('»', node.tail)
+        node.text = QUOTE_CHARACTERS_CLOSE.sub('«', node.text)
     for child in node.iterchildren():
         normalize_quotes(child)
+    return node
+
+
+def normalize_quotes_to_inch_sign(node):
+    if node.text:
+        node.text = QUOTE_CHARACTERS.sub('"', node.text)
+    if node.tail:
+        node.tail = QUOTE_CHARACTERS.sub('"', node.tail)
+    for child in node.iterchildren():
+        normalize_quotes_to_inch_sign(child)
     return node
 
 

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -474,7 +474,12 @@ class DoubleQuotes:
 
     def __call__(self):
         return json.dumps(
-            zeit.content.article.article.QUOTE_CHARACTERS.pattern)
+            {"chars": zeit.content.article.article.QUOTE_CHARACTERS.pattern,
+             "chars_open": (
+                 zeit.content.article.article.QUOTE_CHARACTERS_OPEN.pattern),
+             "chars_close": (
+                 zeit.content.article.article.QUOTE_CHARACTERS_CLOSE.pattern),
+             "normalize_quotes": FEATURE_TOGGLES.find('normalize_quotes')})
 
 
 class EditJobTicker(zeit.edit.browser.form.InlineForm):

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -474,7 +474,7 @@ class DoubleQuotes:
 
     def __call__(self):
         return json.dumps(
-            zeit.content.article.article.DOUBLE_QUOTE_CHARACTERS.pattern)
+            zeit.content.article.article.QUOTE_CHARACTERS.pattern)
 
 
 class EditJobTicker(zeit.edit.browser.form.InlineForm):

--- a/core/src/zeit/content/article/edit/browser/resources/html.js
+++ b/core/src/zeit/content/article/edit/browser/resources/html.js
@@ -10,7 +10,7 @@ zeit.content.article.html.to_xml = function(tree) {
         replace_double_br_with_p,
         kill_empty_p,
         escape_missing_href,
-        normalize_quotation_marks
+        NORMALIZE_QUOTES
     ];
 
     // XXX dropping unknown tags but keeping their text is still implemented on
@@ -133,12 +133,26 @@ function wrap_toplevel_children_in_p(tree) {
 }
 
 
-var DOUBLE_QUOTE_CHARACTERS = '';
+var QUOTE_CHARACTERS = '';
+var QUOTE_CHARACTERS_OPEN = '';
+var QUOTE_CHARACTERS_CLOSE = '';
+var NORMALIZE_QUOTES = normalize_quotation_marks_to_inch_sign;
+
+function normalize_quotation_marks_to_inch_sign(tree) {
+    forEach(tree.childNodes, function(el) {
+        if (el.nodeType == el.TEXT_NODE) {
+            el.nodeValue = el.nodeValue.replace(QUOTE_CHARACTERS, '"');
+        } else {
+            normalize_quotation_marks_to_inch_sign(el);
+        }
+    });
+}
 
 function normalize_quotation_marks(tree) {
     forEach(tree.childNodes, function(el) {
         if (el.nodeType == el.TEXT_NODE) {
-            el.nodeValue = el.nodeValue.replace(DOUBLE_QUOTE_CHARACTERS, '"');
+            el.nodeValue = el.nodeValue.replace(QUOTE_CHARACTERS_OPEN, '»');
+            el.nodeValue = el.nodeValue.replace(QUOTE_CHARACTERS_CLOSE, '«');
         } else {
             normalize_quotation_marks(el);
         }
@@ -152,7 +166,10 @@ MochiKit.Signal.connect(window, 'cp-editor-loaded', function() {
     $.getJSON(
         application_url + '/@@double-quote-characters',
         function(response) {
-            DOUBLE_QUOTE_CHARACTERS = new RegExp(response, 'g');
+            QUOTE_CHARACTERS = new RegExp(response['chars'], 'g');
+            QUOTE_CHARACTERS_OPEN = new RegExp(response['chars_open'], 'g');
+            QUOTE_CHARACTERS_CLOSE = new RegExp(response['chars_close'], 'g');
+            NORMALIZE_QUOTES = (response["normalize_quotes"]) ? normalize_quotation_marks : normalize_quotation_marks_to_inch_sign;
     });
 });
 

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -4,6 +4,7 @@ from zeit.cms.checkout.helper import checked_out
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_ERROR
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_SUCCESS
 from zeit.push.interfaces import IPushMessages
+from zeit.cms.content.sources import FEATURE_TOGGLES
 import zeit.cms.content.interfaces
 import zeit.cms.content.reference
 import zeit.cms.interfaces
@@ -156,7 +157,7 @@ class MainImageTest(zeit.content.article.testing.FunctionalTestCase):
 
 class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
 
-    def test_normalize_body(self):
+    def test_normalize_body_to_inch(self):
         article = self.get_article()
         p = self.get_factory(article, 'p')()
         p.text = '“up” and „down‟ and «around»'
@@ -165,12 +166,30 @@ class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
             block = co.body.values()[0]
             self.assertEqual('"up" and "down" and "around"', block.text)
 
-    def test_normalize_teaser(self):
+    def test_normalize_teaser_to_inch(self):
         article = self.get_article()
         article.teaserTitle = '“up” and „down‟ and «around»'
         self.repository['article'] = article
         with checked_out(self.repository['article']) as co:
             self.assertEqual('"up" and "down" and "around"', co.teaserTitle)
+
+    def test_normalize_body(self):
+        FEATURE_TOGGLES.set('normalize_quotes')
+        article = self.get_article()
+        p = self.get_factory(article, 'p')()
+        p.text = '‟up” and „down“ and »around«'
+        self.repository['article'] = article
+        with checked_out(self.repository['article']) as co:
+            block = co.body.values()[0]
+            self.assertEqual('»up« and »down« and »around«', block.text)
+
+    def test_normalize_teaser(self):
+        FEATURE_TOGGLES.set('normalize_quotes')
+        article = self.get_article()
+        article.teaserTitle = '“up” and „down‟ and «around»'
+        self.repository['article'] = article
+        with checked_out(self.repository['article']) as co:
+            self.assertEqual('»up« and »down« and »around«', co.teaserTitle)
 
 
 class LayoutHeaderByArticleTemplate(

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -160,7 +160,7 @@ class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
     def test_normalize_body_to_inch(self):
         article = self.get_article()
         p = self.get_factory(article, 'p')()
-        p.text = '“up” and „down‟ and «around»'
+        p.text = '“up” and „down‟ and »around«'
         self.repository['article'] = article
         with checked_out(self.repository['article']) as co:
             block = co.body.values()[0]
@@ -168,7 +168,7 @@ class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
 
     def test_normalize_teaser_to_inch(self):
         article = self.get_article()
-        article.teaserTitle = '“up” and „down‟ and «around»'
+        article.teaserTitle = '“up” and „down‟ and »around«'
         self.repository['article'] = article
         with checked_out(self.repository['article']) as co:
             self.assertEqual('"up" and "down" and "around"', co.teaserTitle)
@@ -177,7 +177,7 @@ class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
         FEATURE_TOGGLES.set('normalize_quotes')
         article = self.get_article()
         p = self.get_factory(article, 'p')()
-        p.text = '‟up” and „down“ and »around«'
+        p.text = '“up” and „down‟ and »around«'
         self.repository['article'] = article
         with checked_out(self.repository['article']) as co:
             block = co.body.values()[0]
@@ -186,7 +186,7 @@ class NormalizeQuotes(zeit.content.article.testing.FunctionalTestCase):
     def test_normalize_teaser(self):
         FEATURE_TOGGLES.set('normalize_quotes')
         article = self.get_article()
-        article.teaserTitle = '“up” and „down‟ and «around»'
+        article.teaserTitle = '“up” and „down‟ and »around«'
         self.repository['article'] = article
         with checked_out(self.repository['article']) as co:
             self.assertEqual('»up« and »down« and »around«', co.teaserTitle)


### PR DESCRIPTION
This basically changes the functionality from a very basic replacing pattern of quote characters to a slightly more complex one. Since this happens in Python and JS and since we need toggling, some more complexity was needed, which needs to be removed, when the feature is in production.