### PR TITLE
ZO-4612: Create publisher payload per content object and catch errors

### DIFF
--- a/core/docs/changelog/ZO-4612.change
+++ b/core/docs/changelog/ZO-4612.change
@@ -1,0 +1,1 @@
+ZO-4612: Create publisher payload per content object and catch errors

--- a/core/src/zeit/cms/ftesting.zcml
+++ b/core/src/zeit/cms/ftesting.zcml
@@ -22,6 +22,16 @@
 
   <meta:provides feature="zeit.connector.mock" />
   <include package="zeit.connector" file="service.zcml" />
+  <subscriber
+    handler="zeit.cms.testing.reset_connector"
+    for="zeit.cms.testing.ResetMocks" />
+
+  <subscriber
+    handler="zeit.cms.workflow.mock.reset"
+    for="zeit.cms.testing.ResetMocks" />
+  <subscriber
+    handler="pyramid_dogpile_cache2.clear"
+    for="zeit.cms.testing.ResetMocks" />
 
   <include package="zeit.cms.workflow" file="mock.zcml" />
   <include package="zeit.cms.tagging" file="mock.zcml" />

--- a/core/src/zeit/connector/ftesting.zcml
+++ b/core/src/zeit/connector/ftesting.zcml
@@ -4,6 +4,9 @@
   <include package="zeit.cms" file="application.zcml" />
   <include package="zeit.cms" file="ftesting-securitypolicy.zcml" />
   <utility factory="zeit.cms.tracing.default_tracer" />
+  <subscriber
+    handler="zeit.cms.testing.reset_connector"
+    for="zeit.cms.testing.ResetMocks" />
 
   <include package="zeit.connector" />
   <include package="zeit.connector" file="service.zcml" />

--- a/core/src/zeit/content/article/ctesting.zcml
+++ b/core/src/zeit/content/article/ctesting.zcml
@@ -25,5 +25,6 @@
   <include package="zeit.find.browser" />
 
   <grok:grok package="zeit.workflow.publish_3rdparty" />
+  <include package="zeit.workflow" file="ctesting.zcml" />
 
 </configure>

--- a/core/src/zeit/content/article/testing.py
+++ b/core/src/zeit/content/article/testing.py
@@ -61,6 +61,8 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         zeit.content.volume.testing.CONFIG_LAYER,
         zeit.wochenmarkt.testing.CONFIG_LAYER,
     ),
+    # XXX Kludge because we depend on zeit.workflow.publish_3rdparty in our tests
+    patches={'zeit.workflow': {'facebooknewstab-startdate': '2021-03-24'}},
 )
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -6,7 +6,6 @@ from zeit.cms.repository.interfaces import IRepository
 from zeit.content.audio.audio import Audio
 from zeit.content.audio.interfaces import IPodcastEpisodeInfo, ISpeechInfo, Podcast
 import zeit.cms.testing
-import zeit.workflow.testing
 
 
 T = TypeVar('T')  # Can be anything
@@ -19,10 +18,7 @@ product_config = """
 
 CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     product_config,
-    bases=(
-        zeit.workflow.testing.CONFIG_LAYER,
-        zeit.cms.testing.CONFIG_LAYER,
-    ),
+    bases=(zeit.cms.testing.CONFIG_LAYER,),
 )
 
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', bases=(CONFIG_LAYER,))

--- a/core/src/zeit/content/gallery/testing.py
+++ b/core/src/zeit/content/gallery/testing.py
@@ -9,7 +9,6 @@ import zeit.content.image.image
 import zeit.content.image.interfaces
 import zeit.crop.testing
 import zeit.push.testing
-import zeit.workflow.testing
 
 
 product_config = """

--- a/core/src/zeit/content/image/testing.py
+++ b/core/src/zeit/content/image/testing.py
@@ -9,7 +9,6 @@ import zeit.cms.repository.interfaces
 import zeit.cms.testing
 import zeit.content.image.image
 import zeit.content.image.imagegroup
-import zeit.workflow.testing
 
 
 product_config = """
@@ -26,7 +25,7 @@ product_config = """
 
 
 CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
-    product_config, bases=(zeit.workflow.testing.CONFIG_LAYER,)
+    product_config, bases=(zeit.cms.testing.CONFIG_LAYER,)
 )
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))

