### PR TITLE
ZO-3351: increased memory consumption

### DIFF
--- a/core/docs/changelog/ZO-3351.change
+++ b/core/docs/changelog/ZO-3351.change
@@ -1,0 +1,1 @@
+ZO-3351: Revert asynchronous to synchronous tasks during checkout/publish 

--- a/core/src/zeit/cms/checkout/browser/manager.py
+++ b/core/src/zeit/cms/checkout/browser/manager.py
@@ -129,8 +129,6 @@ class Checkin(zeit.cms.browser.view.Base, CheckinAndRedirect):
             semantic_change = None
         else:
             semantic_change = bool(semantic_change)
-        if isinstance(event, str) and event == 'False':
-            event = False
         return self.perform_checkin(
             semantic_change, bool(event), bool(ignore_conflicts))
 

--- a/core/src/zeit/content/article/edit/browser/save-and-publish.pt
+++ b/core/src/zeit/content/article/edit/browser/save-and-publish.pt
@@ -3,7 +3,7 @@
 
 <tal:block condition="view/can_publish">
 <ol id="worklist">
-  <li action="checkin" cms:param="&amp;semantic_change=None&amp;event=False" i18n:translate="">Checking in</li>
+  <li action="checkin" cms:param="&amp;semantic_change=None" i18n:translate="">Checking in</li>
   <li action="start_job" cms:param="publish" i18n:translate="">Publishing</li>
   <li action="reload" i18n:translate="">Reloading</li>
 </ol>

--- a/core/src/zeit/content/gallery/workflow.txt
+++ b/core/src/zeit/content/gallery/workflow.txt
@@ -107,8 +107,6 @@ work/image-folder/01.jpg
 work/online/gallery
 done.
 <BLANKLINE>
-BeforeCheckin: remove live properties from http://xml.zeit.de/online/gallery
-AfterCheckin: Creating async index job for http://xml.zeit.de/online/gallery: publishing: True
 Done http://xml.zeit.de/online/gallery (...s)
 
 

--- a/core/src/zeit/content/gallery/workflow.txt
+++ b/core/src/zeit/content/gallery/workflow.txt
@@ -107,6 +107,8 @@ work/image-folder/01.jpg
 work/online/gallery
 done.
 <BLANKLINE>
+BeforeCheckin: remove live properties from http://xml.zeit.de/online/gallery
+AfterCheckin: Creating async index job for http://xml.zeit.de/online/gallery: publishing: True
 Done http://xml.zeit.de/online/gallery (...s)
 
 

--- a/core/src/zeit/retresco/testhelper.py
+++ b/core/src/zeit/retresco/testhelper.py
@@ -41,7 +41,6 @@ class TMSMockLayer(plone.testing.Layer):
         self['tms'].get_related_documents.return_value = (
             zeit.cms.interfaces.Result())
         self['tms'].get_article_data.return_value = {}
-        self['tms'].generate_keyword_list.return_value = []
         zope.interface.alsoProvides(
             self['tms'], zeit.retresco.interfaces.ITMS)
         zope.component.getSiteManager().registerUtility(self['tms'])

--- a/core/src/zeit/retresco/tests/test_update.py
+++ b/core/src/zeit/retresco/tests/test_update.py
@@ -189,7 +189,6 @@ class UpdatePublishTest(zeit.retresco.testing.FunctionalTestCase):
         super().setUp()
         self.tms = mock.Mock()
         self.tms.get_article_data.return_value = {}
-        self.tms.generate_keyword_list.return_value = []
         zope.component.getGlobalSiteManager().registerUtility(
             self.tms, zeit.retresco.interfaces.ITMS)
 

--- a/core/src/zeit/retresco/update.py
+++ b/core/src/zeit/retresco/update.py
@@ -40,7 +40,7 @@ def index_after_add(event):
             event.newParent):
         return
     log.info('AfterAdd: Creating index job for %s', context.uniqueId)
-    update_content_index(context.uniqueId)
+    index_async.delay(context.uniqueId)
 
 
 @grok.subscribe(
@@ -64,7 +64,10 @@ def index_on_publish(context, event):
     # speaking that "already happened" on checkin, to support the "checkin
     # and publish immediately" use case -- since there publish likely
     # happens *before* the index_async job created by checkin ran.
-    update_content_index(context.uniqueId, publish=True)
+    enrich = True
+    if not FEATURE_TOGGLES.find('tms_enrich_on_checkin'):
+        enrich = False
+    index(context, enrich=enrich)
 
 
 @grok.subscribe(
@@ -99,13 +102,6 @@ def index_workflow_properties(context, event):
 
 @zeit.cms.celery.task(bind=True, queue='search')
 def index_async(self, uniqueId, enrich=True):
-    try:
-        update_content_index(uniqueId, enrich=enrich)
-    except zeit.retresco.interfaces.TechnicalError:
-        self.retry()
-
-
-def update_content_index(uniqueId, enrich=True, publish=False):
     context = zeit.cms.interfaces.ICMSContent(uniqueId, None)
     if context is None:
         log.warning('Could not index %s because it does not exist any longer.',
@@ -115,11 +111,13 @@ def update_content_index(uniqueId, enrich=True, publish=False):
         enrich = False
     meta = zeit.cms.content.interfaces.ICommonMetadata(context, None)
     has_keywords = meta is not None and meta.keywords
-    index(
-        context,
-        enrich=enrich,
-        update_keywords=enrich and not has_keywords,
-        publish=publish)
+    try:
+        index(
+            context,
+            enrich=enrich,
+            update_keywords=enrich and not has_keywords)
+    except zeit.retresco.interfaces.TechnicalError:
+        self.retry()
 
 
 # Preserve previously stored fields during re-index.


### PR DESCRIPTION
we revert the changes, because the memory consumption on `vivi-task` and `vivi-app`. Local workflow tests are green 👍 

JENKINS_BATOU_BRANCH=ZO-3351_update_newsimport_again