### PR TITLE
ZO-3814: layout fix for topiclinks

### DIFF
--- a/core/docs/changelog/ZO-3814.fix
+++ b/core/docs/changelog/ZO-3814.fix
@@ -1,0 +1,1 @@
+ZO-3814: layout fix for topiclinks

--- a/core/src/zeit/content/cp/browser/resources/editor.css
+++ b/core/src/zeit/content/cp/browser/resources/editor.css
@@ -23,8 +23,8 @@
 .edit-common-box .fieldname-topiclink_label_5,
 .edit-common-box .fieldname-topiclink_url_1,
 .edit-common-box .fieldname-topiclink_url_2,
-.edit-common-box .fieldname-topiclink_url_3
-.edit-common-box .fieldname-topiclink_url_4
+.edit-common-box .fieldname-topiclink_url_3,
+.edit-common-box .fieldname-topiclink_url_4,
 .edit-common-box .fieldname-topiclink_url_5 {
     float: none;
     margin-right: 0px;


### PR DESCRIPTION
# Vorher

![previously](https://github.com/ZeitOnline/vivi/assets/121817095/c6431d13-f13f-48f1-933c-1884378e931a)

# Nachher

![](![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/a054dc14-a9d8-4793-8410-eb6d18ba593c))