### PR TITLE
ZO-4293: `load` event is being triggered for both tabs therefore check which tab we are in before setting form

### DIFF
--- a/core/docs/changelog/ZO-4293.change
+++ b/core/docs/changelog/ZO-4293.change
@@ -1,0 +1,1 @@
+ZO-4293: `load` event is being triggered for both tabs therefore check which tab we are in before setting form

--- a/core/src/zeit/edit/browser/js/lightbox.js
+++ b/core/src/zeit/edit/browser/js/lightbox.js
@@ -93,15 +93,17 @@ zeit.edit.TabbedLightBoxForm = zeit.edit.LightBoxForm.extend({
             self.events.push(
                 MochiKit.Signal.connect(
                     tab_view, 'load', function() {
-                    self.form = MochiKit.DOM.getFirstElementByTagAndClassName(
-                        'form', null, $(tab_view.target_id));
-                    if (!isNull(self.form)) {
-                        self.rewire_submit_buttons();
-                    }
-                    $(tab_view.target_id).__handler__ = self;
-                    zeit.cms.evaluate_js_and_css(
-                        self.container, function(code) { eval(code); });
-                    MochiKit.Signal.signal(self, 'after-reload');
+                        if (self.tabs.active_tab.id === tab_view.target_id) {
+                            self.form = MochiKit.DOM.getFirstElementByTagAndClassName(
+                                'form', null, $(tab_view.target_id));
+                            if (!isNull(self.form)) {
+                                self.rewire_submit_buttons();
+                            }
+                            $(tab_view.target_id).__handler__ = self;
+                            zeit.cms.evaluate_js_and_css(
+                                self.container, function(code) { eval(code); });
+                            MochiKit.Signal.signal(self, 'after-reload');
+                        }
             }));
             if (self.context_element == tab_definition) {
                 self.tabs.activate(tab_id);


### PR DESCRIPTION
…