### PR TITLE
ZO-3758: Remove `fb` facebook python library, talk directly to the HTTP API

### DIFF
--- a/core/docs/changelog/ZO-3758.change
+++ b/core/docs/changelog/ZO-3758.change
@@ -1,0 +1,1 @@
+ZO-3758: Allow configuring facebook graph api version

--- a/core/setup.py
+++ b/core/setup.py
@@ -25,7 +25,6 @@ setup(
         'collective.monkeypatcher',
         'commentjson',
         'elasticsearch >=7.16.0, <8.0.0',
-        'fb',
         'filetype',
         'gocept.cache >= 2.1',
         # XXX Should move to [ui], but is entrenched

--- a/core/src/zeit/push/interfaces.py
+++ b/core/src/zeit/push/interfaces.py
@@ -262,9 +262,8 @@ class FacebookAccountSource(zeit.cms.content.sources.XMLSource):
                            self.attribute,
                            xml.sax.saxutils.quoteattr(value)))
         if not nodes:
-            return (None, None)
-        node = nodes[0]
-        return node.get('token')
+            return 'invalid'
+        return nodes[0].get('token')
 
 
 facebookAccountSource = FacebookAccountSource()

--- a/core/src/zeit/push/real-webservice.zcml
+++ b/core/src/zeit/push/real-webservice.zcml
@@ -4,7 +4,7 @@
 
   <utility factory=".urbanairship.from_product_config" name="urbanairship" />
   <utility factory=".twitter.from_product_config" name="twitter" />
-  <utility factory=".facebook.Connection" name="facebook" />
+  <utility factory=".facebook.from_product_config" name="facebook" />
   <utility factory=".banner.Push" name="homepage" />
   <utility factory=".grafana.from_product_config" name="grafana" />
 

--- a/core/src/zeit/push/tests/test_facebook.py
+++ b/core/src/zeit/push/tests/test_facebook.py
@@ -8,7 +8,6 @@ import zeit.push.facebook
 import zeit.push.interfaces
 import zeit.push.testing
 import zope.component
-import requests
 
 
 class FacebookTest(zeit.push.testing.TestCase):
@@ -25,10 +24,6 @@ class FacebookTest(zeit.push.testing.TestCase):
         self.api = fb.graph.api(self.access_token)
         # repr keeps all digits  while str would cut them.
         self.nugget = repr(time.time())
-
-        URL = 'https://graph.facebook.com?access_token=' + self.access_token
-        self.current_api_version = float(
-            requests.head(URL).headers['facebook-api-version'][1:])
 
     # Only relevant for the test_send_posts_status test
     def tearDown(self):


### PR DESCRIPTION
Konfiguration in ZeitOnline/vivi-deployment@931eeb10, Doku in ZeitOnline/vivi-deployment@402eb206