### PR TITLE
 ZO-4223: use short article uuid from speechbert to get content

### DIFF
--- a/core/docs/changelog/ZO-4223.change
+++ b/core/docs/changelog/ZO-4223.change
@@ -1,0 +1,1 @@
+ZO-4223: use short article uuid from speechbert to get content

--- a/core/docs/changelog/layout.fix
+++ b/core/docs/changelog/layout.fix
@@ -1,0 +1,1 @@
+Audio: filename in navigation layout

--- a/core/src/zeit/cms/content/contentuuid.py
+++ b/core/src/zeit/cms/content/contentuuid.py
@@ -49,6 +49,9 @@ def properties(context):
 @zope.interface.implementer(zeit.cms.content.interfaces.IUUID)
 class SimpleUUID(Shortenable):
     def __init__(self, context):
+        # work with shortened uuid
+        if not context.startswith('{urn:uuid:'):
+            context = f'{{urn:uuid:{context}}}'
         self.id = context
 
 

--- a/core/src/zeit/cms/content/tests/test_contentuuid.py
+++ b/core/src/zeit/cms/content/tests/test_contentuuid.py
@@ -1,0 +1,15 @@
+from cms.checkout.helper import checked_out
+from zeit.cms.content.interfaces import IUUID
+from zeit.cms.interfaces import ICMSContent
+import zeit.cms.testing
+
+
+class ContentUUIDTest(zeit.cms.testing.ZeitCmsTestCase):
+    def test_use_short_uuid_to_get_content(self):
+        unique_id = 'http://xml.zeit.de/online/2007/01/Somalia'
+        with checked_out(ICMSContent(unique_id)):
+            pass
+        content = ICMSContent(unique_id)
+        short_uuid = IUUID(content).shortened
+        content_from_short_uuid = ICMSContent(IUUID(short_uuid))
+        assert content_from_short_uuid == content

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -83,7 +83,7 @@ class Form:
 
     field_groups = (
         gocept.form.grouped.Fields(
-            _('Navigation'), ('__name__'), css_class='wide-widgets column-right'
+            _('Navigation'), ('__name__',), css_class='wide-widgets column-right'
         ),
         Base.audio_fields,
         podcast_file_fields,


### PR DESCRIPTION
Wir übergeben Speechbert die Kurze UUID und bekommen diese entsprechend wieder zurück.

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://media.giphy.com/media/kBNacfEgENH2Hon6hc/giphy-downsized.gif)