### PR TITLE
ZO-1847: Seriesheader preview should not cover Vivi UI

### DIFF
--- a/core/docs/changelog/ZO-1847.fix
+++ b/core/docs/changelog/ZO-1847.fix
@@ -1,0 +1,1 @@
+ZO-1847: Seriesheader preview should not cover Vivi UI

--- a/core/src/zeit/content/cp/browser/blocks/layout.headerimage.content.pt
+++ b/core/src/zeit/content/cp/browser/blocks/layout.headerimage.content.pt
@@ -1,11 +1,10 @@
 <div i18n:domain="zeit.cms">
+  <img tal:condition="context/image"
+       tal:attributes="src view/image_url" />
   <div class="header">
     <tal:block condition="context/supertitle">
     <span class="supertitle" tal:content="context/supertitle"/><br/>
     </tal:block>
     <span class="title" tal:content="context/title"/>
   </div>
-
-  <img tal:condition="context/image"
-       tal:attributes="src view/image_url" />
 </div>

--- a/core/src/zeit/content/cp/browser/resources/editor.css
+++ b/core/src/zeit/content/cp/browser/resources/editor.css
@@ -601,15 +601,17 @@ buttons, we only can get a different label if we override it here. */
 
 
 .block.type-headerimage .header {
-  background-color: white;
   text-align: center;
+}
+.block.type-headerimage img {
+  width: 100%;
+}
+.block.type-headerimage img + .header {
+  background-color: white;
   position: absolute;
   top: 20%;
   width: 90%;
   left: 5%;
-}
-.block.type-headerimage img {
-  width: 100%;
 }
 
 .block.type-headerimage .edit {


### PR DESCRIPTION
Auf Seiten mit Serienheader gab es folgenden Bug: die "Vorschau" des Serienheaders überdeckte das Vivi UI. Grund ist, dass der Text des Serienheaders absolut positioniert ist, um auf Headerbildern zu liegen. Wenn es allerdings kein Headerbild gibt, dann schiebt sich der Text über die Aufklappzeile vom Vivi UI.

Dieser Fix macht, dass die Zeile nur dann absolut positioniert wird, wenn es tatsächlich ein Headerbild gibt. Für diesen zweck haben wir auch das Template etwas umsortiert.

| vorher | nachher |
| ----- | ----- |
|![grafik](https://user-images.githubusercontent.com/148697/209151941-4306a62c-9bd1-4c34-84a7-7fb8d332cbcd.png)|![grafik](https://user-images.githubusercontent.com/148697/209151917-800e49b1-8203-4a25-8df2-de6060fdce33.png)|

Zu sehen zum Beispiel auf http://localhost:8080/repository/serie/die-pflichtverteidigung .

![](https://media.giphy.com/media/D2K4iXeXExAQeMaogd/giphy.gif)