### PR TITLE
ZO-3159:  Don't publish dpa articles to speechbert

### DIFF
--- a/core/docs/changelog/ZO-3159.change
+++ b/core/docs/changelog/ZO-3159.change
@@ -1,0 +1,1 @@
+ZO-3159: Ignore news articles in speechbert

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -165,6 +165,8 @@ class Speechbert(grok.Adapter):
             template = self.context.template
             if template is not None and template.lower() in ignore_templates:
                 return True
+        if self.context.product.is_news:
+            return True
         return False
 
     def get_body(self):

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -277,6 +277,25 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             name="speechbert")
         assert data_factory.publish_json() is not None
 
+    def test_speechbert_ignores_dpa_news(self):
+        article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
+        data_factory = zope.component.getAdapter(
+            article,
+            zeit.workflow.interfaces.IPublisherData,
+            name="speechbert")
+        assert data_factory.publish_json() is not None
+        with checked_out(article) as co:
+            co.product = zeit.cms.content.sources.Product(
+                id='dpaBY',
+                title='DPA Bayern',
+                show='source',
+                is_news=True)
+        data_factory = zope.component.getAdapter(
+            article,
+            zeit.workflow.interfaces.IPublisherData,
+            name="speechbert")
+        assert data_factory.publish_json() is None
+
 
 class SpeechbertPayloadTest(zeit.workflow.testing.FunctionalTestCase):
 


### PR DESCRIPTION
The products.xml defines if an article is part of the news group (dpa, reuters etc.). The attribute `is_news` of articles belonging to this group, is set to `True`, if the `ProductSource` is used. This is preferable to introducing a third config file regarding the product ids. 

we have to check tomorrow, whether the `is_news` attribute is correctly set in zeit.newsimport.