### PR TITLE
ZO-3775: Correct podcasts folder

### DIFF
--- a/core/docs/changelog/ZO-3578.change
+++ b/core/docs/changelog/ZO-3578.change
@@ -1,0 +1,1 @@
+ZO-3578: Simplecast audios are automatically saved in the correct folder

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -30,20 +30,6 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
         self.url = info['audio_file_url']
 
 
-def audio_container(create=False):
-    container_id = 'podcast-audio'
-    repository = zope.component.getUtility(
-        zeit.cms.repository.interfaces.IRepository)
-    if container_id in repository:
-        log.info('Container %s found', container_id)
-        return repository[container_id]
-    if create:
-        log.info('Container %s created', container_id)
-        repository[container_id] = zeit.cms.repository.folder.Folder()
-        return repository[container_id]
-    return None
-
-
 def add_audio(container, info):
     log.info('Add audio %s', info['id'])
     audio = Audio()

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -13,6 +13,8 @@ import zeit.content.audio.interfaces
 
 log = logging.getLogger(__name__)
 
+AUDIO_SCHEMA_NS = 'http://namespaces.zeit.de/CMS/audio'
+
 
 @zope.interface.implementer(
     zeit.content.audio.interfaces.IAudio,
@@ -22,7 +24,7 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
 
     zeit.cms.content.dav.mapProperties(
         zeit.content.audio.interfaces.IAudio,
-        'http://namespaces.zeit.de/CMS/audio',
+        AUDIO_SCHEMA_NS,
         ('title', 'episode_id', 'url'))
 
     def update(self, info):

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -1,4 +1,3 @@
-import zope.component
 import zeit.content.audio.audio
 import zeit.content.audio.testing
 
@@ -13,10 +12,3 @@ class TestAudio(zeit.content.audio.testing.FunctionalTestCase):
         self.assertEqual(audio.title, 'foo')
         self.assertEqual(audio.url, 'https://foo.bah/1234/episode-mp3')
         self.assertEqual(audio.episode_id, '12-34')
-
-    def test_audio_is_saved_in_container(self):
-        repository = zope.component.getUtility(
-            zeit.cms.repository.interfaces.IRepository)
-        self.assertNotIn('podcast-audio', repository.keys())
-        zeit.content.audio.audio.audio_container(create=True)
-        self.assertIn('podcast-audio', repository.keys())

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -1,7 +1,9 @@
 import logging
-import requests
 import grokcore.component as grok
+import requests
 import zope.app.appsetup.product
+
+import zeit.cms.repository.interfaces
 import zeit.simplecast.interfaces
 
 log = logging.getLogger(__name__)
@@ -41,3 +43,17 @@ class Simplecast(grok.GlobalUtility):
 
     def fetch_episode(self, episode_id):
         return self._request('GET', f'episodes/{episode_id}').json()
+
+    def folder(self, episode_create_at):
+        """Podcast should end up in this folder by default"""
+        repository = zope.component.getUtility(
+            zeit.cms.repository.interfaces.IRepository)
+        podcasts = 'podcasts'
+        # Select year and month from string instead of parsing YYYY-MM with
+        # pendulum and converting it back to the correct format
+        yyyy_mm = episode_create_at[0:7]
+        if podcasts not in repository:
+            repository[podcasts] = zeit.cms.repository.folder.Folder()
+        if yyyy_mm not in repository[podcasts]:
+            repository[podcasts][yyyy_mm] = zeit.cms.repository.folder.Folder()
+        return repository[podcasts][yyyy_mm]

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -18,17 +18,6 @@ class Simplecast(grok.GlobalUtility):
         self.api_url = config['simplecast-url']
         self.api_token = f"Bearer {config['simplecast-token']}"
 
-    def get_episode(self, episode_id):
-        response = self._request('GET', f'episodes/{episode_id}')
-        try:
-            title = response.json()['title']
-            url = response.json()['audio_file_url']
-            duration = response.json()['duration']
-            return url, duration, title
-        except KeyError:
-            log.error('Episode information is not available.')
-            raise
-
     def _request(self, verb, path):
         url = f'{self.api_url}{path}'
         headers = {'Authorization': self.api_token}

--- a/core/src/zeit/simplecast/interfaces.py
+++ b/core/src/zeit/simplecast/interfaces.py
@@ -3,7 +3,5 @@ import zope.interface
 
 class ISimplecast(zope.interface.Interface):
 
-    def get_episode(episode_id):
-        """
-        Request information about the episode from the simplecast API
-        """
+    def fetch_episode(self, episode_id):
+        """Request epiosde data from simplecast, return json body"""

--- a/core/src/zeit/simplecast/json/webhook.py
+++ b/core/src/zeit/simplecast/json/webhook.py
@@ -40,13 +40,13 @@ class Notification:
         if body.get('event') == 'episode_created':
             log.info('Create episode from simplecast request.')
             info = simplecast.fetch_episode(body.get('episode_id'))
-            container = zeit.content.audio.audio.audio_container(create=True)
+            container = simplecast.folder(info['created_at'])
             zeit.content.audio.audio.add_audio(container, info)
 
         elif body.get('event') == 'episode_updated':
             log.info('Update episode from simplecast request.')
             info = simplecast.fetch_episode(body.get('episode_id'))
-            container = zeit.content.audio.audio.audio_container()
+            container = simplecast.folder(info['created_at'])
             if container is not None:
                 with zeit.cms.checkout.helper.checked_out(
                         container[body.get('episode_id')]) as episode:
@@ -54,7 +54,7 @@ class Notification:
 
         elif body.get('event') == 'episode_deleted':
             log.info('Delete episode from simplecast request.')
-            container = zeit.content.audio.audio.audio_container()
+            container = simplecast.folder(info['created_at'])
             if container is not None:
                 zeit.content.audio.audio.remove_audio(
                     container[body.get('episode_id')])

--- a/core/src/zeit/simplecast/json/webhook.py
+++ b/core/src/zeit/simplecast/json/webhook.py
@@ -50,16 +50,20 @@ class Notification:
                 with zeit.cms.checkout.helper.checked_out(
                         container[body.get('episode_id')]) as episode:
                     episode.update(info)
-                    log.info('Audio %s successfully updated.', episode.uniqueId)
+                    log.info(
+                        'Audio %s successfully updated.', episode.uniqueId)
 
         elif body.get('event') == 'episode_deleted':
             log.info('Delete episode from simplecast request.')
-            container = simplecast.folder(info['created_at'])
-            if container is not None:
-                uniqueId = container[body.get('episode_id')].uniqueId
-                zeit.content.audio.audio.remove_audio(
-                    container[body.get('episode_id')])
+            audio = simplecast.find_existing_episode(body.get('episode_id'))
+            if audio:
+                uniqueId = audio.uniqueId
+                zeit.content.audio.audio.remove_audio(audio)
                 log.info('Audio %s successfully deleted.', uniqueId)
+            else:
+                log.warning(
+                    'No podcast episode %s found. No episode deleted.',
+                    body.get('episode_id'))
 
         else:
             log.info('No episode processed.')

--- a/core/src/zeit/simplecast/testing.py
+++ b/core/src/zeit/simplecast/testing.py
@@ -17,12 +17,32 @@ ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 
+EPISODE_INFO = {
+    "title": "Episode 42",
+    "id": "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac",
+    "audio_file_url": (
+        "https://injector.simplecastaudio.com/"
+        "04b0bba3-e114-4d7a-bf27-c398dcff13fd/episodes/"
+        "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac/audio/128/default.mp3"
+        "?awCollectionId=04b0bba3-e114-4d7a-bf27-c398dcff13fd"
+        "&awEpisodeId=b44b1838-4ff4-4c29-ba1c-9c4f4b863eac"),
+    "ad_free_audio_file_url": (
+        "https://cdn.simplecast.com/audio/"
+        "04b0bba3-e114-4d7a-bf27-c398dcff13fd/episodes/"
+        "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac/audio/"
+        "2123a65c-e415-4640-b1f1-108d3029a856/default_tc.mp3"),
+    "duration": 663,
+    "created_at": "2023-08-31T13:51:00-01:00"
+}
+
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
 
     layer = ZOPE_LAYER
+    episode_info = EPISODE_INFO
 
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
     layer = WSGI_LAYER
+    episode_info = EPISODE_INFO

--- a/core/src/zeit/simplecast/testing.py
+++ b/core/src/zeit/simplecast/testing.py
@@ -5,6 +5,7 @@ product_config = """\
 <product-config zeit.simplecast>
   simplecast-url https://testapi.simplecast.com/
   simplecast-token TkQvZUd2MHRnR0UybFhsgTfs
+  podcast-folder podcasts
 </product-config>
 """
 

--- a/core/src/zeit/simplecast/testing.py
+++ b/core/src/zeit/simplecast/testing.py
@@ -41,8 +41,16 @@ class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
     layer = ZOPE_LAYER
     episode_info = EPISODE_INFO
 
+    def setUp(self):
+        super().setUp()
+        self.repository.connector.search_result = []
+
 
 class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
     layer = WSGI_LAYER
     episode_info = EPISODE_INFO
+
+    def setUp(self):
+        super().setUp()
+        self.repository.connector.search_result = []

--- a/core/src/zeit/simplecast/tests/test_connection.py
+++ b/core/src/zeit/simplecast/tests/test_connection.py
@@ -17,34 +17,17 @@ JSON = {
 
 class TestSimplecastAPI(zeit.simplecast.testing.FunctionalTestCase):
 
-    def test_audio_has_url(self):
+    def test_simplecast_yields_episode_info(self):
         m_simple = requests_mock.Mocker()
-        episode_id = '1234'
+        episode_id = "1234"
         m_simple.get(
-            f'https://testapi.simplecast.com/episodes/{episode_id}', json=JSON)
+            f"https://testapi.simplecast.com/episodes/{episode_id}",
+            json=JSON)
         simplecast = zope.component.getUtility(
             zeit.simplecast.interfaces.ISimplecast)
         with m_simple:
-            (url, duration, title) = simplecast.get_episode(episode_id)
-            assert url == (
-                'https://injector.simplecastaudio.com/5678/episodes/'
-                '1234/audio/128/default.mp3?awCollectionId=5678'
-                '&awEpisodeId=1234')
-            assert duration == 666
-
-    def test_episode_not_found_breaks(self):
-        m_simple = requests_mock.Mocker()
-        episode_id = '1234'
-        m_simple.get(
-            f'https://testapi.simplecast.com/episodes/{episode_id}',
-            json={},
-            status_code=404)
-        simplecast = zope.component.getUtility(
-            zeit.simplecast.interfaces.ISimplecast)
-
-        with m_simple:
-            with self.assertRaises(KeyError):
-                simplecast.get_episode(episode_id)
+            result = simplecast.fetch_episode(episode_id)
+            self.assertEqual(result, JSON)
 
     def test_simplecast_gets_podcast_folder(self):
         simplecast = zope.component.getUtility(

--- a/core/src/zeit/simplecast/tests/test_connection.py
+++ b/core/src/zeit/simplecast/tests/test_connection.py
@@ -10,6 +10,7 @@ JSON = {
         "https://injector.simplecastaudio.com/5678/episodes/1234/audio"
         "/128/default.mp3?awCollectionId=5678&awEpisodeId=1234"),
     "ad_free_audio_file_url": None,
+    "created_at": "2023-08-31T13:51:00-01:00",
     "duration": 666,
 }
 
@@ -44,3 +45,9 @@ class TestSimplecastAPI(zeit.simplecast.testing.FunctionalTestCase):
         with m_simple:
             with self.assertRaises(KeyError):
                 simplecast.get_episode(episode_id)
+
+    def test_simplecast_gets_podcast_folder(self):
+        simplecast = zope.component.getUtility(
+            zeit.simplecast.interfaces.ISimplecast)
+        container = simplecast.folder(JSON["created_at"])
+        self.assertEqual(container, self.repository['podcasts']['2023-08'])

--- a/core/src/zeit/simplecast/tests/test_connection.py
+++ b/core/src/zeit/simplecast/tests/test_connection.py
@@ -33,4 +33,4 @@ class TestSimplecastAPI(zeit.simplecast.testing.FunctionalTestCase):
         simplecast = zope.component.getUtility(
             zeit.simplecast.interfaces.ISimplecast)
         container = simplecast.folder(JSON["created_at"])
-        self.assertEqual(container, self.repository['podcasts']['2023-08'])
+        self.assertEqual(container, self.repository["podcasts"]["2023-08"])

--- a/core/src/zeit/simplecast/tests/test_webhook.py
+++ b/core/src/zeit/simplecast/tests/test_webhook.py
@@ -17,8 +17,12 @@ def episode_create():
     return {
         "sent_at": "2023-08-28 13:32:11.967735Z",
         "data": {
-            "message": "A new episode has been created. The new episode id is: `b44b1838-4ff4-4c29-ba1c-9c4f4b863eac`",
-            "href": "localhost/testapi/episodes/b44b1838-4ff4-4c29-ba1c-9c4f4b863eac",
+            "message": (
+                "A new episode has been created. The new episode id is: "
+                "`b44b1838-4ff4-4c29-ba1c-9c4f4b863eac`"),
+            "href": (
+                "localhost/testapi/episodes/"
+                "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac"),
             "event": "episode_created",
             "episode_id": episode_id()}}
 
@@ -27,8 +31,12 @@ def episode_update():
     return {
         "sent_at": "2023-08-28 13:32:12.553408Z",
         "data": {
-            "message": "An episode has been updated. The episode id is: `b44b1838-4ff4-4c29-ba1c-9c4f4b863eac`",
-            "href": "localhost/testapi/episodes/b44b1838-4ff4-4c29-ba1c-9c4f4b863eac",
+            "message": (
+                "An episode has been updated. The episode id is: "
+                "`b44b1838-4ff4-4c29-ba1c-9c4f4b863eac`"),
+            "href": (
+                "localhost/testapi/episodes/"
+                "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac"),
             "event": "episode_updated",
             "episode_id": episode_id()}}
 
@@ -111,6 +119,10 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
             zeit.simplecast.interfaces.ISimplecast)
         container = simplecast.folder(self.episode_info['created_at'])
         zeit.content.audio.audio.add_audio(container, self.episode_info)
