### PR TITLE
ZO-2522: Article checksum for speechbert

### DIFF
--- a/core/docs/changelog/ZO-2522.change
+++ b/core/docs/changelog/ZO-2522.change
@@ -1,0 +1,1 @@
+ZO-2522: Use checksome to validate speechbert audio against article text 

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -4,6 +4,8 @@ from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.workflow.interfaces import CAN_PUBLISH_ERROR
 import gocept.cache.property
 import grokcore.component as grok
+import hashlib
+import json
 import lxml.etree
 import lxml.objectify
 import re
@@ -24,6 +26,7 @@ import zeit.content.portraitbox.interfaces
 import zeit.edit.interfaces
 import zeit.edit.rule
 import zeit.workflow.dependency
+import zeit.workflow.interfaces
 import zeit.workflow.workflow
 import zope.component
 import zope.dublincore.interfaces
@@ -383,3 +386,29 @@ class ArticleMetadataUpdater(zeit.cms.content.xmlsupport.XMLReferenceUpdater):
     def update_with_context(self, node, context):
         if context.genre:
             node.set('genre', context.genre)
+
+
+@zope.interface.implementer(
+    zeit.content.article.interfaces.ISpeechbertChecksum)
+class Speechbert(zeit.cms.content.dav.DAVPropertiesAdapter):
+
+    checksum = zeit.cms.content.dav.DAVProperty(
+        zeit.content.article.interfaces.ISpeechbertChecksum['checksum'],
+        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS, 'checksum',
+        writeable=zeit.cms.content.interfaces.WRITEABLE_LIVE)
+
+
+@grok.subscribe(
+    zeit.content.article.interfaces.IArticle,
+    zeit.cms.workflow.interfaces.IBeforePublishEvent)
+def calculate_checksum(context, event):
+    speechbert = zope.component.getAdapter(
+        context, zeit.workflow.interfaces.IPublisherData, name='speechbert')
+    if speechbert.ignore('publish'):
+        return
+    checksum = hashlib.md5()
+    body = json.dumps(speechbert.get_body(), ensure_ascii=False).encode(
+        'utf-8')
+    checksum.update(body)
+    article = zeit.content.article.interfaces.ISpeechbertChecksum(context)
+    article.checksum = checksum.hexdigest()

