### PR TITLE
ZO-3708: vivi validation for social fields in article should prevent checkin

### DIFF
--- a/core/docs/changelog/ZO-3708.change
+++ b/core/docs/changelog/ZO-3708.change
@@ -1,0 +1,1 @@
+ZO-3708: add social push messages to article validation

--- a/core/docs/changelog/error_message.fix
+++ b/core/docs/changelog/error_message.fix
@@ -1,0 +1,4 @@
+Improve layout for error messages
+
+- now the box and the arrow below point directly at the widget
+- when more than one message appears, the message no longer shifts

--- a/core/src/zeit/campus/browser/social.py
+++ b/core/src/zeit/campus/browser/social.py
@@ -29,8 +29,3 @@ class SocialBase(zeit.push.browser.form.SocialBase):
             form_fields +
             self.FormFieldsFactory(zeit.push.interfaces.IAccountData).select(
                 *self.campus_fields))
-
-    def setUpWidgets(self, *args, **kw):
-        super().setUpWidgets(*args, **kw)
-        if self.request.form.get('%s.facebook_campus_enabled' % self.prefix):
-            self._set_widget_required('facebook_campus_text')

--- a/core/src/zeit/content/article/edit/body.py
+++ b/core/src/zeit/content/article/edit/body.py
@@ -192,6 +192,7 @@ def validate_article(context, event):
     interfaces = [
         zeit.content.article.interfaces.IArticle,
         zeit.content.image.interfaces.IImages,
+        zeit.push.interfaces.IAccountData,
     ]
     for iface in interfaces:
         err = zope.schema.getValidationErrors(iface, iface(context)) or []

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -909,6 +909,11 @@
   top: 95px;
 }
 
+.type-article .fieldtype-text.error div.empty {
+  position: inherit;
+  left: auto;
+}
+
 .type-article #edit-form-filename fieldset.table .fieldname-rename_to.error .label span.error {
   margin-top: 23px;
 }
@@ -941,6 +946,10 @@
   clear: left;
   float: left;
   margin-right: 0.5em;
+}
+
+.type-article dl.errors dd {
+  margin-top: auto;
 }
 
 
@@ -1783,6 +1792,15 @@
 
 
 /* social media */
+.type-article #form-social {
+  display: flex;
+  flex-flow: column;
+}
+
+.type-article #form-mobile {
+  display: flex;
+  flex-flow: column;
+}
 
 .type-article #form-social .field.fieldname-facebook_main_text .label,
 .type-article #form-social .field.fieldname-facebook_magazin_text .label,
@@ -1793,13 +1811,7 @@
 .type-article #form-social .field.fieldname-twitter_print_text .label,
 .type-article #form-mobile .field.fieldname-mobile_text .label,
 .type-article #form-mobile .field.fieldname-mobile_image .label {
-   display: none;
-}
-
-.type-article #form-mobile .field.fieldname-mobile_payload_template .label,
-.type-article #form-mobile .field.fieldname-mobile_title .label {
-  /* Counteract float left */
-  clear: both;
+  display: none;
 }
 
 .type-article #social\.short_text,
@@ -1844,19 +1856,25 @@
 
 /* XXX We should use <fieldset>, but we'd have to combine the templates of
    zeit.edit.browser.form.InlineForm and gocept.form.grouped which is hard */
+.type-article #form-social .field.fieldname-facebook_main_text,
+.type-article #form-social .field.fieldname-facebook_magazin_text,
+.type-article #form-social .field.fieldname-facebook_campus_text,
+.type-article #form-social .field.fieldname-facebook_zett_text,
 .type-article #form-social .field.fieldname-short_text,
 .type-article #form-social .field.fieldname-twitter_ressort_text,
 .type-article #form-social .field.fieldname-twitter_print_text {
     border-top: 1px solid #d5dee7;
     clear: both;
     display: flow-root;
-    margin-top: 1em;
     margin-bottom: 0;
-    padding-top: 1em;
+    padding-top: 0.5em;
     padding-bottom: 0;
 }
 
-.type-article #form-social .field.fieldname-facebook_main_text:before ,
+.type-article #form-social .field.fieldname-facebook_main_text:before,
+.type-article #form-social .field.fieldname-facebook_magazin_text:before,
+.type-article #form-social .field.fieldname-facebook_campus_text:before,
+.type-article #form-social .field.fieldname-facebook_zett_text:before,
 .type-article #form-social .field.fieldname-short_text:before ,
 .type-article #form-social .field.fieldname-twitter_ressort_text:before ,
 .type-article #form-social .field.fieldname-twitter_print_text:before {
@@ -1866,6 +1884,7 @@
 }
 
 .type-article #form-social .field.fieldname-facebook_main_enabled,
+.type-article #form-social .field.fieldname-facebook_zett_enabled,
 .type-article #form-social .field.fieldname-twitter_main_enabled {
     clear: both;
     display: flow-root;
