### PR TITLE
ZO-3550: Implement path prefix exclude for checkin webhook

### DIFF
--- a/core/docs/changelog/ZO-3550.change
+++ b/core/docs/changelog/ZO-3550.change
@@ -1,0 +1,1 @@
+ZO-3550: Implement path prefix exclude for checkin webhook

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -112,3 +112,10 @@ class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):
         with checked_out(self.repository['testcontent']) as co:
             IAutomaticallyRenameable(co).renameable = True
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
+
+    def test_match_path_prefix(self):
+        hook = zeit.cms.checkout.webhook.Hook(None)
+        hook.add_exclude('path_prefix', '/online')
+        self.assertFalse(hook.should_exclude(self.repository['testcontent']))
+        self.assertTrue(hook.should_exclude(
+            self.repository['online']['2007']['01']['Somalia']))

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -116,6 +116,10 @@ class Hook:
             return False
         return content.product and content.product.id == value
 
+    def _match_path_prefix(self, content, value):
+        path = content.uniqueId.replace(zeit.cms.interfaces.ID_NAMESPACE, '/')
+        return path.startswith(value)
+
 
 class HookSource(zeit.cms.content.sources.SimpleXMLSource):
 


### PR DESCRIPTION
Stellt sich raus, neben News-Bildern häufen sich z.B. auch die Artikel, die von der Nachtwache alle paar Minuten veröffentlicht werden. Das ist vermeidbarer Datenmüll.