--- a/core/src/zeit/content/article/interfaces.py
+++ b/core/src/zeit/content/article/interfaces.py
@@ -278,3 +278,13 @@ class IErrorPage(IArticle):
 
     This interface is applied manually.
     """
+
+
+class ISpeechbertChecksum(zope.interface.Interface):
+    """ Checksum of speechbert payload of article to validate consistency
+    between audio and article body.
+    """
+
+    checksum = zope.schema.Text(
+        title=_('Speechbert Checksum'),
+        required=False)

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -391,7 +391,7 @@ class ArticleSpeechbertTest(zeit.content.article.testing.FunctionalTestCase):
         checksum = zeit.content.article.interfaces.ISpeechbertChecksum(self.repository['article'])
         assert checksum.checksum == 'b4a1bd02e1a320ce563a9b23715be5ef'
 
-    def test_checksum_updates_on_checkin(self):
+    def test_checksum_updates_on_publish(self):
         old = zeit.content.article.interfaces.ISpeechbertChecksum(self.repository['article']).checksum
         article = self.repository['article']
         p = self.get_factory(article, 'p')()

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -379,10 +379,7 @@ class ArticleSpeechbertTest(zeit.content.article.testing.FunctionalTestCase):
     def setUp(self):
         super().setUp()
         article = self.get_article()
-        p = self.get_factory(article, 'p')()
-        p.text = 'speechbert reads interesting news'
-        p = self.get_factory(article, 'p')()
-        p.text = 'one two three'
+        article.body.create_item('p').text = 'foo'
         self.repository['article'] = article
         IPublishInfo(self.repository['article']).urgent = True
         IPublish(self.repository['article']).publish()
@@ -390,18 +387,17 @@ class ArticleSpeechbertTest(zeit.content.article.testing.FunctionalTestCase):
     def test_article_has_speechbert_checksum(self):
         checksum = zeit.content.article.interfaces.ISpeechbertChecksum(
             self.repository['article'])
-        assert checksum.checksum == 'b4a1bd02e1a320ce563a9b23715be5ef'
+        assert checksum.checksum == 'deddeca0c34609deb8dc43eb5b8176c5'
 
     def test_checksum_updates_on_publish(self):
         old = zeit.content.article.interfaces.ISpeechbertChecksum(
             self.repository['article']).checksum
         article = self.repository['article']
-        p = self.get_factory(article, 'p')()
-        p.text = 'foo bar baz'
+        article.body.create_item('p').text = 'bar'
         article = self.repository['article'] = article
         IPublish(article).publish()
         new = zeit.content.article.interfaces.ISpeechbertChecksum(article)
-        assert new.checksum == 'b21be74fea26f7211b63f21aff05ef0b'
+        assert new.checksum == '63a4bec39620f3b239ba5a111e77b1ed'
         assert new.checksum != old
 
     def test_no_body_does_not_break(self):

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -376,29 +376,24 @@ class ArticleElementReferencesTest(
 
 class ArticleSpeechbertTest(zeit.content.article.testing.FunctionalTestCase):
 
-    def setUp(self):
-        super().setUp()
+    def test_checksum_updates_on_publish(self):
         article = self.get_article()
         article.body.create_item('p').text = 'foo'
-        self.repository['article'] = article
-        IPublishInfo(self.repository['article']).urgent = True
-        IPublish(self.repository['article']).publish()
+        article = self.repository['article'] = article
+        IPublishInfo(article).urgent = True
+        IPublish(article).publish()
 
-    def test_article_has_speechbert_checksum(self):
-        checksum = zeit.content.article.interfaces.ISpeechbertChecksum(
-            self.repository['article'])
-        assert checksum.checksum == 'deddeca0c34609deb8dc43eb5b8176c5'
+        checksum = zeit.content.article.interfaces.ISpeechbertChecksum(article)
+        first = checksum.checksum
+        assert len(first) == 32
 
-    def test_checksum_updates_on_publish(self):
-        old = zeit.content.article.interfaces.ISpeechbertChecksum(
-            self.repository['article']).checksum
-        article = self.repository['article']
         article.body.create_item('p').text = 'bar'
         article = self.repository['article'] = article
         IPublish(article).publish()
-        new = zeit.content.article.interfaces.ISpeechbertChecksum(article)
-        assert new.checksum == '63a4bec39620f3b239ba5a111e77b1ed'
-        assert new.checksum != old
+
+        second = checksum.checksum
+        assert len(second) == 32
+        assert second != first
 
     def test_no_body_does_not_break(self):
         article = self.repository['article'] = self.get_article()

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -2,7 +2,6 @@ from itertools import chain
 import datetime
 import grokcore.component as grok
 import logging
-import time
 import zope.app.appsetup.product
 import zeit.cms.content.interfaces
 import zeit.cms.interfaces
@@ -149,13 +148,9 @@ class Speechbert(grok.Adapter):
     grok.context(zeit.content.article.interfaces.IArticle)
     grok.name('speechbert')
 
-    def ignore(self, date_first_released, method):
+    def ignore(self, method):
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow') or {}
-        max_age = int(config['speechbert-max-age'])
-        if date_first_released is not None:
-            if (time.time() - date_first_released.float_timestamp) >= max_age:
-                return True
         if method == "publish":
             ignore_genres = [
                 x.lower()
@@ -241,14 +236,12 @@ class Speechbert(grok.Adapter):
         return {k: v for k, v in payload.items() if v}
 
     def publish_json(self):
-        info = zeit.cms.workflow.interfaces.IPublishInfo(self.context)
-        if self.ignore(info.date_first_released, 'publish'):
+        if self.ignore('publish'):
             return
         return self._json()
 
     def retract_json(self):
-        info = zeit.cms.workflow.interfaces.IPublishInfo(self.context)
-        if self.ignore(info.date_first_released, 'retract'):
+        if self.ignore('retract'):
             return
         return {
             # Can we simplify this protocol? uuid is already passed in toplevel

--- a/core/src/zeit/workflow/testing.py
+++ b/core/src/zeit/workflow/testing.py
@@ -32,7 +32,6 @@ product_config = """
     facebooknewstab-startdate 2021-03-24
     speechbert-ignore-genres datenvisualisierung video quiz
     speechbert-ignore-templates zon-liveblog
