### PR TITLE
ZO-3262: Set target for RSS feed links (wiwo parquet)

### DIFF
--- a/core/docs/changelog/ZO-3262.change
+++ b/core/docs/changelog/ZO-3262.change
@@ -1,0 +1,1 @@
+ZO-3262: Set target for RSS feed links (wiwo parquet)

--- a/core/src/zeit/content/cp/blocks/rss.py
+++ b/core/src/zeit/content/cp/blocks/rss.py
@@ -32,6 +32,8 @@ class RSSLink:
 
     authorships = ()
 
+    target = '_blank'
+
     @cachedproperty
     def title(self):
         title = self.xml.findtext('title')


### PR DESCRIPTION
Usage and tests follow as a zeit.web PR ... 