### PR TITLE
Minor layout fixes

### DIFF
--- a/core/docs/changelog/layout_landing_zone_size.fix
+++ b/core/docs/changelog/layout_landing_zone_size.fix
@@ -1,0 +1,1 @@
+Increase size for article landing zone

--- a/core/docs/changelog/layout_publish_state.fix
+++ b/core/docs/changelog/layout_publish_state.fix
@@ -1,0 +1,1 @@
+align details heading and publish state vertically

--- a/core/docs/changelog/layout_remove_button.fix
+++ b/core/docs/changelog/layout_remove_button.fix
@@ -1,0 +1,1 @@
+move 'remove'-button for object references to prevent preview and cms button being on top of each other

--- a/core/src/zeit/cms/browser/resources/cms.css
+++ b/core/src/zeit/cms/browser/resources/cms.css
@@ -807,21 +807,22 @@ li.busy {
 }
 
 .publish-state {
-    padding-top:15px;
-    padding-left:20px;
-    background: url("./icons/icons_sprites.png") no-repeat 15px -1581px;
+    background: url("./icons/icons_sprites.png") no-repeat 15px -1582px;
+    height: 25px;
+    width: 25px;
+    background-repeat: no-repeat;
 }
 
 .publish-state.published {
-    background-position: 7px -1581px;
+    background-position: 7px -1582px;
 }
 
 .publish-state.not-published {
-    background-position: 7px -1670px;
+    background-position: 7px -1672px;
 }
 
 .publish-state.published-with-changes {
-    background-position: 7px -1611px;
+    background-position: 7px -1612px;
 }
 
 /* error page */

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -473,7 +473,6 @@ table.properties textarea {
   color: #fff;
   cursor: pointer;
   display: none;
-  font-family: arial,serif;
   font-size: 14px;
   height: 18px;
   margin-right: 16px;
@@ -492,6 +491,9 @@ table.properties textarea {
   margin-top: 0;
 }
 
+.drop-object-widget .object-reference .type-animation~a[rel="remove"],
+.drop-object-widget .object-reference .type-audio~a[rel="remove"],
+.drop-object-widget .object-reference .type-embed~a[rel="remove"],
 .drop-object-widget .object-reference .type-infobox ~ a[rel="remove"],
 .drop-object-widget .object-reference .type-portraitbox ~ a[rel="remove"] {
   margin-top: 5px;

--- a/core/src/zeit/cms/browser/resources/object_details.css
+++ b/core/src/zeit/cms/browser/resources/object_details.css
@@ -55,10 +55,6 @@
     vertical-align: middle;
 }
 
-.object-details-heading span.publish-state {
-    padding-top:5px;
-}
-
 .object-details-heading ul {
     font-family: "Lucida Grande",Verdana,Lucida,Helvetica,Arial,sans-serif;
     font-size: 11px;
@@ -72,7 +68,9 @@
 .object-details-heading ul,
 .object-details-heading div,
 .object-details-heading li {
-    display: inline;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 }
 
 #internallinks\.related li a[rel="remove"],
@@ -100,9 +98,12 @@
 
 .object-details-heading li:before {
     content: "| ";
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
 .object-details-heading li:first-child:before {
+    margin-left: 0px;
     content: "";
 }
 
@@ -121,8 +122,6 @@
 .object-details .supertitle {
   display: block;
   font-weight: 400;
-  margin-bottom: .5em;
-  vertical-align: middle;
 }
 
 .object-details .supertitle .text {
@@ -140,7 +139,6 @@
 .object-details .teaser_title {
   font-size: 1.2em;
   font-weight: 700;
-  margin-bottom: .3em;
 }
 
 .object-details .teaser_text {

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -427,7 +427,12 @@
 }
 
 .type-article .editable-area > .landing-zone {
-  height: 4px;
+  height: 2px;
+  transition: height 0.3s ease-in-out;
+}
+
+.type-article .editable-area>.landing-zone.droppable-active {
+  height: 20px;
 }
 
 .type-article .charcount.charalert {
@@ -1794,7 +1799,6 @@
   color: lightslategray;
   float: left;
   display: block;
-  vertical-align: middle;
   line-height: 1.9rem;
   margin-right: 10px;
 }

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -29,11 +29,6 @@
   color:white
 }
 
-.type-article .object-details-heading span.publish-state {
-  background-position: 15px auto;
-  padding-left:25px;
-}
-
 .type-article .content-icon.type-article img {
   display: none;
 }
@@ -1359,10 +1354,6 @@
 
 .type-article #edit-form-teaser .inline-form .object-details img {
   float: left;
-}
-
-.type-article #edit-form-teaser .inline-form .object-details span.publish-state {
-  padding-top: 15px;
 }
 
 .type-article #edit-form-teaser .inline-form .object-details ul.metadata {

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -1053,32 +1053,17 @@
   vertical-align: middle;
 }
 
