### PR TITLE
MAINT: new pre commit hook to check changelog files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
   - id: flake8
     additional_dependencies:
     - flake8-awesome
+-   repo: https://github.com/ZeitOnline/zeit-git-hooks
+    rev: "1.0.0"
+    hooks:
+    -   id: check-added-changelog
+        args: ["--ignore", ".keep"]


### PR DESCRIPTION
pre-commit erstellt der auf valide Endungen prüft um im Deployment nicht wieder zu scheitern nur weil eine Datei ``.changes`` heißt