### PR TITLE
ZO-2104: Mark unstable tests xfail

### DIFF
--- a/core/docs/changelog/ZO-2107.fix
+++ b/core/docs/changelog/ZO-2107.fix
@@ -1,0 +1,1 @@
+ZO-2104: Mark unstable test as xfail

--- a/core/src/zeit/connector/tests/test_cache.py
+++ b/core/src/zeit/connector/tests/test_cache.py
@@ -2,6 +2,7 @@
 from io import BytesIO
 import BTrees
 import ZODB
+import pytest
 import os
 import threading
 import transaction
@@ -75,6 +76,7 @@ class TestResourceCache(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual(expected, got.read())
         got.close()
 
+    @pytest.mark.xfail
     def test_blob_conflict_resolution(self):
         size = zeit.connector.cache.Body.BUFFER_SIZE
         body = BytesIO(b'body' * size)

--- a/core/src/zeit/content/cp/browser/tests/test_area.py
+++ b/core/src/zeit/content/cp/browser/tests/test_area.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import json
 import lxml.cssselect
+import pytest
 import unittest
 import zeit.cms.testing
 import zeit.content.cp.browser.testing
@@ -304,6 +305,7 @@ class ConfiguredRegionTest(zeit.content.cp.testing.SeleniumTestCase):
         self.make_one()
         s.waitForCssCount('css=.type-region', count + 1)
 
+    @pytest.mark.xfail
     def test_creating_configured_region_sets_kind_on_region(self):
         self.open_centerpage()
         self.make_one()

--- a/core/src/zeit/content/image/browser/tests/test_variant.py
+++ b/core/src/zeit/content/image/browser/tests/test_variant.py
@@ -255,5 +255,6 @@ class VariantJasmineTestCase(gocept.jasmine.jasmine.TestCase):
     layer = gocept.jasmine.jasmine.get_layer(VariantApp())
     level = 2
 
+    @pytest.mark.xfail
     def test_all_jasmine_unit_tests_run_successfully(self):
         self.run_jasmine()


### PR DESCRIPTION
Not really a solution 😞 das ist quasi nicht lokal reproduziertbar, denn die Tests failen manchmal, wenn man alle Tests laufen lässt. Testet man selektiv sind die Tests grün.

![wet](https://media.giphy.com/media/KTZ8KtDGHhlLy/giphy.gif)