### PR TITLE
ZO-2808: preview for markup in vivi

### DIFF
--- a/core/docs/changelog/ZO-2808.change
+++ b/core/docs/changelog/ZO-2808.change
@@ -1,0 +1,2 @@
+ZO-2808: display teaser preview for markup in centerpage
+ZO-2808: display markup preview in folder list view

--- a/core/src/zeit/cms/content/browser/common_metadata_preview.pt
+++ b/core/src/zeit/cms/content/browser/common_metadata_preview.pt
@@ -2,13 +2,21 @@
   <metal:data fill-slot="preview">
     <div class="super-title"
       title="Spitzmarke"
+      tal:condition="context/teaserTitle"
       tal:content="context/supertitle">
-      Super title
+      Super Title
     </div>
     <div class="teaser-title"
       title="Teaser"
+      tal:condition="context/teaserTitle"
       tal:content="context/teaserTitle">
-      Teaser Title 
+      Teaser Title
+    </div>
+    <div class="teaser-title"
+      title="Title"
+      tal:condition="not:context/teaserTitle"
+      tal:content="context/title">
+      Title
     </div>
     <div class="teaser-text"
       title="Teaser"

--- a/core/src/zeit/content/cp/browser/blocks/teaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/teaser.py
@@ -156,22 +156,24 @@ class ITeaserRepresentation(zope.interface.Interface):
 @grok.implementer(ITeaserRepresentation)
 def default_teaser_representation(content, request):
 
-    def make_text_entry(metadata, css_class, name=None):
+    def make_text_entry(metadata, css_class, name=None, fallback=None):
         if name is None:
             name = css_class
-        return dict(css_class=css_class, content=getattr(metadata, name))
+        value = getattr(metadata, name)
+        if not value and fallback:
+            value = getattr(metadata, fallback)
+        return dict(css_class=css_class, content=value)
 
     texts = []
     metadata = zeit.cms.content.interfaces.ICommonMetadata(
         content, None)
     if metadata is not None:
-        supertitle_property = (
-            'teaserSupertitle' if metadata.teaserSupertitle
-            else 'supertitle')
         texts.append(make_text_entry(
-            metadata, 'supertitle', supertitle_property))
-        for name in ('teaserTitle', 'teaserText'):
-            texts.append(make_text_entry(metadata, name))
+            metadata, 'supertitle', 'teaserSupertitle', 'supertitle'))
+        texts.append(make_text_entry(
+            metadata, 'teaserTitle', fallback='title'))
+        texts.append(make_text_entry(
+            metadata, 'teaserText'))
     else:
         # General-purpose fallback, mostly to support IAuthor teasers.
         list_repr = zope.component.queryMultiAdapter(

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
@@ -243,3 +243,14 @@ class FunctionalTeaserDisplayTest(zeit.content.cp.testing.FunctionalTestCase):
             'content'])
         self.assertEqual('Baz', view.teasers[0]['texts'][2][
             'content'])
+
+    def test_content_types_without_teaser_property_have_fallbacks(
+            self):
+        article = zeit.content.article.article.Article()
+        article.title = 'Bar'
+        self.repository['article_with_citation'] = article
+        quote_teaserblock = self.create_teaserblock('zar-quote-yellow')
+        quote_teaserblock.insert(0, article)
+        view = self.view(quote_teaserblock)
+        self.assertEqual('Bar', view.teasers[0]['texts'][1][
+            'content'])

--- a/core/src/zeit/content/markup/markup.py
+++ b/core/src/zeit/content/markup/markup.py
@@ -28,6 +28,17 @@ class Markup(zeit.cms.content.metadata.CommonMetadata):
 
     text = zeit.cms.content.property.Structure('.text')
 
+    @property
+    def teaserText(self):
+        '''for metadata preview, return text as teaser text
+        to display it.
+        If text is longer than 15 words, shorten it
+        '''
+        if self.text and self.text.count(' ') > 15:
+            teaser = ' '.join(self.text.split(' ')[:10])
+            return f'{teaser} ...'
+        return self.text
+
 
 class MarkupType(zeit.cms.type.XMLContentTypeDeclaration):
 

--- a/core/src/zeit/content/markup/tests/test_markup.py
+++ b/core/src/zeit/content/markup/tests/test_markup.py
@@ -1,3 +1,5 @@
+import string
+
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.testing import xmltotext
 
@@ -35,3 +37,28 @@ class MarkupTest(zeit.content.markup.testing.FunctionalTestCase):
         self.assertEqual('<h1>baz</h1>', self.repository['markup'].text)
         self.assertEllipsis(
             '...<h1>baz</h1>...', xmltotext(self.repository['markup'].xml))
+
+    def test_teaser_text_shows_a_shorter_version_of_text(self):
+        markup = zeit.content.markup.markup.Markup()
+        self.repository['markup'] = markup
+        with checked_out(self.repository['markup']) as co:
+            co.text = ' '.join([letter for letter in string.ascii_lowercase])
+
+        self.assertEqual(
+            'a b c d e f g h i j ...',
+            self.repository['markup'].teaserText)
+
+    def test_teaser_text_shows_nothing_if_text_is_missing(self):
+        markup = zeit.content.markup.markup.Markup()
+        self.repository['markup'] = markup
+        self.assertEqual(None, self.repository['markup'].teaserText)
+
+    def test_teaser_text_only_shortened_if_long_enough(self):
+        markup = zeit.content.markup.markup.Markup()
+        self.repository['markup'] = markup
+        with checked_out(self.repository['markup']) as co:
+            co.text = 'a b'
+
+        self.assertEqual(
+            'a b',
+            self.repository['markup'].teaserText)


### PR DESCRIPTION
- ZO-2808: display teaser preview for markup in centerpage
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/7b7f9eca-6ece-4510-8c54-d40b6916fdd9)


- ZO-2808: display markup preview in folder list view
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/aacf9bbd-6b3f-47f4-bcb3-8f33f47bd4c6)

  Lange Text werden gekürzt

  ![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/56f1cc01-ff30-4408-932f-06cb3443d108)

