### PR TITLE
ZO-3846: ensure podcast episode type is always 'podcast'

### DIFF
--- a/core/docs/changelog/ZO-3846.change
+++ b/core/docs/changelog/ZO-3846.change
@@ -1,0 +1,1 @@
+ZO-3846: ensure podcast episode type is always 'podcast'

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -118,6 +118,7 @@ class Simplecast(grok.GlobalUtility):
             return None
 
     def _update_properties(self, episode_data, audio):
+        audio.audio_type = 'podcast'
         for iface, properties in self._properties.items():
             obj = iface(audio)
             for vivi, simplecast in properties.items():
@@ -134,7 +135,6 @@ class Simplecast(grok.GlobalUtility):
         episode_data = self._fetch_episode(episode_id)
         container = self.folder(episode_data['created_at'])
         audio = zeit.content.audio.audio.Audio()
-        audio.audio_type = 'podcast'
         self._update_properties(episode_data, audio)
         container[episode_id] = audio
         log.info('Podcast Episode %s successfully created.', audio.uniqueId)


### PR DESCRIPTION
Better safe than sorry - more or less a workaround for migration period that podcast episodes are always type `podcast`