### PR TITLE
ZO-3351: race condition for asynchronous index tasks

### DIFF
--- a/core/docs/changelog/ZO-3351.change
+++ b/core/docs/changelog/ZO-3351.change
@@ -1,0 +1,1 @@
+ZO-3351: fix race condition for asynchronous index tasks on publish

--- a/core/src/zeit/cms/checkout/browser/manager.py
+++ b/core/src/zeit/cms/checkout/browser/manager.py
@@ -129,6 +129,8 @@ class Checkin(zeit.cms.browser.view.Base, CheckinAndRedirect):
             semantic_change = None
         else:
             semantic_change = bool(semantic_change)
+        if isinstance(event, str) and event == 'False':
+            event = False
         return self.perform_checkin(
             semantic_change, bool(event), bool(ignore_conflicts))
 

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -21,6 +21,8 @@ log = logging.getLogger(__name__)
     zeit.cms.checkout.interfaces.IAfterCheckinEvent)
 def notify_after_checkin(context, event):
     # XXX Work around redis/ZODB race condition, see BUG-796.
+    log.info('AfterCheckin: Creating async index job for %s: publishing: %s',
+             context.uniqueId, event.publishing)
     for hook in HOOKS:
         notify_webhook.apply_async((context.uniqueId, hook.url), countdown=5)
 

--- a/core/src/zeit/cms/content/liveproperty.py
+++ b/core/src/zeit/cms/content/liveproperty.py
@@ -2,12 +2,15 @@ from zeit.cms.content.interfaces import WRITEABLE_ALWAYS, WRITEABLE_LIVE
 from zeit.cms.content.interfaces import WRITEABLE_ON_CHECKIN
 from zeit.connector.interfaces import DeleteProperty
 import collections.abc
+import logging
 import zeit.cms.checkout.interfaces
 import zeit.cms.repository.interfaces
 import zeit.connector.interfaces
 import zope.component
 import zope.interface
 import zope.security.interfaces
+
+log = logging.getLogger(__name__)
 
 
 @zope.component.adapter(zeit.cms.repository.interfaces.IRepositoryContent)
@@ -92,6 +95,7 @@ def remove_live_properties(context, event):
         properties = zeit.connector.interfaces.IWebDAVProperties(context)
     except TypeError:
         return
+    log.info('BeforeCheckin: remove live properties from %s', context.uniqueId)
     manager = zope.component.getUtility(
         zeit.cms.content.interfaces.ILivePropertyManager)
     for live_property in manager.live_properties:

--- a/core/src/zeit/cms/relation/corehandlers.py
+++ b/core/src/zeit/cms/relation/corehandlers.py
@@ -21,6 +21,8 @@ def update_index_on_checkin(context, event):
         return
     if getattr(event, 'publishing', False):
         return
+    log.info('BeforeCheckin: Creating async index job for %s',
+             context.uniqueId)
     relations = zope.component.getUtility(
         zeit.cms.relation.interfaces.IRelations)
     relations.index(context)

--- a/core/src/zeit/content/article/edit/browser/save-and-publish.pt
+++ b/core/src/zeit/content/article/edit/browser/save-and-publish.pt
@@ -3,7 +3,7 @@
 
 <tal:block condition="view/can_publish">
 <ol id="worklist">
-  <li action="checkin" cms:param="&amp;semantic_change=None" i18n:translate="">Checking in</li>
+  <li action="checkin" cms:param="&amp;semantic_change=None&amp;event=False" i18n:translate="">Checking in</li>
   <li action="start_job" cms:param="publish" i18n:translate="">Publishing</li>
   <li action="reload" i18n:translate="">Reloading</li>
 </ol>

--- a/core/src/zeit/content/gallery/workflow.txt
+++ b/core/src/zeit/content/gallery/workflow.txt
@@ -107,6 +107,8 @@ work/image-folder/01.jpg
 work/online/gallery
 done.
 <BLANKLINE>
+BeforeCheckin: remove live properties from http://xml.zeit.de/online/gallery
+AfterCheckin: Creating async index job for http://xml.zeit.de/online/gallery: publishing: True
 Done http://xml.zeit.de/online/gallery (...s)
 
 

--- a/core/src/zeit/retresco/testhelper.py
+++ b/core/src/zeit/retresco/testhelper.py
@@ -41,6 +41,7 @@ class TMSMockLayer(plone.testing.Layer):
         self['tms'].get_related_documents.return_value = (
             zeit.cms.interfaces.Result())
         self['tms'].get_article_data.return_value = {}
+        self['tms'].generate_keyword_list.return_value = []
         zope.interface.alsoProvides(
             self['tms'], zeit.retresco.interfaces.ITMS)
         zope.component.getSiteManager().registerUtility(self['tms'])

--- a/core/src/zeit/retresco/tests/test_update.py
+++ b/core/src/zeit/retresco/tests/test_update.py
@@ -189,6 +189,7 @@ class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
         super().setUp()
         self.tms = mock.Mock()
         self.tms.get_article_data.return_value = {}
+        self.tms.generate_keyword_list.return_value = []
         zope.component.getGlobalSiteManager().registerUtility(
             self.tms, zeit.retresco.interfaces.ITMS)
 

--- a/core/src/zeit/retresco/update.py
+++ b/core/src/zeit/retresco/update.py
@@ -39,7 +39,7 @@ def index_after_add(event):
     if zeit.cms.workingcopy.interfaces.IWorkingcopy.providedBy(
             event.newParent):
         return
-    log.info('AfterAdd: Creating async index job for %s' % context.uniqueId)
+    log.info('AfterAdd: Creating index job for %s', context.uniqueId)
     index_async.delay(context.uniqueId)
 
 
@@ -52,6 +52,7 @@ def index_after_checkin(context, event):
     # XXX Work around race condition between celery/redis (applies already
     # in tpc_vote) and DAV-cache in ZODB (applies only in tpc_finish, so
     # the celery job *may* start executing before that happens), BUG-796.
+    log.info('AfterCheckin: Creating async index job for %s', context.uniqueId)
     index_async.apply_async((context.uniqueId,), countdown=5)
 
 
@@ -73,6 +74,7 @@ def index_on_publish(context, event):
     zeit.cms.interfaces.ICMSContent,
     zeit.cms.workflow.interfaces.IRetractedEvent)
 def index_after_retract(context, event):
+    log.info('AfterRetract: Creating async index job for %s', context.uniqueId)
     index_async.apply_async((context.uniqueId, False), countdown=5)
 
 


### PR DESCRIPTION
- [x] Changelog
- [ ] Review presentation sheets

Test Dependency in [zeit.newsimport/pull/77](https://github.com/ZeitOnline/zeit.newsimport/pull/77)

JENKINS_BATOU_BRANCH=ZO-3351_update_newsimport