--- a/core/src/zeit/content/volume/browser/tests/test_admin.py
+++ b/core/src/zeit/content/volume/browser/tests/test_admin.py
@@ -10,7 +10,6 @@ import zeit.cms.content.field
 import zeit.cms.interfaces
 import zeit.content.volume.testing
 import zeit.find.interfaces
-import zeit.workflow.testing
 
 
 class VolumeAdminBrowserTest(zeit.content.volume.testing.BrowserTestCase):

--- a/core/src/zeit/edit/testing.py
+++ b/core/src/zeit/edit/testing.py
@@ -1,10 +1,9 @@
 import gocept.selenium
 
 import zeit.cms.testing
-import zeit.workflow.testing
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.workflow.testing.CONFIG_LAYER,))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(zeit.cms.testing.CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))
 WSGI_LAYER = zeit.cms.testing.WSGILayer(bases=(ZOPE_LAYER,))
 HTTP_LAYER = zeit.cms.testing.WSGIServerLayer(name='HTTPLayer', bases=(WSGI_LAYER,))

--- a/core/src/zeit/retresco/ftesting.zcml
+++ b/core/src/zeit/retresco/ftesting.zcml
@@ -12,6 +12,7 @@
   <include package="zeit.retresco.xmlrpc" />
 
   <include package="zeit.content.advertisement" />
+  <exclude package="zeit.workflow" file="ctesting.zcml" />
   <include package="zeit.content.article" file="ctesting.zcml" />
   <include package="zeit.content.author" />
   <include package="zeit.content.dynamicfolder" file="ctesting.zcml" />

--- a/core/src/zeit/simplecast/testing.py
+++ b/core/src/zeit/simplecast/testing.py
@@ -1,6 +1,5 @@
 import zeit.cms.testing
 import zeit.content.audio.testing