-.type-article .module-icon-video,
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.0"] {
+.type-article .module-icon-video {
   background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -654px transparent;
 }
 
-.type-article .module-icon-image,
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.1"] {
+.type-article .module-icon-image{
   background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -835px transparent;
 }
 
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.2"] {
-  background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -896px transparen;t
-}
-
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.3"] {
-  background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -715px transparent;
-}
-
 .type-article .module-icon-audio,
-.type-article .module-icon-podcast,
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.4"] {
+.type-article .module-icon-podcast {
   background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -776px transparent;
-}
-
-.type-article form[action$="asset-badges"] .value label[for="asset-badges\.badges\.5"] {
-  background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -955px transparent;
 }
 
 .type-article .editable-area .module-icon-image {
@@ -1100,25 +1085,6 @@
 
 .type-article .editable-area .module-icon-gallery {
   background: url("/fanstatic/zeit.cms/icons/icons_sprites.png") no-repeat scroll 20px -1800px transparent;
-}
-
-
-.type-article label[for^="asset-badges"] .checkboxType {
-  margin-left:3px;
-}
-
-.type-article #form-asset-badges .field {
-  margin-bottom: 0;
-  margin-top: 0;
-}
-
-.type-article #form-asset-badges .widget {
-  margin-left: -4px;
-  margin-top: 1px;
-}
-
-.type-article #form-asset-badges .value label {
-  padding-top: 0;
 }
 
 /* Decrease distance between two product-management-formas a and b  */

--- a/core/src/zeit/content/cp/browser/resources/editor.css
+++ b/core/src/zeit/content/cp/browser/resources/editor.css
@@ -550,6 +550,7 @@ buttons, we only can get a different label if we override it here. */
 .type-centerpage-2009 .landing-zone.droppable-active {
   background: none;
   border: 1px solid transparent;
+  transition: height 0.3s ease-in-out;
 }
 
 /* XXX Had to copy all rules from zeit.cms:cms.css */


### PR DESCRIPTION
Small layout improvements that been fixed while creating #519 

---
### Remove Button

**Before**
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/0cde6996-616a-42d1-9a6b-39ebee4eda12)

**After**
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/e644eb5b-ae65-4d6e-9b60-2120c63c57af)

---
### Publish state alignment

**Before** 
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/03a6424d-b4c2-403f-a377-6304e50efa7d)
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/d26cd806-ba00-4df5-bf7a-2c44b6ee3daa)

**After** 
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/35f34ecb-82c5-4bd8-9461-6c713bcc0595)
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/496a0e71-bffe-46ed-925a-9934f1850beb)

---
### drop size increase
**Before**
![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/63c6bc06-0dcf-4292-a9c4-21b0a0b6d14c)

**After**
![vivi-drop](https://github.com/ZeitOnline/vivi/assets/121817095/550fcfeb-ca45-47aa-9be3-7486f91abc61)