### PR TITLE
ZO-3933: Podigee_id attribute to podcast.xml

### DIFF
--- a/core/docs/changelog/ZO-3933.change
+++ b/core/docs/changelog/ZO-3933.change
@@ -1,0 +1,1 @@
+ZO-3933: podigee_id attribute to podcast source, ensure parallel operation of podcast hosts

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -48,13 +48,15 @@ class IPodcast(zope.interface.Interface):
 class Podcast(zeit.cms.content.sources.AllowedBase):
 
     def __init__(
-            self, id, title,
-            external_id, subtitle, distribution_channels=None):
+            self, id, title, external_id, subtitle,
+            distribution_channels=None, podigee_id=None):
         super().__init__(id, title, available=None)
         self.external_id = external_id
         self.subtitle = subtitle
         #: mapping of distribution channel (itunes, spotify, etc.) to url
         self.distribution_channels = distribution_channels
+        # For parallel use of podcast hosts
+        self.podigee_id = podigee_id
 
 
 class PodcastSource(zeit.cms.content.sources.ObjectSource,
@@ -89,7 +91,8 @@ class PodcastSource(zeit.cms.content.sources.ObjectSource,
             node.get(self.attribute),
             node.get('title'),
             node.get('external_id'),
-            node.get('subtitle'))
+            node.get('subtitle'),
+            podigee_id=node.get('podigee_id'))
         podcast.distribution_channels = distribution_channels
         return podcast
 

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -58,6 +58,16 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         # For parallel use of podcast hosts
         self.podigee_id = podigee_id
 
+    def __eq__(self, other):
+        return (
+            zope.security.proxy.isinstance(other, self.__class__) and
+            self.id == other.id and
+            self.title == other.title and
+            self.external_id == other.external_id and
+            self.subtitle == other.subtitle and
+            self.distribution_channels == other.distribution_channels and
+            self.podigee_id == other.podigee_id)
+
 
 class PodcastSource(zeit.cms.content.sources.ObjectSource,
                     zeit.cms.content.sources.XMLSource):

--- a/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
+++ b/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <podcasts>
-    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes">
+    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" podigee_id="asdf-1234">
         <distribution_channel id="itunes" href="http://example.com/itunes">Apple Podcasts</distribution_channel>
         <distribution_channel id="google" href="http://example.com/google">Google Podcasts</distribution_channel>
     </podcast>

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -23,7 +23,7 @@ class PodcastSourceTest(zeit.content.audio.testing.FunctionalTestCase):
             'google': 'http://example.com/google'
         }
         podcast = Podcast(
-            'cat-jokes-pawdcast', 'Cat Jokes Pawdcast', 'c3161c7d',
+            'cat-jokes-pawdcast', 'Cat Jokes Pawdcast', '1234',
             'A podcast of cat jokes', distribution_channels, 'asdf-1234')
         assert values[0] == podcast
 

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -24,7 +24,7 @@ class PodcastSourceTest(zeit.content.audio.testing.FunctionalTestCase):
         }
         podcast = Podcast(
             'cat-jokes-pawdcast', 'Cat Jokes Pawdcast', 'c3161c7d',
-            'A podcast of cat jokes', distribution_channels)
+            'A podcast of cat jokes', distribution_channels, 'asdf-1234')
         assert values[0] == podcast
 
     def test_audio_provides_ICommonMetadata(self):


### PR DESCRIPTION
Once added, we can start to write all data to `podcast.xml`