### PR TITLE
ZO-3718: Audio container

### DIFF
--- a/core/docs/changelog/ZO-3718.change
+++ b/core/docs/changelog/ZO-3718.change
@@ -1,0 +1,1 @@
+ZO-3718: Save podcast episodes in new folder

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -34,7 +34,7 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
 
 
 def audio_container(create=False):
-    container_id = 'audio'
+    container_id = 'podcast-audio'
     repository = zope.component.getUtility(
         zeit.cms.repository.interfaces.IRepository)
     if container_id in repository:

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -1,3 +1,4 @@
+import zope.component
 import zeit.content.audio.audio
 import zeit.content.audio.testing
 
@@ -12,3 +13,10 @@ class TestAudio(zeit.content.audio.testing.FunctionalTestCase):
         self.assertEqual(audio.title, 'foo')
         self.assertEqual(audio.url, 'https://foo.bah/1234/episode-mp3')
         self.assertEqual(audio.episodeId, '12-34')
+
+    def test_audio_is_saved_in_container(self):
+        repository = zope.component.getUtility(
+            zeit.cms.repository.interfaces.IRepository)
+        self.assertNotIn('podcast-audio', repository.keys())
+        zeit.content.audio.audio.audio_container(create=True)
+        self.assertIn('podcast-audio', repository.keys())


### PR DESCRIPTION
Both `audios` and `audio` already exist as references to premium audio, therefore we require a new place to store podcast episodes.