### PR TITLE
ZO-2032: Always provide ICommonMetadata attributes

### DIFF
--- a/core/docs/changelog/ZO-2032.change
+++ b/core/docs/changelog/ZO-2032.change
@@ -1,0 +1,1 @@
+ZO-2032: Provide ICommonMetadata attributes even if article ref is broken

--- a/core/src/zeit/content/animation/animation.py
+++ b/core/src/zeit/content/animation/animation.py
@@ -38,6 +38,11 @@ class Animation(zeit.cms.content.xmlsupport.XMLContentBase):
     def __getattr__(self, name):
         if name not in self._proxy_attributes:
             raise AttributeError(name)
+        # ZO-2032: MUST provide ICommonMetadata attributes under
+        # any and all circumstances. If the article reference is
+        # broken, return None values at least.
+        if self.article is None:
+            return None
         return getattr(self.article, name)
 
 


### PR DESCRIPTION
Animation acts as proxy for Article. If the Article reference is broken, animations must still provide the expected attributes.
