### PR TITLE
ZO-3708: twitter main account social field validation activated

### DIFF
--- a/core/docs/changelog/ZO-3708.change
+++ b/core/docs/changelog/ZO-3708.change
@@ -1,0 +1,1 @@
+ZO-3708: twitter main account social field validation activated

--- a/core/src/zeit/push/browser/form.py
+++ b/core/src/zeit/push/browser/form.py
@@ -64,6 +64,8 @@ class SocialBase(Base):
         self.set_charlimit('short_text')
         self.set_charlimit('twitter_print_text')
         self.set_charlimit('twitter_ressort_text')
+        if self.request.form.get('%s.twitter_main_enabled' % self.prefix):
+            self._set_widget_required('short_text')
 
 
 class MobileBase(Base):


### PR DESCRIPTION
it is a bit special, because it is a mixture of IPushMessages and the Checkbox from IAccountData.

Therefore we cannot work with our new ToggleDependentText field easily