### PR TITLE
ZO-3770: added new properties to audio interface

### DIFF
--- a/core/docs/changelog/ZO-3770.change
+++ b/core/docs/changelog/ZO-3770.change
@@ -1,0 +1,1 @@
+ZO-3770: added new properties to audio interface

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -25,7 +25,7 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
     zeit.cms.content.dav.mapProperties(
         zeit.content.audio.interfaces.IAudio,
         AUDIO_SCHEMA_NS,
-        ('title', 'serie', 'image', 'episode_id', 'url'))
+        ('title', 'serie', 'image', 'episode_id', 'url', 'duration'))
 
     def update(self, info):
         self.title = info['title']

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -25,7 +25,7 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
     zeit.cms.content.dav.mapProperties(
         zeit.content.audio.interfaces.IAudio,
         AUDIO_SCHEMA_NS,
-        ('title', 'episode_id', 'url'))
+        ('title', 'serie', 'image', 'episode_id', 'url'))
 
     def update(self, info):
         self.title = info['title']

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -10,7 +10,7 @@ class Base:
 
     form_fields = zope.formlib.form.FormFields(
         zeit.content.audio.interfaces.IAudio).select(
-            'title', 'episode_id', 'url')
+            'title', 'serie', 'episode_id', 'url', 'image', 'duration')
 
     field_groups = (
         gocept.form.grouped.RemainingFields(

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -7,6 +7,8 @@ import zeit.cms.content.contentsource
 
 class IAudio(zeit.cms.content.interfaces.IXMLContent):
     title = zope.schema.TextLine(title=_("Title"), required=False)
+    serie = zope.schema.TextLine(title=_("Serie"), required=False)
+    image = zope.schema.URI(title=_('Remote image URL'), required=False)
     episode_id = zope.schema.TextLine(title=_("Episode Id"))
     url = zope.schema.URI(title=_("Url"), required=False)
 

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -11,6 +11,7 @@ class IAudio(zeit.cms.content.interfaces.IXMLContent):
     image = zope.schema.URI(title=_('Remote image URL'), required=False)
     episode_id = zope.schema.TextLine(title=_("Episode Id"))
     url = zope.schema.URI(title=_("Url"), required=False)
+    duration = zope.schema.Int(title=_("Duration"), required=False)
 
 
 class AudioSource(zeit.cms.content.contentsource.CMSContentSource):

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -9,6 +9,12 @@ class TestAudio(zeit.content.audio.testing.FunctionalTestCase):
         audio.title = 'foo'
         audio.url = 'https://foo.bah/1234/episode-mp3'
         audio.episode_id = '12-34'
+        audio.serie = 'was gibts'
+        audio.duration = 123
+        audio.image = 'https://test-ing.com/test-image'
         self.assertEqual(audio.title, 'foo')
         self.assertEqual(audio.url, 'https://foo.bah/1234/episode-mp3')
         self.assertEqual(audio.episode_id, '12-34')
+        self.assertEqual(audio.duration, 123)
+        self.assertEqual(audio.image, 'https://test-ing.com/test-image')
+        self.assertEqual(audio.serie, 'was gibts')


### PR DESCRIPTION
Preparing migration in zeit.web, the audio interface should be used in templates and therefore we add the missing properties used inside the templates to replace the Podcast object dependency

![](https://media.giphy.com/media/ATxVdsdpJ609i/giphy.gif)