-    speechbert-max-age 7776000
 </product-config>
 """
 

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -5,7 +5,6 @@ from zeit.cms.workflow.interfaces import IPublishInfo, IPublish
 from zeit.content.image.testing import create_image_group_with_master_image
 import pytest
 import requests_mock
-import sys
 import zeit.cms.related.interfaces
 import zeit.cms.tagging.tag
 import zeit.cms.tagging.testing
@@ -247,8 +246,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             'http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow')
-        # disable the max-age filter
-        config['speechbert-max-age'] = sys.maxsize
         config['speechbert-ignore-genres'] = 'rezept-vorstellung'
         data_factory = zope.component.getAdapter(
             article,
@@ -267,8 +264,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             'http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow')
-        # disable the max-age filter
-        config['speechbert-max-age'] = sys.maxsize
         config['speechbert-ignore-templates'] = 'article'
         data_factory = zope.component.getAdapter(
             article,
@@ -276,23 +271,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             name="speechbert")
         assert data_factory.publish_json() is None
         config['speechbert-ignore-templates'] = ''
-        data_factory = zope.component.getAdapter(
-            article,
-            zeit.workflow.interfaces.IPublisherData,
-            name="speechbert")
-        assert data_factory.publish_json() is not None
-
-    def test_speechbert_max_age(self):
-        article = ICMSContent(
-            'http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
-        config = zope.app.appsetup.product.getProductConfiguration(
-            'zeit.workflow')
-        data_factory = zope.component.getAdapter(
-            article,
-            zeit.workflow.interfaces.IPublisherData,
-            name="speechbert")
-        assert data_factory.publish_json() is None
-        config['speechbert-max-age'] = sys.maxsize
         data_factory = zope.component.getAdapter(
             article,
             zeit.workflow.interfaces.IPublisherData,
@@ -315,7 +293,7 @@ class SpeechbertPayloadTest(zeit.workflow.testing.FunctionalTestCase):
         monkeypatch.setattr(
             zeit.workflow.publish_3rdparty.Speechbert,
             'ignore',
-            lambda s, d, m: False)
+            lambda s, m: False)
 
     def test_speechbert_payload(self):
         article = ICMSContent(

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -2,7 +2,6 @@ from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.interfaces import ICMSContent
 from zeit.cms.workflow.interfaces import IPublishInfo, IPublish
 import requests_mock
-import sys
 import zeit.content.article.testing
 import zeit.workflow.testing
 import zope.component
@@ -93,8 +92,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             'http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow')
-        # disable the max-age filter
-        config['speechbert-max-age'] = sys.maxsize
         config['speechbert-ignore-genres'] = 'rezept-vorstellung'
         data_factory = zope.component.getAdapter(
             article,
@@ -108,8 +105,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             'http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
         config = zope.app.appsetup.product.getProductConfiguration(
             'zeit.workflow')
-        # disable the max-age filter
-        config['speechbert-max-age'] = sys.maxsize
         config['speechbert-ignore-templates'] = 'article'
         data_factory = zope.component.getAdapter(
             article,


### PR DESCRIPTION
Summary
---
We calculate the checksum of the body payload for speechbert, in order to verify that article body and speechbert audio match. Calculating the body for the speechbert payload twice, once before and once during the publish process, is not ideal. However, this implementation separates writing and reading operations, which is preferable to changing the properties of the article halfway during the publishing process.

How to test
---
well run the tests
```
$ bin/test vivi/core/src/zeit/content/article/tests/test_article.py -k checksum
```
or start local server with `$ bin/serve`. Create an article with a body containing text and publish it. Check the dav properties for the entry `checksum` this should contain an obscure hash, eg. `<attribute ns="http://namespaces.zeit.de/CMS/document" name="checksum">2769e0b12545a890218a81de3b8a866b</attribute>` 
