### PR TITLE
ZO-3997: Audio object form without publish or retract actions

### DIFF
--- a/core/docs/changelog/ZO-3997.change
+++ b/core/docs/changelog/ZO-3997.change
@@ -1,0 +1,1 @@
+ZO-3997: Audio object form without publish or retract actions

--- a/core/src/zeit/cms/permissions.zcml
+++ b/core/src/zeit/cms/permissions.zcml
@@ -177,6 +177,11 @@
     />
 
   <permission
+    id="zeit.content.audio.Publish"
+    title="Publish Audio objects"
+    />
+
+  <permission
     id="zeit.content.text.AddEmbed"
     title="Add Embed objects"
     />

--- a/core/src/zeit/content/audio/browser/configure.zcml
+++ b/core/src/zeit/content/audio/browser/configure.zcml
@@ -58,7 +58,7 @@
     permission="zope.View"
     />
 
-  <!-- restrict permissions for retract and delete -->
+  <!-- restrict permissions for publish, retract and delete -->
   <!-- retract -->
   <browser:viewlet
     name="Retract"
@@ -69,6 +69,7 @@
     permission="zeit.content.audio.Retract"
     icon="/@@/zeit.cms/icons/retract_topmenu.png"
     />
+
   <configure package="zeit.workflow.browser">
   <browser:page
     for="zeit.content.audio.interfaces.IAudio"
@@ -78,6 +79,28 @@
     permission="zeit.content.audio.Retract"
     />
   </configure>
+
+  <!-- publish -->
+  <browser:viewlet
+    name="Publish"
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.IRepositoryLayer"
+    class="zeit.workflow.browser.publish.PublishMenuItem"
+    manager="zeit.cms.browser.interfaces.IContextActions"
+    permission="zeit.content.audio.Publish"
+    icon="/@@/zeit.cms/icons/page_white_lightning.png"
+    />
+
+  <configure package="zeit.workflow.browser">
+  <browser:page
+    for="zeit.content.audio.interfaces.IAudio"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="publish.html"
+    template="publish.pt"
+    permission="zeit.content.audio.Publish"
+    />
+  </configure>
+
   <!-- delete -->
   <browser:viewlet
     for="zeit.content.audio.interfaces.IAudio"
@@ -90,6 +113,7 @@
     lightbox="@@delete.html"
     weight="500"
     />
+
   <configure package="zeit.cms.repository.browser">
   <browser:page
     for="zeit.content.audio.interfaces.IAudio"
@@ -100,5 +124,10 @@
     permission="zeit.content.audio.Delete"
     />
   </configure>
+
+  <adapter
+    factory=".form.Workflow"
+    provides="zeit.workflow.browser.interfaces.IWorkflowForm"
+  />
 
 </configure>

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -3,6 +3,7 @@ import gocept.form.grouped
 import zope.formlib
 
 import zeit.cms.browser.form
+import zeit.workflow.browser.form
 import zeit.content.audio.audio
 import zeit.content.audio.interfaces
 
@@ -64,3 +65,24 @@ class Display(PodcastForm, zeit.cms.browser.form.DisplayForm):
 
     title = _('View audio')
     for_display = True
+
+
+@zope.component.adapter(
+    zeit.content.audio.interfaces.IAudio,
+    zeit.cms.browser.interfaces.ICMSLayer)
+@zope.interface.implementer(zeit.workflow.browser.interfaces.IWorkflowForm)
+class Workflow(zeit.workflow.browser.form.AssetWorkflow):
+    """Publishing for audio is controlled by external provider
+    therefore implement the Workflow without the actions.
+
+    We utilize a limitation of zope.formlib:
+    Once you list an @action in a subclass,
+    no actions are inherited from the base class.
+
+    Less actions equals less buttons.
+    """
+
+    @zope.formlib.form.action(_('Save state only'),
+                              name='save')
+    def handle_save_state(self, action, data):
+        super().handle_edit_action.success(data)


### PR DESCRIPTION
- Entfernt 1 click-Publish im Menü
- Entfernt unten die Action Buttons für Publish und Retract

Sofern TTS oder Premium einen anderen Workflow haben und es möglich ist diese selbst zu veröffentlichen, muss eine andere Lösung her.

`IPublishInfo` um `can_retract` erweitern o.Ä.