### PR TITLE
ZO-4225: filter audio references by audio type

### DIFF
--- a/core/docs/changelog/ZO-4225.change
+++ b/core/docs/changelog/ZO-4225.change
@@ -1,0 +1,1 @@
+ZO-4225: filter audio references by type

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -434,6 +434,23 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         self.audio = AudioBuilder().build(self.repository)
         self.info = zeit.content.audio.interfaces.IPodcastEpisodeInfo(self.audio)
 
+    def test_filter_audios_by_audio_type(self):
+        self.repository['article'] = self.article
+        tts = AudioBuilder().with_audio_type('tts').build(self.repository, 'tts')
+        pc1 = AudioBuilder().with_audio_type('podcast').build(self.repository, 'pc1')
+        pc2 = AudioBuilder().with_audio_type('podcast').build(self.repository, 'pc2')
+        audios_refs = zeit.content.audio.interfaces.IAudioReferences(self.article)
+        audios_refs.add(tts)
+        audios_refs.add(pc1)
+        audios_refs.add(pc2)
+        audios_tts = audios_refs.get_by_type('tts')
+        audios_pcs = audios_refs.get_by_type('podcast')
+        assert len(audios_tts) == 1
+        assert audios_tts[0].uniqueId == 'http://xml.zeit.de/tts'
+        assert len(audios_pcs) == 2
+        assert audios_pcs[0].uniqueId == 'http://xml.zeit.de/pc1'
+        assert audios_pcs[1].uniqueId == 'http://xml.zeit.de/pc2'
+
     def test_remove_audio_from_article(self):
         self.repository['article'] = self.article
         with checked_out(self.article) as co:

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -145,6 +145,9 @@ class IAudioReferences(zope.interface.Interface):
     def add(audio: IAudio):
         pass
 
+    def get_by_type(audio_type: str) -> [IAudio]:
+        pass
+
 
 class ISpeechInfo(zope.interface.Interface):
     article_uuid = zope.schema.ASCIILine(

--- a/core/src/zeit/content/audio/reference.py
+++ b/core/src/zeit/content/audio/reference.py
@@ -11,3 +11,6 @@ class AudioReferences(zeit.cms.related.related.RelatedBase):
 
     def add(self, audio):
         self.items += (audio,)
+
+    def get_by_type(self, audio_type):
+        return [i for i in self.items if audio_type == i.audio_type]

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -81,7 +81,9 @@ class AudioBuilder:
                 return self
         raise ValueError(f'Unknown attribute {attribute_name}')
 
-    def build(self, repository: Optional[IRepository] = None) -> Audio:
+    def build(
+        self, repository: Optional[IRepository] = None, unique_id: Optional[str] = 'audio'
+    ) -> Audio:
         audio = Audio()
         audio_type = self.attributes['audio']['audio_type']
         for attribute, value in self.attributes['audio'].items():
@@ -96,7 +98,7 @@ class AudioBuilder:
             for attribute, value in self.attributes[audio_type].items():
                 setattr(tts, attribute, value)
         if repository is not None:
-            repository['audio'] = audio
+            repository[unique_id] = audio
 
         return audio
 


### PR DESCRIPTION
~Das macht in zeit.web bereits, was es soll. Ich versuche mich gerade noch darin, mehrer Audios unterschiedlichen Typs mit
```
        AudioBuilder().with_audio_type('tts').build(self.repository)
        self._add_audio_to_article()
```
an Artikel zu hängen.~ Ergänzung, damit das klappt, ist Teil des PRs


### Checklist

- [ ] ~Documentation~
- [x] Changelog
- [x] Tests
- [ ] ~Translations~

