### PR TITLE
ZO-4198: always call publish/retract if episode is(not) published

### DIFF
--- a/core/docs/changelog/ZO-4198.fix
+++ b/core/docs/changelog/ZO-4198.fix
@@ -1,0 +1,1 @@
+ZO-4198: publish audio object episode update even if it's published already

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -162,7 +162,7 @@ class Simplecast(grok.GlobalUtility):
         return IPublishInfo(audio).published and not IPodcastEpisodeInfo(audio).is_published
 
     def _publish_state_needs_sync(self, audio):
-        return not IPublishInfo(audio).published and IPodcastEpisodeInfo(audio).is_published
+        return IPodcastEpisodeInfo(audio).is_published
 
     def _create(self, episode_id, episode_data):
         container = self.folder(episode_data['created_at'])


### PR DESCRIPTION
Das ist am Ende erstmal ziemlich trivial. Nach meinem Verständis soll _immer_ veröffentlicht werden, wenn eine veröffentlichte Episode ans Vivi geschickt wird und _immer_ zurückgezogen werden, wenn eine unveröffentlichte Episode ans Vivi geschickt wird 🤷.

[Nachtrag](https://github.com/ZeitOnline/vivi/compare/8805f1c87f7f708849eadcbf75b259122220184c..616de3b3ccf2698203f9bd87a8a1e46e1616ac1a): Wenn das Audioobjekt unveröffentlicht ist und eine unveröffentlichte Episode ans Vivi geschickt wird, soll weder (selbsverständlich) weder veröffentlicht noch zurückgezogen werden (was nicht veröffentlicht ist)