### PR TITLE
ZO-4369: Format audio episode notes to correct html in article body

### DIFF
--- a/core/docs/changelog/ZO-4369.change
+++ b/core/docs/changelog/ZO-4369.change
@@ -1,0 +1,1 @@
+ZO-4369: Add complete audio episode notes html to article body

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -23,8 +23,10 @@ import zeit.cms.workflow.dependency
 import zeit.cms.workflow.interfaces
 import zeit.connector.filesystem
 import zeit.connector.interfaces
+import zeit.content.article.edit.audio
 import zeit.content.article.edit.interfaces
 import zeit.content.article.interfaces
+import zeit.content.audio.interfaces
 import zeit.content.infobox.interfaces
 import zeit.content.portraitbox.interfaces
 import zeit.edit.interfaces
@@ -36,7 +38,6 @@ import zope.dublincore.interfaces
 import zope.index.text.interfaces
 import zope.interface
 import zope.security.proxy
-import zeit.content.audio.interfaces
 
 
 ARTICLE_NS = zeit.content.article.interfaces.ARTICLE_NS
@@ -397,20 +398,22 @@ def set_podcast_header_when_article_has_podcast_audio(context, event):
     context.header_layout = 'podcast'
 
     main_audio = audio.items[0]
-    if main_audio.audio_type == 'podcast':
-        if not context.title:
-            context.title = main_audio.title
-        episode = zeit.content.audio.interfaces.IPodcastEpisodeInfo(main_audio)
-        if not context.teaserText:
-            context.teaserText = episode.summary
-        if not context.teaserTitle:
-            context.teaserTitle = main_audio.title
-        if not context.subtitle:
-            context.subtitle = episode.summary
-        # article image reserves first position
-        body = context.body
-        if not body or (len(body.keys()) == 1 and context.main_image_block):
-            body.create_item('p').text = episode.notes
+    if main_audio.audio_type != 'podcast':
+        return
+
+    if not context.title:
+        context.title = main_audio.title
+    episode = zeit.content.audio.interfaces.IPodcastEpisodeInfo(main_audio)
+    if not context.teaserText:
+        context.teaserText = episode.summary
+    if not context.teaserTitle:
+        context.teaserTitle = main_audio.title
+    if not context.subtitle:
+        context.subtitle = episode.summary
+    body = context.body
+    # article image reserves first position
+    if not body or (len(body.keys()) == 1 and context.main_image_block):
+        zeit.content.article.edit.audio.apply_notes(body, episode)
 
 
 @grok.subscribe(

--- a/core/src/zeit/content/article/edit/audio.py
+++ b/core/src/zeit/content/article/edit/audio.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from zeit.cms.i18n import MessageFactory as _
 import grokcore.component as grok
 import zeit.content.article.edit.block
@@ -28,3 +29,18 @@ def factor_block_from_content(body, context, position):
     block = Factory(body)(position)
     block.references = context
     return block
+
+
+def apply_notes(body, episode_info):
+    notes = BeautifulSoup(episode_info.notes, 'html.parser')
+    mapping = {
+        'p': 'p',
+        'ul': 'ul',
+        'ol': 'ol',
+        'h1': 'intertitle',
+        'h2': 'intertitle',
+        'h3': 'intertitle',
+    }
+    for item in notes.contents:
+        tag_name = mapping.get(item.name, 'p')
+        body.create_item(tag_name).text = str(item)

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -55,7 +55,7 @@ class AudioBuilder:
                 'episode_nr': 1,
                 'url_ad_free': 'http://simplecast.com/adfree.mp3',
                 'summary': 'lorem ipsum',
-                'notes': 'dolor <b>sit</b> amet',
+                'notes': '<p>dolor <b>sit</b> amet</p>',
                 'is_published': True,
                 'dashboard_link': 'http://simplecast.com/pawdcast',
                 'podcast': Podcast(


### PR DESCRIPTION
We want all the paragraphs of the audio episode notes! Including but not limited to the very weird ones, without html tags.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations no

### gif
![audiocity](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb293Z3hmZHpweXNwdGQyZmw1c25sN3ZjNjUybGZ3YmtxOTZ0N3dmcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26n5ZZfTd3cBLoj2E/giphy.gif)