### PR TITLE
ZO-2483: option ignore 3rd party publishing

### DIFF
--- a/core/docs/changelog/ZO-2483.changes
+++ b/core/docs/changelog/ZO-2483.changes
@@ -1,0 +1,1 @@
+ZO-2483: ignore 3rd party services list as parameter for publisher

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -402,7 +402,8 @@ class PublishRetractTask:
             headers['host'] = hostname
 
         url = f'{publisher_base_url}{method}'
-        json = [cls._format_json(obj, method) for obj in to_process_list]
+        json = [zeit.workflow.interfaces.IPublisherData(obj)(method)
+                for obj in to_process_list]
         response = requests.post(
             url=url, json=json, headers=headers)
         timer.mark('Called Publisher HTTP API: %s' % method)

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -272,3 +272,24 @@ class TMS(grok.Adapter):
         if self.ignore():
             return
         return {}
+
+
+@grok.implementer(zeit.workflow.interfaces.IPublisherData)
+class PublisherData(grok.Adapter):
+    grok.context(zeit.cms.interfaces.ICMSContent)
+
+    ignore = ()  # extension point e.g. for bulk publish scripts
+
+    def __call__(self, action):
+        uuid = zeit.cms.content.interfaces.IUUID(self.context)
+        result = {'uuid': uuid.shortened, 'uniqueId': self.context.uniqueId}
+        for name, adapter in zope.component.getAdapters(
+                (self.context,), zeit.workflow.interfaces.IPublisherData):
+            if not name:  # ourselves
+                continue
+            if name in self.ignore:
+                continue
+            data = getattr(adapter, f'{action}_json')()
+            if data is not None:
+                result[name] = data
+        return result

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -451,3 +451,24 @@ class TMSPayloadTest(zeit.workflow.testing.FunctionalTestCase):
             name='tms')
         payload = data_factory.publish_json()
         assert payload is None
+
+
+@grok.implementer(zeit.workflow.interfaces.IPublisherData)
+class PublisherData(grok.Adapter):
+    grok.context(zeit.cms.interfaces.ICMSContent)
+
+    ignore = ()  # extension point e.g. for bulk publish scripts
+
+    def __call__(self, action):
+        uuid = zeit.cms.content.interfaces.IUUID(self.context)
+        result = {'uuid': uuid.shortened, 'uniqueId': self.context.uniqueId}
+        for name, adapter in zope.component.getAdapters(
+                (self.context,), zeit.workflow.interfaces.IPublisherData):
+            if not name:  # ourselves
+                continue
+            if name in self.ignore:
+                continue
+            data = getattr(adapter, f'{action}_json')()
+            if data is not None:
+                result[name] = data
+        return result

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -21,6 +21,38 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         self.patch.stop()
         super().tearDown()
 
+    def test_ignore_3rdparty_list_is_respected(self):
+        FEATURE_TOGGLES.set('new_publisher')
+        article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
+        IPublishInfo(article).urgent = True
+        self.assertFalse(IPublishInfo(article).published)
+        article_2 = ICMSContent('http://xml.zeit.de/online/2007/01/Schrempp')
+        IPublishInfo(article_2).urgent = True
+        IPublishInfo(article_2).published = True
+        self.assertTrue(IPublishInfo(article_2).published)
+        with requests_mock.Mocker() as rmock:
+            zeit.workflow.publish_3rdparty.PublisherData.ignore = [
+                'speechbert', 'facebooknewstab']
+            response = rmock.post(
+                'http://localhost:8060/test/retract', status_code=200)
+            IPublish(article).retract(background=True)
+            (result,) = response.last_request.json()
+            assert 'facebooknewstab' not in result
+            assert 'speechbert' not in result
+            assert 'bigquery' in result
+            zeit.workflow.publish_3rdparty.PublisherData.ignore = [
+                'speechbert']
+            response = rmock.post(
+                'http://localhost:8060/test/retract', status_code=200)
+            IPublish(article_2).retract(background=False)
+            (result,) = response.last_request.json()
+            assert 'speechbert' not in result
+            assert 'facebooknewstab' in result
+            assert 'bigquery' in result
+        zeit.workflow.publish_3rdparty.PublisherData.ignore = []  # reset
+        self.assertFalse(IPublishInfo(article).published)
+        self.assertFalse(IPublishInfo(article_2).published)
+
     def test_authordashboard_is_ignored_during_retraction(self):
         FEATURE_TOGGLES.set('new_publisher')
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')


### PR DESCRIPTION
Erstmal schauen, ob der richtige Ansatz.

Einen Aufruf stelle ich mir so vor: https://github.com/ZeitOnline/vivi-deployment/commit/a9d438f36eb97e3a141265689056e10a37ff7f35