### PR TITLE
ZO-3701: Simplecast tab

### DIFF
--- a/core/docs/changelog/ZO-3701.change
+++ b/core/docs/changelog/ZO-3701.change
@@ -1,0 +1,1 @@
+ZO-3701: Request episode data from simplecast manually

--- a/core/src/zeit/content/audio/browser/configure.zcml
+++ b/core/src/zeit/content/audio/browser/configure.zcml
@@ -1,5 +1,6 @@
 <configure
   xmlns="http://namespaces.zope.org/zope"
+  xmlns:gocept="http://namespaces.gocept.com/zcml"
   xmlns:browser="http://namespaces.zope.org/browser"
   i18n_domain="zeit.cms">
 
@@ -49,5 +50,33 @@
     file="resources/audio.png"
     layer="zeit.cms.browser.interfaces.ICMSStyles"
     />
+
+  <gocept:pagelet
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="simplecast.html"
+    class=".connection.Status"
+    template="simplecast.pt"
+    permission="zope.View"
+    />
+
+  <browser:menuItem
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    menu="zeit-context-views"
+    title="Simplecast"
+    action="@@simplecast.html"
+    permission="zope.View"
+    filter="python:modules['zeit.cms.repository.interfaces'].IRepositoryContent.providedBy(context)"
+    />
+
+  <browser:page
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="simplecast-request"
+    class=".connection.Request"
+    permission="zope.Public"
+    />
+
 
 </configure>

--- a/core/src/zeit/content/audio/browser/connection.py
+++ b/core/src/zeit/content/audio/browser/connection.py
@@ -1,0 +1,20 @@
+import zeit.cms.browser.view
+import zeit.content.audio.interfaces
+
+
+class Status:
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def has_permission(self, permission):
+        return self.request.interaction.checkPermission(
+            permission, self.context)
+
+
+class Request(zeit.cms.browser.view.Base):
+
+    def __call__(self):
+        zeit.simplecast.interfaces.IConnector(self.context)
+        return self.redirect(self.url('simplecast.html'))

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -1,6 +1,7 @@
 from zeit.cms.i18n import MessageFactory as _
 import zope.formlib
 import gocept.form
+import zeit.cms.browser.form
 import zeit.content.audio.interfaces
 import zeit.content.audio.audio
 

--- a/core/src/zeit/content/audio/browser/simplecast.pt
+++ b/core/src/zeit/content/audio/browser/simplecast.pt
@@ -1,0 +1,14 @@
+<tal:block>
+<h3>Podcast episode</h3>
+<p>Title <tal:x replace="view/context/title"/></p>
+<p>Episode Id <tal:x replace="view/context/episode_id"/></p>
+<p>Url <tal:x replace="view/context/url"/></p>
+</tal:block>
+
+<tal:block condition="python: view.has_permission('zeit.audio.SimplecastRequest')">
+<p>
+<form method="GET" action="@@simplecast-request">
+  <input type="submit" value="Request episode data" />
+</form>
+</p>
+</tal:block>

--- a/core/src/zeit/content/audio/browser/tests/test_connection.py
+++ b/core/src/zeit/content/audio/browser/tests/test_connection.py
@@ -1,0 +1,31 @@
+import requests_mock
+import zeit.content.audio.testing
+
+
+class TestSimplecastRequest(zeit.content.audio.testing.BrowserTestCase):
+
+    login_as = 'producer:producerpw'
+
+    def test_add_audio(self):
+        self.make_audio()
+        m_simple = requests_mock.Mocker()
+        episode_id = '1234'
+        m_simple.get(
+            f'https://testapi.simplecast.com/episodes/{episode_id}',
+            json=self.json)
+        url = (
+            'https://injector.simplecastaudio.com/5678/episodes/1234/audio'
+            '/128/default.mp3?awCollectionId=5678&awEpisodeId=1234')
+
+        with m_simple:
+            browser = self.browser
+            browser.open(
+                'http://localhost/++skin++vivi/repository/1234/'
+                '@@simplecast.html')
+            self.assertEllipsis(
+                '...Title Cat Jokes Pawdcast...', browser.contents)
+            self.assertEllipsis('...Url ...', browser.contents)
+            browser.getControl('Request episode data').click()
+            self.assertEllipsis(
+                '...Title Cat Jokes Pawdcast', browser.contents)
+            self.assertEllipsis(f'...Url {url}...', browser.contents)

--- a/core/src/zeit/content/audio/configure.zcml
+++ b/core/src/zeit/content/audio/configure.zcml
@@ -32,4 +32,8 @@
       />
   </class>
 
+  <permission
+    id="zeit.audio.SimplecastRequest"
+    title="Request podcast data from simplecast"
+    />
 </configure>

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -1,4 +1,5 @@
 import zeit.cms.testing
+import zeit.content.audio.audio
 
 
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
@@ -6,6 +7,17 @@ ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
     bases=(zeit.cms.testing.CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
+
+JSON = {
+    "title": "Cat Jokes Pawdcast",
+    "id": "1234",
+    "audio_file_url": (
+        "https://injector.simplecastaudio.com/5678/episodes/1234/audio"
+        "/128/default.mp3?awCollectionId=5678&awEpisodeId=1234"),
+    "ad_free_audio_file_url": None,
+    "created_at": "2023-08-31T13:51:00-01:00",
+    "duration": 666,
+}
 
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
@@ -16,3 +28,11 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
     layer = WSGI_LAYER
+    json = JSON
+
+    def make_audio(self):
+        audio = zeit.content.audio.audio.Audio()
+        audio.title = self.json['title']
+        audio.episode_id = self.json['id']
+        audio.url = self.json['audio_file_url']
+        self.repository[audio.episode_id] = audio

--- a/core/src/zeit/securitypolicy/security.zcml
+++ b/core/src/zeit/securitypolicy/security.zcml
@@ -201,6 +201,10 @@
     />
   <grant
     role="zeit.Producer"
+    permission="zeit.audio.SimplecastRequest"
+    />
+  <grant
+    role="zeit.Producer"
     permission="zeit.content.author.Add"
     />
   <grant

--- a/core/src/zeit/simplecast/interfaces.py
+++ b/core/src/zeit/simplecast/interfaces.py
@@ -5,3 +5,10 @@ class ISimplecast(zope.interface.Interface):
 
     def fetch_episode(self, episode_id):
         """Request epiosde data from simplecast, return json body"""
+
+
+class IConnector(zope.interface.Interface):
+
+    def request(context):
+        """Request data from podcast episode via simplecast
+        """


### PR DESCRIPTION
Nach Rebase nun wieder auf dem aktuellen Stand, aber mit dem selben Problem wie vorher:
- lokal kann ich den Button in dem neuen Tab klicken, aber der Browser Tests findet ihn nicht
- gehört der Connector nach `zeit.
<img width="1429" alt="Screenshot 2023-09-06 at 17 09 54" src="https://github.com/ZeitOnline/vivi/assets/20401272/4e44c741-2396-4744-85c7-1b2b6c90505a">
content.audio.browser` oder nach `zeit.simplecast`

