### PR TITLE
Revert "ZO-1471: undo copy teaser text to twitter field (ZO-920)"

### DIFF
--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -228,6 +228,24 @@ def modify_speechbert_audio_depeding_on_genre(article, event):
                 article.audio_speechbert = False
 
 
+@grok.subscribe(
+    zeit.content.article.interfaces.IArticle,
+    zope.lifecycleevent.IObjectModifiedEvent)
+def copy_teaser_to_push(article, event):
+    if not article.genre or article.genre != 'nachricht':
+        return
+    for desc in event.descriptions:
+        if (desc.interface is zeit.cms.content.interfaces.ICommonMetadata and
+                'teaserText' in desc.attributes):
+            break
+    else:
+        return
+
+    push = zeit.push.interfaces.IPushMessages(article)
+    if not push.short_text:
+        push.short_text = article.teaserText
+
+
 @grok.adapter(zeit.content.article.interfaces.IArticle)
 @grok.implementer(zeit.edit.interfaces.IElementReferences)
 def iter_referenced_content(context):

--- a/core/src/zeit/content/article/edit/browser/form.py
+++ b/core/src/zeit/content/article/edit/browser/form.py
@@ -405,6 +405,9 @@ class TeaserText(zeit.edit.browser.form.InlineForm,
         super().setUpWidgets(*args, **kw)
         self.set_charlimit('teaserText')
 
+    def _success_handler(self):
+        self.signal('reload-inline-form', 'social')
+
 
 class OptionFormGroup(zeit.edit.browser.form.FoldableFormGroup):
 

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -3,6 +3,8 @@ from unittest import mock
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_ERROR
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_SUCCESS
+from zeit.push.interfaces import IPushMessages
+from zeit.cms.content.sources import FEATURE_TOGGLES
 import zeit.cms.content.interfaces
 import zeit.cms.content.reference
 import zeit.cms.interfaces
@@ -326,6 +328,34 @@ def notify_modified(article, field):
     zope.event.notify(zope.lifecycleevent.ObjectModifiedEvent(
         article, zope.lifecycleevent.Attributes(
             zeit.cms.content.interfaces.ICommonMetadata, field)))
+
+
+class CopyTeaserToPush(zeit.content.article.testing.FunctionalTestCase):
+
+    def setUp(self):
+        super().setUp()
+        article = self.get_article()
+        article.teaserText = 'mytext'
+        self.repository['article'] = article
+        self.article = self.repository['article']
+
+    def test_most_genre_does_nothing(self):
+        with checked_out(self.article) as article:
+            notify_modified(article, 'teaserText')
+            self.assertEqual(None, IPushMessages(article).short_text)
+
+    def test_genre_nachricht_copies(self):
+        with checked_out(self.article) as article:
+            article.genre = 'nachricht'
+            notify_modified(article, 'teaserText')
+            self.assertEqual('mytext', IPushMessages(article).short_text)
+
+    def test_push_already_set_does_not_change_anything(self):
+        with checked_out(self.article) as article:
+            article.genre = 'nachricht'
+            IPushMessages(article).short_text = 'manual'
+            notify_modified(article, 'teaserText')
+            self.assertEqual('manual', IPushMessages(article).short_text)
 
 
 class ArticleXMLReferenceUpdate(


### PR DESCRIPTION
Reverts ZeitOnline/vivi#397