### PR TITLE
ZO-3821: Audio objects provide ICommonMetadata, so they are indexed in TMS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "python.formatting.provider": "none"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/core/docs/changelog/ZO-3821.change
+++ b/core/docs/changelog/ZO-3821.change
@@ -1,0 +1,1 @@
+ZO-3821: Audio objects provide ICommonMetadata, so they are indexed in TMS

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -9,6 +9,7 @@ import zope.interface
 
 import zeit.cms.content.dav
 import zeit.cms.content.property
+import zeit.cms.content.interfaces
 import zeit.cms.content.xmlsupport
 import zeit.cms.interfaces
 import zeit.cms.repository.folder
@@ -37,6 +38,10 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
             'duration',
             'audio_type'))
 
+    def __getattr__(self, name):
+        if name in zeit.cms.content.interfaces.ICommonMetadata:
+            return zeit.cms.content.interfaces.ICommonMetadata[name].default
+        raise AttributeError(name)
 
 @zope.interface.implementer(IPodcastEpisodeInfo)
 class PodcastEpisodeInfo(zeit.cms.content.dav.DAVPropertiesAdapter):

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -43,6 +43,7 @@ class Audio(zeit.cms.content.xmlsupport.XMLContentBase):
             return zeit.cms.content.interfaces.ICommonMetadata[name].default
         raise AttributeError(name)
 
+
 @zope.interface.implementer(IPodcastEpisodeInfo)
 class PodcastEpisodeInfo(zeit.cms.content.dav.DAVPropertiesAdapter):
 

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -14,17 +14,20 @@ class Base:
             'title',
             'url',
             'duration',
-            'audio_type')
+            'audio_type') + \
+        zope.formlib.form.FormFields(
+            zeit.content.audio.interfaces.IAudio).select('__name__')
 
-    field_groups = (
-        gocept.form.grouped.Fields(
-            _("Audio"),
-            ('title', 'url', 'duration', 'audio_type',),
-            css_class='wide-widgets column-left'),)
+    audio_fields = gocept.form.grouped.Fields(
+        _("Audio"),
+        ('title', 'url', 'duration', 'audio_type',),
+        css_class='wide-widgets column-left')
+
+    field_groups = (audio_fields,)
 
 
-class PodcastInfo:
-    form_fields = zope.formlib.form.FormFields(
+class PodcastForm:
+    form_fields = Base.form_fields + zope.formlib.form.FormFields(
         zeit.content.audio.interfaces.IPodcastEpisodeInfo).select(
             'podcast',
             'image',
@@ -32,36 +35,33 @@ class PodcastInfo:
             'summary',
             'notes')
 
+    podcast_fields = gocept.form.grouped.Fields(
+        _('Podcast Episode Info'),
+        ('podcast', 'image', 'episode_nr', 'summary', 'notes'),
+        'wide-widgets column-left')
+
     field_groups = (
         gocept.form.grouped.Fields(
-            _('Podcast Episode Info'),
-            ('podcast', 'image', 'episode_nr', 'summary', 'notes'),
-            'wide-widgets column-left'),)
+            _('Navigation'), ('__name__',),
+            css_class='wide-widgets column-right'),
+        Base.audio_fields,
+        podcast_fields
+    )
 
 
-class Add(Base, zeit.cms.browser.form.AddForm):
+class Add(PodcastForm, zeit.cms.browser.form.AddForm):
 
     title = _('Add audio')
     factory = zeit.content.audio.audio.Audio
-    form_fields = Base.form_fields + PodcastInfo.form_fields + \
-        zope.formlib.form.FormFields(
-            zeit.content.audio.interfaces.IAudio).select('__name__')
-
-    field_groups = (
-        (gocept.form.grouped.Fields(
-            _('Navigation'), ('__name__',),
-            css_class='wide-widgets column-right'),)
-        + Base.field_groups + PodcastInfo.field_groups)
 
 
-class Edit(Base, zeit.cms.browser.form.EditForm):
+class Edit(PodcastForm, zeit.cms.browser.form.EditForm):
 
     title = _('Edit audio')
-    form_fields = Base.form_fields.omit('__name__')
+    form_fields = PodcastForm.form_fields.omit('__name__')
 
 
-class Display(Base, zeit.cms.browser.form.DisplayForm):
+class Display(PodcastForm, zeit.cms.browser.form.DisplayForm):
 
     title = _('View audio')
-    form_fields = Base.form_fields.omit('__name__') + PodcastInfo.form_fields
     for_display = True

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -19,7 +19,8 @@ class AudioTypeSource(zeit.cms.content.sources.SimpleFixedValueSource):
     }
 
 
-class IAudio(zeit.cms.content.interfaces.IXMLContent):
+class IAudio(zeit.cms.content.interfaces.ICommonMetadata,
+             zeit.cms.content.interfaces.IXMLContent):
     """
     Basic playable audio containing minimum required information
     for ZEIT audio players.

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -105,7 +105,8 @@ class IPodcastEpisodeInfo(zope.interface.Interface):
     """Additional Audioinformation for podcast episodes."""
     podcast = zope.schema.Choice(
         title=_('Podcast Serie'),
-        source=PodcastSource())
+        source=PodcastSource(),
+        readonly=True)
     # XXX reference image group instead of URL
     image = zope.schema.URI(
         title=_('Remote Image URL'),

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -8,6 +8,7 @@ import zeit.cms.testing
 import zeit.content.audio.interfaces
 import zeit.content.audio.audio
 import zeit.content.audio.testing
+import zope.interface.verify
 
 
 class PodcastSourceTest(zeit.content.audio.testing.FunctionalTestCase):
@@ -25,3 +26,10 @@ class PodcastSourceTest(zeit.content.audio.testing.FunctionalTestCase):
             'cat-jokes-pawdcast', 'Cat Jokes Pawdcast', 'c3161c7d',
             'A podcast of cat jokes', distribution_channels)
         assert values[0] == podcast
+
+    def test_audio_provides_ICommonMetadata(self):
+        audio = zeit.content.audio.audio.Audio()
+        zope.interface.verify.verifyObject(
+            zeit.cms.content.interfaces.ICommonMetadata, audio)
+        # Returns default values for not applicable properties
+        self.assertEqual((), audio.authorships)

--- a/core/src/zeit/content/cp/blocks/automatic.py
+++ b/core/src/zeit/content/cp/blocks/automatic.py
@@ -37,7 +37,6 @@ class AutomaticTeaserBlock(
     def __getattr__(self, name):
         if name in zeit.content.cp.interfaces.ITeaserBlock:
             return zeit.content.cp.interfaces.ITeaserBlock[name].default
-            return zeit.content.cp.interfaces.ITeaserBlock[name].default
         raise AttributeError(name)
 
     @property


### PR DESCRIPTION
While we don't foresee audio objects using _most_ of the ICommonMetadata fields, they will use some (at least title, and later access, probably series), so in sum it's probably more helpful to use the interface than to not use it. (Just one example: This now automatically displays the title in directory listings)

Das gibt bestimmt nen Mergekonflikt mit #509 aber die Änderung hier ist so klein, das rebase ich im Anschluss dann gern.