### PR TITLE
ZO-4496: Retry celery task on simplecast 429 error

### DIFF
--- a/core/docs/changelog/ZO-4496.change
+++ b/core/docs/changelog/ZO-4496.change
@@ -1,0 +1,1 @@
+ZO-4496: Retry celery task on simplecast 429 error

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -66,10 +66,6 @@ class Simplecast:
                 )
                 status_code = response.status_code
                 response_text = response.text
-                # 404 is a valid response
-                # will trigger delete if audio exist
-                if status_code == 404:
-                    return None
                 response.raise_for_status()
                 json = response.json()
             except requests.exceptions.JSONDecodeError as err:
@@ -79,6 +75,8 @@ class Simplecast:
                 if not status_code:
                     status_code = getattr(err.response, 'status_code', 599)
                 response_text = getattr(err.response, 'text', str(err))
+                if status_code == 404:
+                    return None  # Triggers delete if audio object exist.
                 log.error('%s returned %s', request, status_code, exc_info=True)
                 raise
             finally:

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -77,6 +77,8 @@ class Simplecast:
                 response_text = getattr(err.response, 'text', str(err))
                 if status_code == 404:
                     return None  # Triggers delete if audio object exist.
+                if status_code == 429:
+                    raise zeit.simplecast.interfaces.TechnicalError(response_text, status_code)
                 log.error('%s returned %s', request, status_code, exc_info=True)
                 raise
             finally:

--- a/core/src/zeit/simplecast/interfaces.py
+++ b/core/src/zeit/simplecast/interfaces.py
@@ -18,3 +18,11 @@ class ISimplecast(zope.interface.Interface):
 
     def publish(self, audio: IAudio):
         """Publish audio object"""
+
+
+class TechnicalError(Exception):
+    """Service had a technical error. The request can be retried."""
+
+    def __init__(self, message, status):
+        super().__init__(message)
+        self.status = status

--- a/core/src/zeit/simplecast/testing.py
+++ b/core/src/zeit/simplecast/testing.py
@@ -9,6 +9,7 @@ product_config = """\
   simplecast-token TkQvZUd2MHRnR0UybFhsgTfs
   podcast-folder podcasts
   principal zope.simplecast
+  retry-delay-seconds 0
 </product-config>
 """
 

--- a/core/src/zeit/simplecast/tests/test_connection.py
+++ b/core/src/zeit/simplecast/tests/test_connection.py
@@ -76,6 +76,18 @@ class TestSimplecast(zeit.simplecast.testing.FunctionalTestCase):
             'Invalid Json Expecting value: ' 'line 1 column 1 (char 0): no json', args[2]
         )
 
+    @requests_mock.Mocker()
+    def test_simplecast_too_many_requests_raises(self, m):
+        episode_id = '1234'
+        m.get(
+            f'https://testapi.simplecast.com/episodes/{episode_id}',
+            status_code=429,
+        )
+        with self.assertRaises(zeit.simplecast.interfaces.TechnicalError):
+            self.simplecast.fetch_episode(episode_id)
+        args, _ = self.trace_mock.call_args_list[0]
+        self.assertEqual(429, args[1])
+
     def test_simplecast_yields_episode_info(self):
         m_simple = requests_mock.Mocker()
         episode_id = self.episode_info['id']

--- a/core/src/zeit/simplecast/tests/test_webhook.py
+++ b/core/src/zeit/simplecast/tests/test_webhook.py
@@ -40,7 +40,7 @@ class TestWebHook(zeit.simplecast.testing.BrowserTestCase):
         self.simplecast = zope.component.getUtility(zeit.simplecast.interfaces.ISimplecast)
 
     def tearDown(self):
-        self.simplecast.reset_mock()
+        self.simplecast.reset_mock(return_value=True, side_effect=True)
 
     @pytest.fixture(autouse=True)
     def _caplog(self, caplog):


### PR DESCRIPTION
### Checklist

- [x] Documentation, siehe ZeitOnline/vivi-deployment@d55c7a45
- [x] Configuration, siehe ZeitOnline/vivi-deployment@f7f39bba
- [x] Changelog
- [x] Tests
- [x] ~Translations~