### PR TITLE
ZO-3438: ensure id for opentelemetry has type str

### DIFF
--- a/core/docs/changelog/ZO-3438.fix
+++ b/core/docs/changelog/ZO-3438.fix
@@ -1,0 +1,1 @@
+ZO-3438: correct id type for opentelemetry span to avoid errormessages in logs

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -204,7 +204,7 @@ class Connector:
                 data.seek(0)
                 with zeit.cms.tracing.use_span(
                         __name__ + '.tracing', 'gcs', attributes={
-                        'db.operation': 'upload', 'id': id,
+                        'db.operation': 'upload', 'id': props.id,
                         'size': str(size)}):
                     blob.upload_from_file(data, size=size, retry=DEFAULT_RETRY)
             else:
@@ -237,7 +237,7 @@ class Connector:
             blob = self.bucket.blob(props.id)
             with zeit.cms.tracing.use_span(
                     __name__ + '.tracing', 'gcs', attributes={
-                    'db.operation': 'delete', 'id': id}):
+                    'db.operation': 'delete', 'id': props.id}):
                 try:
                     blob.delete()
                 except google.api_core.exceptions.NotFound:


### PR DESCRIPTION
It is a UUID but I think it's enough. Opentelemetry expects a str (or other simple types)