### PR TITLE
ZO-3997: restrict retract and delete permissions for audio

### DIFF
--- a/core/docs/changelog/ZO-3997.change
+++ b/core/docs/changelog/ZO-3997.change
@@ -1,0 +1,1 @@
+ZO-3997: restrict retract and delete permissions for audio

--- a/core/src/zeit/cms/permissions.zcml
+++ b/core/src/zeit/cms/permissions.zcml
@@ -167,6 +167,16 @@
     />
 
   <permission
+    id="zeit.content.audio.Retract"
+    title="Retract Audio objects"
+    />
+
+  <permission
+    id="zeit.content.audio.Delete"
+    title="Delete Audio objects"
+    />
+
+  <permission
     id="zeit.content.text.AddEmbed"
     title="Add Embed objects"
     />

--- a/core/src/zeit/content/audio/browser/configure.zcml
+++ b/core/src/zeit/content/audio/browser/configure.zcml
@@ -58,4 +58,47 @@
     permission="zope.View"
     />
 
+  <!-- restrict permissions for retract and delete -->
+  <!-- retract -->
+  <browser:viewlet
+    name="Retract"
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    class="zeit.workflow.browser.publish.RetractMenuItem"
+    manager="zeit.cms.browser.interfaces.ISecondaryContextActions"
+    permission="zeit.content.audio.Retract"
+    icon="/@@/zeit.cms/icons/retract_topmenu.png"
+    />
+  <configure package="zeit.workflow.browser">
+  <browser:page
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="retract.html"
+    template="retract.pt"
+    permission="zeit.content.audio.Retract"
+    />
+  </configure>
+  <!-- delete -->
+  <browser:viewlet
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.IRepositoryLayer"
+    name="Delete"
+    manager="zeit.cms.browser.interfaces.ISecondaryContextActions"
+    class="zeit.cms.repository.browser.menu.Delete"
+    permission="zeit.content.audio.Delete"
+    icon="/@@/zeit.cms/icons/delete.png"
+    lightbox="@@delete.html"
+    weight="500"
+    />
+  <configure package="zeit.cms.repository.browser">
+  <browser:page
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.IRepositoryLayer"
+    name="delete.html"
+    class=".delete.DeleteContent"
+    template="delete.pt"
+    permission="zeit.content.audio.Delete"
+    />
+  </configure>
+
 </configure>

--- a/core/src/zeit/content/audio/browser/tests/test_audio.py
+++ b/core/src/zeit/content/audio/browser/tests/test_audio.py
@@ -1,11 +1,13 @@
-from zeit.content.audio.interfaces import Podcast
+from zope.testbrowser.browser import LinkNotFoundError
+
 from zeit.content.audio.audio import Audio, PodcastEpisodeInfo
+from zeit.content.audio.interfaces import Podcast
 import zeit.content.audio.testing
 
 
 class AudioObjectDetails(zeit.content.audio.testing.BrowserTestCase):
 
-    def test_displays_details(self):
+    def create_audio(self):
         audio = Audio()
         audio.title = 'mytitle'
         audio.url = 'http://example.com/cats.mp3'
@@ -16,6 +18,10 @@ class AudioObjectDetails(zeit.content.audio.testing.BrowserTestCase):
         PodcastEpisodeInfo(audio).podcast = podcast
 
         self.repository['audio'] = audio
+        return audio
+
+    def test_displays_details(self):
+        audio = self.create_audio()
         b = self.browser
         b.open('/repository/audio/@@object-details')
         self.assert_ellipsis(
@@ -44,3 +50,10 @@ class AudioObjectDetails(zeit.content.audio.testing.BrowserTestCase):
         assert 'Duration:' not in b.contents, 'Duration should not be displayed without duration set'
         assert 'open-audio object-link' not in b.contents, 'Play should not be displayed without url'
         assert 'Podcast:' not in b.contents, 'Podcast should not be displayed without audio_type set to podcast'
+
+    def test_cannot_delete_if_permissions_missing(self):
+        self.create_audio()
+        b = self.browser
+        b.open('/repository/audio')
+        with self.assertRaises(LinkNotFoundError):
+            assert not b.getLink(url="@@delete.html")


### PR DESCRIPTION
PR für Doku in Deployment und Anpassung der [components/zope/site.zcml](https://github.com/ZeitOnline/vivi-deployment/blob/main/components/zope/site.zcml) folgt.

Mit `<grant>` muss ich dem simplecast Principal dann ja die Rechte geben

- [vivi-deployment/pull/668](https://github.com/ZeitOnline/vivi-deployment/pull/668)