@@ -1873,6 +1892,9 @@
 
 .type-article #form-social .field.fieldname-facebook_main_text:before {
     content: "Facebook";
+}
+.type-article #form-social .field.fieldname-facebook_zett_text:before {
+  content: "Facebook ze.tt";
 }
 .type-article #form-social .field.fieldname-short_text:before {
     content: "Twitter";

--- a/core/src/zeit/magazin/browser/social.py
+++ b/core/src/zeit/magazin/browser/social.py
@@ -27,8 +27,3 @@ class SocialBase(zeit.push.browser.form.SocialBase):
             super().social_form_fields +
             self.FormFieldsFactory(zeit.push.interfaces.IAccountData).select(
                 *self.magazin_fields))
-
-    def setUpWidgets(self, *args, **kw):
-        super().setUpWidgets(*args, **kw)
-        if self.request.form.get('%s.facebook_magazin_enabled' % self.prefix):
-            self._set_widget_required('facebook_magazin_text')

--- a/core/src/zeit/push/browser/resources/push.css
+++ b/core/src/zeit/push/browser/resources/push.css
@@ -2,6 +2,7 @@
 .field.fieldname-twitter_ressort_enabled,
 .field.fieldname-twitter_print_enabled,
 .field.fieldname-facebook_main_enabled,
+.field.fieldname-facebook_zett_enabled,
 .field.fieldname-facebook_magazin_enabled {
     float: left;
 }

--- a/core/src/zeit/push/facebook.py
+++ b/core/src/zeit/push/facebook.py
@@ -37,11 +37,7 @@ class Message(zeit.push.message.Message):
 
     @property
     def text(self):
-        text = self.config.get('override_text')
-        if not text:  # BBB
-            self.get_text_from = 'long_text'
-            text = super().text
-        return text
+        return self.config.get('override_text')
 
     @property
     def url(self):

--- a/core/src/zeit/push/interfaces.py
+++ b/core/src/zeit/push/interfaces.py
@@ -309,52 +309,84 @@ class PayloadTemplateSource(zeit.cms.content.sources.FolderItemSource):
 PAYLOAD_TEMPLATE_SOURCE = PayloadTemplateSource()
 
 
+class ToggleDependentText(zope.schema.Text):
+    """Text field value is required if ``dependent_field`` has value."""
+
+    #: Name of field that controls whether this field is required
+    dependent_field = None
+
+    def __init__(self, dependent_field=None, **kw):
+        self.dependent_field = dependent_field
+        super(ToggleDependentText, self).__init__(**kw)
+
+    def validate(self, value):
+        super(ToggleDependentText, self).validate(value)
+        if not value and getattr(self.context, self.dependent_field):
+            raise zope.schema.interfaces.RequiredMissing(self.__name__)
+
+
 class IAccountData(zope.interface.Interface):
     """Convenience access to IPushMessages.message_config entries"""
 
-    facebook_main_enabled = zope.schema.Bool(title=_('Enable Facebook'))
-    facebook_main_text = zope.schema.Text(
-        title=_('Facebook Main Text'), required=False)
+    facebook_main_enabled = zope.schema.Bool(
+        title=_('Enable Facebook'), required=False)
+    facebook_main_text = ToggleDependentText(
+        title=_('Facebook Main Text'),
+        required=False,
+        dependent_field='facebook_main_enabled')
 
     facebook_magazin_enabled = zope.schema.Bool(
-        title=_('Enable Facebook Magazin'))
-    facebook_magazin_text = zope.schema.Text(
-        title=_('Facebook Magazin Text'), required=False)
+        title=_('Enable Facebook Magazin'), required=False)
+    facebook_magazin_text = ToggleDependentText(
+        title=_('Facebook Magazin Text'),
+        required=False,
+        dependent_field='facebook_magazin_enabled')
 
     facebook_campus_enabled = zope.schema.Bool(
-        title=_('Enable Facebook Campus'))
-    facebook_campus_text = zope.schema.Text(
-        title=_('Facebook Campus Text'), required=False)
+        title=_('Enable Facebook Campus'), required=False)
+    facebook_campus_text = ToggleDependentText(
+        title=_('Facebook Campus Text'),
+        required=False,
+        dependent_field='facebook_campus_enabled')
 
     facebook_zett_enabled = zope.schema.Bool(
-        title=_('Enable Facebook ze.tt'))
-    facebook_zett_text = zope.schema.Text(
-        title=_('Facebook ze.tt Text'), required=False)
+        title=_('Enable Facebook ze.tt'), required=False)
+    facebook_zett_text = ToggleDependentText(
+        title=_('Facebook ze.tt Text'),
+        required=False,
+        dependent_field='facebook_zett_enabled')
 
