### PR TITLE
ZO-4649: Configure max retry for speech webhook

### DIFF
--- a/core/docs/changelog/ZO-4649.change
+++ b/core/docs/changelog/ZO-4649.change
@@ -1,0 +1,1 @@
+ZO-4649: Configure max retries for speech webhook celery task

--- a/core/src/zeit/speech/json/webhook.py
+++ b/core/src/zeit/speech/json/webhook.py
@@ -63,7 +63,9 @@ def SPEECH_WEBHOOK_TASK(self, payload: dict):
             speech.delete(payload)
     except zeit.cms.checkout.interfaces.CheckinCheckoutError:
         config = zope.app.appsetup.product.getProductConfiguration('zeit.speech')
-        self.retry(countdown=int(config['retry-delay-seconds']))
+        self.retry(
+            countdown=int(config['retry-delay-seconds']), max_retries=int(config['max-retries'])
+        )
 
 
 def validate_request(payload: dict):

--- a/core/src/zeit/speech/testing.py
+++ b/core/src/zeit/speech/testing.py
@@ -17,6 +17,7 @@ product_config = """\
   principal zope.speech
   speech-folder tts
   retry-delay-seconds 0
+  max-retries 1
 </product-config>
 """
 


### PR DESCRIPTION
The retry period for the celery task should cover one hour. 
### Checklist

- [x] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~
- [x] Requires https://github.com/ZeitOnline/vivi-deployment/pull/846

### gif
![again](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExazUwMmdudHN2NG1rZ3VraG9zN3VleDFpbW5xMHYwYzZmbm9zMXo2biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7WIQ4FARJdpmUni8/giphy-downsized-large.gif)