### PR TITLE
ZO-3364: Renames 'AnimatedHeader' modul to 'Animation'

### DIFF
--- a/core/docs/changelog/ZO-3364.change
+++ b/core/docs/changelog/ZO-3364.change
@@ -1,0 +1,1 @@
+ZO-3364: Renames 'AnimatedHeader' modul to 'Animation'

--- a/core/src/zeit/content/article/edit/animation.py
+++ b/core/src/zeit/content/article/edit/animation.py
@@ -4,14 +4,14 @@ import zeit.content.article.edit.block
 import zeit.content.article.edit.interfaces
 
 
-@grok.implementer(zeit.content.article.edit.interfaces.IAnimatedHeader)
-class AnimatedHeader(zeit.content.article.edit.block.Block):
+@grok.implementer(zeit.content.article.edit.interfaces.IAnimation)
+class Animation(zeit.content.article.edit.block.Block):
 
-    type = 'animatedheader'
+    type = 'animation'
     animation = zeit.cms.content.reference.SingleResource(".", "related")
 
 
 class Factory(zeit.content.article.edit.block.BlockFactory):
 
-    produces = AnimatedHeader
-    title = _('Animated header')
+    produces = Animation
+    title = _('Animation')

--- a/core/src/zeit/content/article/edit/browser/configure.zcml
+++ b/core/src/zeit/content/article/edit/browser/configure.zcml
@@ -901,23 +901,23 @@
     />
 
 
-  <!-- Animated Article Header -->
+  <!-- Animation -->
 
   <browser:viewlet
-    for="zeit.content.article.edit.interfaces.IAnimatedHeader"
+    for="zeit.content.article.edit.interfaces.IAnimation"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     view="zope.interface.Interface"
     manager="zeit.edit.interfaces.IContentViewletManager"
-    name="edit-animatedheader"
+    name="edit-animation"
     class="zeit.edit.browser.form.FormLoader"
     permission="zope.View"
     />
 
   <browser:page
-    for="zeit.content.article.edit.interfaces.IAnimatedHeader"
+    for="zeit.content.article.edit.interfaces.IAnimation"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="edit-animatedheader"
-    class=".edit.EditAnimatedHeader"
+    name="edit-animation"
+    class=".edit.EditAnimation"
     permission="zope.View"
     />
 

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -620,16 +620,16 @@ class EditIngredientDice(zeit.edit.browser.form.InlineForm):
         return 'ingredientdice.{0}'.format(self.context.__name__)
 
 
-class EditAnimatedHeader(
+class EditAnimation(
         zeit.cms.browser.manual.FormMixin,
         zeit.edit.browser.form.InlineForm):
 
     legend = ''
     form_fields = zope.formlib.form.FormFields(
-        zeit.content.article.edit.interfaces.IAnimatedHeader).omit(
+        zeit.content.article.edit.interfaces.IAnimation).omit(
             *list(zeit.edit.interfaces.IBlock))
-    undo_description = _('edit animated header block')
+    undo_description = _('edit animation block')
 
     @property
     def prefix(self):
-        return 'animatedheader.{0}'.format(self.context.__name__)
+        return 'animation.{0}'.format(self.context.__name__)

--- a/core/src/zeit/content/article/edit/configure.zcml
+++ b/core/src/zeit/content/article/edit/configure.zcml
@@ -451,13 +451,13 @@
       permission="zeit.EditContent" />
   </class>
 
-  <class class=".animatedheader.AnimatedHeader">
+  <class class=".animation.Animation">
     <require
-      interface=".interfaces.IAnimatedHeader"
+      interface=".interfaces.IAnimation"
       permission="zope.View"
       />
     <require
-      set_schema=".interfaces.IAnimatedHeader"
+      set_schema=".interfaces.IAnimation"
       permission="zeit.EditContent"
       />
   </class>

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -360,7 +360,7 @@ class AnimationObjectSource(zeit.cms.content.contentsource.CMSContentSource):
     check_interfaces = (IAnimation,)
 
 
-class IAnimatedHeader(IBlock):
+class IAnimation(IBlock):
     animation = zope.schema.Choice(
         title=_("URL of animation"),
         source=AnimationObjectSource(),

--- a/core/src/zeit/content/article/edit/tests/header-modules.xml
+++ b/core/src/zeit/content/article/edit/tests/header-modules.xml
@@ -4,5 +4,5 @@
   <module id="video" title="Video"/>
   <module id="raw" title="Embed-Code"/>
   <module id="rawtext" title="Embed-Link"/>
-  <module id="animatedheader" title="AnimatedHeader"/>
+  <module id="animation" title="Animation"/>
 </modules>

--- a/core/src/zeit/content/article/edit/tests/modules.xml
+++ b/core/src/zeit/content/article/edit/tests/modules.xml
@@ -7,7 +7,7 @@
   <module id="citation_comment">Zitat-Leserkommentar</module>
   <module id="division">Seitenumbruch</module>
   <module id="embed">Social Embed</module>
-  <module id="animatedheader">Animated Header</module>
+  <module id="animation">Animation</module>
   <module id="gallery">Bildergalerie</module>
   <module id="image">Bild</module>
   <module id="infobox">Infobox</module>

--- a/core/src/zeit/content/article/edit/tests/test_animation.py
+++ b/core/src/zeit/content/article/edit/tests/test_animation.py
@@ -1,22 +1,22 @@
 from lxml.objectify import E
 from zeit.content.animation.animation import Animation
 from zeit.content.article.article import Article
-from zeit.content.article.edit.animatedheader import AnimatedHeader
+from zeit.content.article.edit.animation import Animation as AnimatedHeader
 from zeit.content.article.testing import FunctionalTestCase, MOCK_LAYER
 from zeit.content.video.video import Video
 
 
-class TestAnimatedHeader(FunctionalTestCase):
+class TestAnimation(FunctionalTestCase):
 
     layer = MOCK_LAYER
 
-    def test_animatedheader(self):
+    def test_animation(self):
         self.repository['article'] = Article()
         self.repository['video'] = Video()
         animation = Animation()
         animation.article = self.repository['article']
         animation.video = self.repository['video']
         self.repository['animation'] = animation
-        animatedheader = AnimatedHeader(None, E.animatedheader())
+        animatedheader = AnimatedHeader(None, E.animation())
         animatedheader.animation = self.repository['animation']
         assert animatedheader.xml.get('href') == 'http://xml.zeit.de/animation'

--- a/core/src/zeit/content/article/tests/article-templates.xml
+++ b/core/src/zeit/content/article/tests/article-templates.xml
@@ -7,9 +7,6 @@
     <header name="embed" allow_header_module="true">
       <title>Header-Modul oben</title>
     </header>
-    <header name="animatedheader" allow_header_module="true">
-      <title>Header-Animated-Modul oben</title>
-    </header>
     <header name="podcast" allow_header_module="true">
       <title>Podcast</title>
     </header>
@@ -21,9 +18,6 @@
     <title>Visual Article</title>
     <header name="embed" allow_header_module="true">
       <title>Header-Modul oben</title>
-    </header>
-    <header name="animatedheader" allow_header_module="true">
-      <title>Header-Animated-Modul oben</title>
     </header>
     <header name="fullwidth-classic">
       <title>Vollbreit, classic</title>


### PR DESCRIPTION
Dieser PR benennt das 'AnimatedHeader'-Modul in 'Animation' um.
Wenn das Modul ggf. auch in _nicht-Header_ verwendet werden soll, ist die Bezeichnung 'Animation' geeigneter.