-    twitter_main_enabled = zope.schema.Bool(title=_('Enable Twitter'))
-    twitter_ressort_text = zope.schema.Text(
+    twitter_main_enabled = zope.schema.Bool(
+        title=_('Enable Twitter'), required=False)
+    twitter_ressort_text = ToggleDependentText(
         title=_('Ressort Tweet'),
         required=False,
-        max_length=256)
+        max_length=256,
+        dependent_field='twitter_ressort_enabled')
     twitter_ressort_enabled = zope.schema.Bool(
-        title=_('Enable Twitter Ressort'))
+        title=_('Enable Twitter Ressort'), required=False)
     twitter_ressort = zope.schema.Choice(
         title=_('Additional Twitter'),
         source=twitterAccountSource,
         required=False)
-    twitter_print_text = zope.schema.Text(
+    twitter_print_text = ToggleDependentText(
         title=_('Print Tweet'),
         required=False,
-        max_length=256)
-    twitter_print_enabled = zope.schema.Bool(title=_('Enable Twitter Print'))
+        max_length=256,
+        dependent_field='twitter_print_enabled')
+    twitter_print_enabled = zope.schema.Bool(
+        title=_('Enable Twitter Print'), required=False)
 
     mobile_title = zope.schema.TextLine(
         title=_('Mobile title'), required=False)
-    mobile_text = zope.schema.Text(
-        title=_('Mobile text'), required=False)
-    mobile_enabled = zope.schema.Bool(title=_('Enable mobile push'))
+    mobile_text = zope.schema.TextLine(
+        title=_('Mobile text'),
+        required=False)
+    mobile_enabled = zope.schema.Bool(
+        title=_('Enable mobile push'), required=False)
 
-    mobile_uses_image = zope.schema.Bool(title=_('Mobile push with image'))
+    mobile_uses_image = zope.schema.Bool(
+        title=_('Mobile push with image'), required=False)
     mobile_image = zope.schema.Choice(
         title=_('Mobile image'),
         description=_("Drag an image group here"),

--- a/core/src/zeit/push/interfaces.py
+++ b/core/src/zeit/push/interfaces.py
@@ -385,10 +385,9 @@ class IAccountData(zope.interface.Interface):
 
     mobile_title = zope.schema.TextLine(
         title=_('Mobile title'), required=False)
-    mobile_text = ToggleDependentText(
+    mobile_text = zope.schema.Text(
         title=_('Mobile text'),
-        required=False,
-        dependent_field='mobile_enabled')
+        required=False)
     mobile_enabled = zope.schema.Bool(
         title=_('Enable mobile push'), required=False)
 

--- a/core/src/zeit/push/tests/test_message.py
+++ b/core/src/zeit/push/tests/test_message.py
@@ -3,6 +3,7 @@ from zeit.cms.workflow.interfaces import IPublish
 import zeit.push.interfaces
 import zeit.push.testing
 import zope.component
+import zope.schema
 
 
 class MessageTest(zeit.push.testing.TestCase):
@@ -103,3 +104,18 @@ class MessageTest(zeit.push.testing.TestCase):
             'type': 'mobile', 'enabled': True, 'override_text': 'mobile',
             'title': 'mobile title', 'uses_image': False, 'variant': 'manual',
             'payload_template': 'eilmeldung.json'},), push.message_config)
+
+    def test_accountdata_validation_raises_error(self):
+        content = self.create_content('mytext')
+        data = zeit.push.interfaces.IAccountData(content)
+        data.facebook_main_enabled = True
+        errors = zope.schema.getSchemaValidationErrors(
+            zeit.push.interfaces.IAccountData, data)
+        assert errors == [
+            ('facebook_main_text',
+             zope.schema.interfaces.RequiredMissing('facebook_main_text'))]
+
+        data.facebook_main_enabled = False
+        errors = zope.schema.getSchemaValidationErrors(
+            zeit.push.interfaces.IAccountData, data)
+        assert not errors

--- a/core/src/zeit/zett/browser/social.py
+++ b/core/src/zeit/zett/browser/social.py
@@ -29,8 +29,3 @@ class SocialBase(zeit.push.browser.form.SocialBase):
             form_fields +
             self.FormFieldsFactory(zeit.push.interfaces.IAccountData).select(
                 *self.zett_fields))
-
-    def setUpWidgets(self, *args, **kw):
-        super().setUpWidgets(*args, **kw)
-        if self.request.form.get('%s.facebook_zett_enabled' % self.prefix):
-            self._set_widget_required('facebook_zett_text')


### PR DESCRIPTION
- [ ] 📰  Review Slides (waiting for my redirection.io access to create the slides for the next review 🤷 )
- [x] 📝  Tests
- [x] 🧹  Cleanup commits
- [ ] 📖 ~~Documentation~~

# An error is displayed and checkin disabled If posting is enabled but message is missing:

![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/6fd2e22b-f2b7-47be-9544-3cc5d8fe14a6)

# Layout improvements

## Before
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/e7d58e6d-f5b7-416e-824e-39992367db20)

![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/ea92b2dd-535e-486d-8f16-62578b368b16)

## After
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/1adf6e1e-660c-43e0-a8d7-3df28d510a11)



![](https://media.giphy.com/media/yYSSBtDgbbRzq/giphy-downsized.gif)