### PR TITLE
ZO-3771: Subscriptions

### DIFF
--- a/core/docs/changelog/ZO-3771.change
+++ b/core/docs/changelog/ZO-3771.change
@@ -1,0 +1,1 @@
+ZO-3771: Add distribution channels to audio object for spotify, google etc.

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -24,8 +24,14 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
 
     zeit.cms.content.dav.mapProperties(
         zeit.content.audio.interfaces.IAudio,
-        AUDIO_SCHEMA_NS,
-        ('title', 'serie', 'image', 'episode_id', 'url', 'duration'))
+        AUDIO_SCHEMA_NS, (
+            'title',
+            'serie',
+            'image',
+            'episode_id',
+            'url',
+            'duration',
+            'distribution_channels'))
 
     def update(self, info):
         self.title = info['title']

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -10,7 +10,8 @@ class Base:
 
     form_fields = zope.formlib.form.FormFields(
         zeit.content.audio.interfaces.IAudio).select(
-            'title', 'serie', 'episode_id', 'url', 'image', 'duration')
+            'title', 'serie', 'episode_id', 'url', 'image', 'duration').omit(
+            'distribution_channels')
 
     field_groups = (
         gocept.form.grouped.RemainingFields(

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -12,6 +12,11 @@ class IAudio(zeit.cms.content.interfaces.IXMLContent):
     episode_id = zope.schema.TextLine(title=_("Episode Id"))
     url = zope.schema.URI(title=_("Url"), required=False)
     duration = zope.schema.Int(title=_("Duration"), required=False)
+    distribution_channels = zope.schema.Dict(
+        title="Distribution channels",
+        required=False,
+        key_type=zope.schema.TextLine(),
+        value_type=zope.schema.TextLine())
 
 
 class AudioSource(zeit.cms.content.contentsource.CMSContentSource):

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -12,9 +12,11 @@ class TestAudio(zeit.content.audio.testing.FunctionalTestCase):
         audio.serie = 'was gibts'
         audio.duration = 123
         audio.image = 'https://test-ing.com/test-image'
+        audio.distribution_channels = {'foo': 'bah'}
         self.assertEqual(audio.title, 'foo')
         self.assertEqual(audio.url, 'https://foo.bah/1234/episode-mp3')
         self.assertEqual(audio.episode_id, '12-34')
         self.assertEqual(audio.duration, 123)
         self.assertEqual(audio.image, 'https://test-ing.com/test-image')
         self.assertEqual(audio.serie, 'was gibts')
+        self.assertEqual(audio.distribution_channels['foo'], 'bah')


### PR DESCRIPTION
Audio object gets new empty dictionary for distribution channels of podcasts such as spotify, google, ios and so on. Its not visible in the ui and not yet set via the simplecast api call. We require the property for use in zeit.web

This is a preliminary fix in order to finish the implementation  in zeit.web. 