-import zeit.workflow.testing
 
 
 product_config = """\
@@ -52,7 +51,7 @@ EPISODE_200 = {
 
 CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     product_config,
-    bases=(zeit.content.audio.testing.CONFIG_LAYER, zeit.workflow.testing.CONFIG_LAYER),
+    bases=(zeit.content.audio.testing.CONFIG_LAYER,),
 )
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))

--- a/core/src/zeit/workflow/ctesting.zcml
+++ b/core/src/zeit/workflow/ctesting.zcml
@@ -1,0 +1,28 @@
+<configure
+   xmlns="http://namespaces.zope.org/zope"
+   xmlns:meta="http://namespaces.zope.org/meta"
+   i18n_domain="zope"
+   >
+
+  <!-- NOTE: Contrary to the "ctesting.zcml" contract, this file does *not*
+  include "everything you need to use this package in your tests".
+
+  1. Ideally, no other package would need to use zeit.workflow anyway,
+  and instead be able to do everything with zeit.cms.workflow.mock.
+  And because the mock is the testing default, those few packages that use
+  zeit.workflow in their tests have to use includeOverrides:ftesting.zcml anyway.
+
+  2. Platonically, publish_3rdparty should be in a separate package,
+  because it uses packages from different dependency tiers (zeit.content.*, zeit.retresco and zeit.workflow).
+  Since we currently think that would be too much bureaucratic effort for too little gain,
+  this results in some edge cases, like z.c.article needing to use publish_3rdparty
+  in its tests, but *without* the rest of zeit.workflow.
+  And *that* is currently the purpose of this file.
+  -->
+
+  <adapter factory=".testing.MockTMSRepresentation" />
+  <subscriber
+    handler=".testing.reset_mock_tms"
+    for="zeit.cms.testing.ResetMocks" />
+
+</configure>

--- a/core/src/zeit/workflow/ftesting.zcml
+++ b/core/src/zeit/workflow/ftesting.zcml
@@ -8,6 +8,7 @@
   <include package="zeit.cms" file="ftesting.zcml" />
 
   <include package="zeit.workflow" />
+  <include package="zeit.workflow" file="ctesting.zcml" />
   <include package="zeit.workflow.browser" />
   <include package="zeit.workflow.json" />
   <include package="zeit.workflow.xmlrpc" />

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -276,8 +276,8 @@ class PublishRetractTask:
 
     def recurse(self, method, obj, *args):
         """Apply method recursively on obj."""
-        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
-        DEPENDENCY_PUBLISH_LIMIT = int(config['dependency-publish-limit'])
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow') or {}
+        DEPENDENCY_PUBLISH_LIMIT = int(config.get('dependency-publish-limit', 1))
         stack = [obj]
         seen = set()
         result_obj = None

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -311,8 +311,8 @@ class PublishRetractTask:
 
         return result_obj
 
-    def collect(self, obj, result):
-        result.append(obj)
+    def serialize(self, obj, result):
+        result.append(zeit.workflow.interfaces.IPublisherData(obj)(self.mode))
         return obj
 
     def log(self, obj, message):
@@ -382,7 +382,7 @@ class PublishTask(PublishRetractTask):
         for obj in published:
             try:
                 deps = []
-                self.recurse(self.collect, obj, deps)
+                self.recurse(self.serialize, obj, deps)
                 to_publish.extend(deps)
             except Exception as e:
                 errors.append((obj, e))
@@ -487,7 +487,7 @@ class RetractTask(PublishRetractTask):
         for obj in retracted:
             try:
                 deps = []
-                self.recurse(self.collect, obj, deps)
+                self.recurse(self.serialize, obj, deps)
                 to_retract.extend(reversed(deps))
             except Exception as e:
                 errors.append((obj, e))

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -390,7 +390,7 @@ class PublishTask(PublishRetractTask):
         try:
             if to_publish:
                 publisher = zope.component.getUtility(zeit.cms.workflow.interfaces.IPublisher)
-                publisher.request(to_publish, 'publish')
+                publisher.request(to_publish, self.mode)
         except zeit.workflow.publisher.PublisherError as e:
             errors.extend(self._assign_publisher_errors_to_objects(e, published))
         except Exception as e:
@@ -495,7 +495,7 @@ class RetractTask(PublishRetractTask):
         try:
             if to_retract:
                 publisher = zope.component.getUtility(zeit.cms.workflow.interfaces.IPublisher)
-                publisher.request(to_retract, 'retract')
+                publisher.request(to_retract, self.mode)
         except zeit.workflow.publisher.PublisherError as e:
             errors.extend(self._assign_publisher_errors_to_objects(e, retracted))
         except Exception as e:

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -200,12 +200,14 @@ class Speechbert(grok.Adapter):
     def ignore(self, method):
         config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow') or {}
         if method == 'publish':
-            ignore_genres = [x.lower() for x in config['speechbert-ignore-genres'].split()]
+            ignore_genres = [x.lower() for x in config.get('speechbert-ignore-genres', '').split()]
             genre = self.context.genre
             if genre and genre.lower() in ignore_genres:
                 return True
         if method == 'publish':
-            ignore_templates = [x.lower() for x in config['speechbert-ignore-templates'].split()]
+            ignore_templates = [
+                x.lower() for x in config.get('speechbert-ignore-templates', '').split()
+            ]
             template = self.context.template
             if template is not None and template.lower() in ignore_templates:
                 return True

--- a/core/src/zeit/workflow/publisher.py
+++ b/core/src/zeit/workflow/publisher.py
@@ -16,8 +16,8 @@ class PublisherError(Exception):
 
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublisher)
 class Publisher:
-    def request(self, to_process_list, method):
-        if not to_process_list:
+    def request(self, items, method):
+        if not items:
             return
 
         config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
@@ -31,13 +31,12 @@ class Publisher:
             headers['host'] = hostname
 
         url = f'{publisher_base_url}{method}'
-        json = [zeit.workflow.interfaces.IPublisherData(obj)(method) for obj in to_process_list]
-        r = requests.post(url=url, json=json, headers=headers)
+        r = requests.post(url, json=items, headers=headers)
         if r.status_code != 200:
             raise PublisherError(r.url, r.status_code, r.json()['errors'])
 
 
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublisher)
 class MockPublisher:
-    def request(self, to_process_list, method):
+    def request(self, items, method):
         return

--- a/core/src/zeit/workflow/publishinfo.py
+++ b/core/src/zeit/workflow/publishinfo.py
@@ -83,8 +83,8 @@ class PublishInfo:
         return zeit.cms.workflow.interfaces.CAN_RETRACT_SUCCESS
 
     def matches_blacklist(self):
-        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
-        blacklist = re.split(', *', config['blacklist'])
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow') or {}
+        blacklist = re.split(', *', config.get('blacklist', ''))
         path = urllib.parse.urlparse(self.context.uniqueId).path
         for item in blacklist:
             if item and path.startswith(item):

--- a/core/src/zeit/workflow/testing.py
+++ b/core/src/zeit/workflow/testing.py
@@ -10,6 +10,7 @@ from zeit.cms.workflow.interfaces import CAN_PUBLISH_ERROR, CAN_PUBLISH_WARNING
 import zeit.cms.testcontenttype.interfaces
 import zeit.cms.testing
 import zeit.cms.workflow.interfaces
+import zeit.content.article.testing
 import zeit.workflow.publishinfo
 
 
@@ -47,6 +48,11 @@ class TMSMockLayer(plone.testing.Layer):
 
 
 TMS_MOCK_LAYER = TMSMockLayer(name='TMSMockLayer', bases=(ZOPE_LAYER,))
+ARTICLE_LAYER = zeit.cms.testing.AdditionalZCMLLayer(
+    'zeit.content.article',
+    'ctesting.zcml',
+    bases=(ZOPE_LAYER, zeit.content.article.testing.CONFIG_LAYER),
+)
 
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):

--- a/core/src/zeit/workflow/testing.py
+++ b/core/src/zeit/workflow/testing.py
@@ -1,7 +1,4 @@
-from unittest import mock
-
 import gocept.selenium
-import plone.testing
 import zope.app.appsetup.product
 import zope.component
 import zope.interface
@@ -37,17 +34,6 @@ HTTP_LAYER = zeit.cms.testing.WSGIServerLayer(name='HTTPLayer', bases=(WSGI_LAYE
 WD_LAYER = zeit.cms.testing.WebdriverLayer(name='WebdriverLayer', bases=(HTTP_LAYER,))
 WEBDRIVER_LAYER = gocept.selenium.WebdriverSeleneseLayer(name='SeleniumLayer', bases=(WD_LAYER,))
 
-
-class TMSMockLayer(plone.testing.Layer):
-    def testSetUp(self):
-        self.patch = mock.patch('zeit.retresco.interfaces.ITMSRepresentation')
-        self.representation = self.patch.start()
-
-    def testTearDown(self):
-        self.patch.stop()
-
-
-TMS_MOCK_LAYER = TMSMockLayer(name='TMSMockLayer', bases=(ZOPE_LAYER,))
 ARTICLE_LAYER = zeit.cms.testing.AdditionalZCMLLayer(
     'zeit.content.article',
     'ctesting.zcml',
@@ -65,6 +51,25 @@ class BrowserTestCase(zeit.cms.testing.BrowserTestCase):
 
 class SeleniumTestCase(zeit.cms.testing.SeleniumTestCase):
     layer = WEBDRIVER_LAYER
+
+
+@zope.component.adapter(zeit.cms.interfaces.ICMSContent)
+@zope.interface.implementer(zeit.retresco.interfaces.ITMSRepresentation)
+class MockTMSRepresentation:
+    result = _default_result = {}
+
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self):
+        return self.result
+
+    @classmethod
+    def reset(cls):
+        cls.result = cls._default_result
+
+
+reset_mock_tms = MockTMSRepresentation.reset  # ZCA cannot use classmethods
 
 
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublishInfo)

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -22,7 +22,6 @@ from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
 import zeit.cms.related.interfaces
 import zeit.cms.testing
 import zeit.cms.workflow.interfaces
-import zeit.content.article.testing
 import zeit.objectlog.interfaces
 import zeit.workflow.interfaces
 import zeit.workflow.publish
@@ -491,7 +490,7 @@ class MultiPublishRetractTest(zeit.workflow.testing.FunctionalTestCase):
 
 
 class NewPublisherTest(zeit.workflow.testing.FunctionalTestCase):
-    layer = zeit.content.article.testing.LAYER
+    layer = zeit.workflow.testing.ARTICLE_LAYER
 
     def setUp(self):
         self.patch = mock.patch('zeit.retresco.interfaces.ITMSRepresentation')

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -493,17 +493,11 @@ class NewPublisherTest(zeit.workflow.testing.FunctionalTestCase):
     layer = zeit.workflow.testing.ARTICLE_LAYER
 
     def setUp(self):
-        self.patch = mock.patch('zeit.retresco.interfaces.ITMSRepresentation')
-        self.representation = self.patch.start()
         super().setUp()
         self.gsm = zope.component.getGlobalSiteManager()
         self.gsm.registerUtility(
             zeit.workflow.publisher.Publisher(), zeit.cms.workflow.interfaces.IPublisher
         )
-
-    def tearDown(self):
-        self.patch.stop()
-        super().tearDown()
 
     def test_object_is_published(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -46,10 +46,8 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_ignore_3rdparty_list_is_respected(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         article_2 = ICMSContent('http://xml.zeit.de/online/2007/01/Schrempp')
-        IPublishInfo(article_2).urgent = True
         IPublishInfo(article_2).published = True
         self.assertTrue(IPublishInfo(article_2).published)
         with requests_mock.Mocker() as rmock:
@@ -73,7 +71,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_authordashboard_is_notified(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)
@@ -85,7 +82,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_bigquery_is_published(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)
@@ -132,7 +128,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_comments_are_published(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)
@@ -179,7 +174,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_facebooknewstab_is_published(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)
@@ -191,7 +185,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_facebooknewstab_skipped_date_first_released(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).date_first_released = pendulum.datetime(2020, 10, 5)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)
@@ -208,7 +201,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_facebooknewstab_skipped_product_id(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
         self.assertFalse(IPublishInfo(article).published)
         self.assertEqual(article.product.id, 'ZEDE')
@@ -232,7 +224,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_facebooknewstab_skipped_ressort(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
         self.assertFalse(IPublishInfo(article).published)
         self.assertEqual(article.ressort, 'International')
@@ -257,7 +248,6 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_speechbert_is_published(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
             response = rmock.post('http://localhost:8060/test/publish', status_code=200)

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import requests_mock
 import zope.component
 
@@ -13,15 +11,9 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
     layer = zeit.workflow.testing.ARTICLE_LAYER
 
     def setUp(self):
-        self.patch = mock.patch('zeit.retresco.interfaces.ITMSRepresentation')
-        self.representation = self.patch.start()
         super().setUp()
         self.gsm = zope.component.getGlobalSiteManager()
         self.gsm.registerUtility(zeit.workflow.publisher.Publisher(), IPublisher)
-
-    def tearDown(self):
-        self.patch.stop()
-        super().tearDown()
 
     def test_ignore_3rdparty_list_is_respected(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
@@ -135,7 +127,7 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_tms_retract_ignores_content_without_tms_representation(self):
         content = self.repository['testcontent']
-        self.representation().return_value = None
+        zeit.workflow.testing.MockTMSRepresentation.result = None
         data_factory = zope.component.getAdapter(
             content, zeit.workflow.interfaces.IPublisherData, name='tms'
         )

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -5,13 +5,12 @@ import zope.component
 
 from zeit.cms.interfaces import ICMSContent
 from zeit.cms.workflow.interfaces import IPublish, IPublisher, IPublishInfo
-import zeit.content.article.testing
 import zeit.workflow.publisher
 import zeit.workflow.testing
 
 
 class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
-    layer = zeit.content.article.testing.LAYER
+    layer = zeit.workflow.testing.ARTICLE_LAYER
 
     def setUp(self):
         self.patch = mock.patch('zeit.retresco.interfaces.ITMSRepresentation')

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -25,10 +25,8 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_ignore_3rdparty_list_is_respected(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         self.assertFalse(IPublishInfo(article).published)
         article_2 = ICMSContent('http://xml.zeit.de/online/2007/01/Schrempp')
-        IPublishInfo(article_2).urgent = True
         IPublishInfo(article_2).published = True
         self.assertTrue(IPublishInfo(article_2).published)
         with requests_mock.Mocker() as rmock:
@@ -52,7 +50,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_authordashboard_is_ignored_during_retraction(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).published = True
         self.assertTrue(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
@@ -64,7 +61,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_bigquery_is_retracted(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).published = True
         self.assertTrue(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
@@ -77,7 +73,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_comments_are_ignored_during_retraction(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).published = True
         self.assertTrue(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
@@ -89,7 +84,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_facebooknewstab_is_retracted(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).published = True
         self.assertTrue(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:
@@ -102,7 +96,6 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
 
     def test_speechbert_is_retracted(self):
         article = ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        IPublishInfo(article).urgent = True
         IPublishInfo(article).published = True
         self.assertTrue(IPublishInfo(article).published)
         with requests_mock.Mocker() as rmock:


### PR DESCRIPTION
### Checklist

- [x] Documentation: Ich würde das zum Anlass nehmen ("Pfadfinder-Regel"), mal zumindest grob den Aufbau von IPublish, IPublishInfo, zeit.cms.workflow vs zeit.workflow [zu beschreiben](https://github.com/ZeitOnline/vivi-deployment/commit/2fb44eeefb618a016c71ecbf0880d66c15e2dea0)
- [x] Changelog
- [x] Tests
- [x] ~Translations~