+
+        self.repository.connector.search_result = [(
+            'http://xml.zeit.de/podcasts/2023-08/'
+            'b44b1838-4ff4-4c29-ba1c-9c4f4b863eac')]
 
         browser = self.browser
         browser.post('http://localhost/@@simplecast_webhook',

--- a/core/src/zeit/simplecast/tests/test_webhook.py
+++ b/core/src/zeit/simplecast/tests/test_webhook.py
@@ -44,26 +44,6 @@ def episode_url():
     return f'https://testapi.simplecast.com/episodes/{episode_id()}'
 
 
-def episode_info():
-    return {
-        "title": "Episode 42",
-        "id": "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac",
-        "audio_file_url": (
-            "https://injector.simplecastaudio.com/"
-            "04b0bba3-e114-4d7a-bf27-c398dcff13fd/episodes/"
-            "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac/audio/128/default.mp3"
-            "?awCollectionId=04b0bba3-e114-4d7a-bf27-c398dcff13fd"
-            "&awEpisodeId=b44b1838-4ff4-4c29-ba1c-9c4f4b863eac"),
-        "ad_free_audio_file_url": (
-            "https://cdn.simplecast.com/audio/"
-            "04b0bba3-e114-4d7a-bf27-c398dcff13fd/episodes/"
-            "b44b1838-4ff4-4c29-ba1c-9c4f4b863eac/audio/"
-            "2123a65c-e415-4640-b1f1-108d3029a856/default_tc.mp3"),
-        "duration": 663,
-        "created_at": "2023-08-31T13:51:00-01:00",
-    }
-
-
 class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
     def test_webhook_environment(self):
         notification = zeit.simplecast.json.webhook.Notification()
@@ -77,7 +57,7 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
         self.caplog.clear()
 
         mocker = requests_mock.Mocker()
-        mocker.get(episode_url(), json=episode_info())
+        mocker.get(episode_url(), json=self.episode_info)
 
         with mocker:
             browser = self.browser
@@ -89,7 +69,7 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
 
     def test_create_episode(self):
         mocker = requests_mock.Mocker()
-        mocker.get(episode_url(), json=episode_info())
+        mocker.get(episode_url(), json=self.episode_info)
 
         with mocker:
             browser = self.browser
@@ -99,19 +79,19 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
 
         simplecast = zope.component.getUtility(
             zeit.simplecast.interfaces.ISimplecast)
-        container = simplecast.folder(episode_info()['created_at'])
+        container = simplecast.folder(self.episode_info['created_at'])
         episode = container[episode_id()]
         self.assertEqual(episode.title, 'Episode 42')
         self.assertEqual(episode.episode_id, episode_id())
-        self.assertEqual(episode.url, episode_info()['audio_file_url'])
+        self.assertEqual(episode.url, self.episode_info['audio_file_url'])
 
     def test_update_episode(self):
         simplecast = zope.component.getUtility(
             zeit.simplecast.interfaces.ISimplecast)
-        container = simplecast.folder(episode_info()['created_at'])
-        zeit.content.audio.audio.add_audio(container, episode_info())
+        container = simplecast.folder(self.episode_info['created_at'])
+        zeit.content.audio.audio.add_audio(container, self.episode_info)
 
-        info = episode_info()
+        info = self.episode_info
         info['title'] = 'New title'
 
         mocker = requests_mock.Mocker()
@@ -129,8 +109,8 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
     def test_delete_episode(self):
         simplecast = zope.component.getUtility(
             zeit.simplecast.interfaces.ISimplecast)
-        container = simplecast.folder(episode_info()['created_at'])
-        zeit.content.audio.audio.add_audio(container, episode_info())
+        container = simplecast.folder(self.episode_info['created_at'])
+        zeit.content.audio.audio.add_audio(container, self.episode_info)
 
         browser = self.browser
         browser.post('http://localhost/@@simplecast_webhook',


### PR DESCRIPTION
Use correct folder to save podcast episodes to storage, via simplecast webhook. 

[x] Tests
[x] Doku
[x] Test instructions

Ich habe angefangen [Doku](https://docs.zeit.de/vivi/implementation/simplecast.html) zu schreiben, aber da ist bestimmt noch viel Luft nach oben.

Testen
-------

Tests laufen lassen 
```
$ bin/test vivi/core/src/zeit/simplecast
$ bin/test vivi/core/src/zeit/content/audio
```

oder manuell den Webhook triggern, wie das geht, steht jetzt in der [Doku](https://github.com/ZeitOnline/vivi-deployment/pull/616). Anschließend prüfen, ob die Episode im richtigen Ordner gelandet ist. 
