### PR TITLE
 ZO-4214: add search filter for audio content type 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,5 @@
 # git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 
 # automatic code formatting
+401eb21d45d1c35356ee55000e830bdebdafe158
 12a4f3f6d4c6be79ed7f2d56005763064e6f353a

--- a/core/docs/changelog/ZO-4214.change
+++ b/core/docs/changelog/ZO-4214.change
@@ -1,0 +1,1 @@
+ZO-4214: add search filter for audio content type

--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -40,6 +40,7 @@ class SearchForm(JSONView):
             'products': self.products,
             'ressorts': self.get_source(metadata_if['ressort'].source, 'ressort', 'ressort_name'),
             'series': self.series,
+            'audio_type': self.audio_types,
             'podcasts': self.podcasts,
             'types': self.types,
         }
@@ -79,6 +80,11 @@ class SearchForm(JSONView):
         for entry in result:
             entry['podcast'] = entry['podcast'].id
         return result
+
+    @property
+    def audio_types(self):
+        types = zeit.content.audio.interfaces.AudioTypeSource().factory.values
+        return [{'key': key, 'value': value} for key, value in types.items()]
 
     CONTENT_TYPES = [
         'advertisement',
@@ -413,6 +419,7 @@ def search_form(request):
     product_id = g('product', None)
     show_news = g('show_news', False)
     serie = g('serie', None)
+    audio_type = g('audio_type', None)
     podcast = g('podcast', None)
     # four states: published, not-published, published-with-changes,
     # don't care (None)
@@ -432,6 +439,7 @@ def search_form(request):
         'product_id': product_id,
         'published': published,
         'serie': serie,
+        'audio_type': audio_type,
         'podcast': podcast,
         'show_news': show_news,
         'topic': topic,

--- a/core/src/zeit/find/browser/resources/search_form.jsont
+++ b/core/src/zeit/find/browser/resources/search_form.jsont
@@ -85,6 +85,15 @@
         </select>
       </fieldset>
       <fieldset>
+        <label>Audiotyp:</label>
+        <select name="audio_type">
+        <option value=""></option>
+        {.repeated section audio_type}
+        <option value="{key}">{value}</option>
+        {.end}
+        </select>
+      </fieldset>
+      <fieldset>
         <label>Podcast:</label>
         <select name="podcast">
         <option value=""></option>

--- a/core/src/zeit/find/browser/tests/test_selenium.py
+++ b/core/src/zeit/find/browser/tests/test_selenium.py
@@ -101,3 +101,14 @@ class TestSearch(zeit.cms.testing.SeleniumTestCase):
         s.assertNotChecked('id=search-type-file')
         self.execute("zeit.cms.activate_objectbrowser(['file'])")
         s.assertChecked('id=search-type-file')
+
+    def test_audio_type_selection(self):
+        s = self.selenium
+        s.verifyNotVisible('id=extended_search')
+        s.click('id=extended_search_button')
+        s.waitForVisible('id=extended_search')
+        s.verifyNotVisible('id=extended_search_info')
+        s.select('name=audio_type', 'Text to Speech')
+        s.verifyValue('name=audio_type', 'tts')
+        s.select('name=audio_type', 'Podcast')
+        s.verifyValue('name=audio_type', 'podcast')

--- a/core/src/zeit/find/search.py
+++ b/core/src/zeit/find/search.py
@@ -36,6 +36,7 @@ field_map = {
     'published': 'payload.vivi.publish_status',
     'raw_tags': 'body',
     'serie': 'payload.document.serie',
+    'audio_type': 'payload.audio.audio_type',
     'podcast': 'payload.audio.podcast',
     'topic': 'payload.document.ressort',
     'types': 'doc_type',


### PR DESCRIPTION
Neues Feld erstellt für die Suche Audiotyp. Das Feld Podcasts ist deaktiviert wenn TTS oder Premium Audio auswählt ist.

![grafik](https://github.com/ZeitOnline/vivi/assets/121817095/d29906f7-cb8f-4fcf-a99a-0383ff75841a)

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://media.giphy.com/media/fxz4o3wIT3FYxMdWlg/giphy.gif)