### PR TITLE
FIX: Don't try to add pytest mark to doctest, it seems to apply to *all* doctests

### DIFF
--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -9,7 +9,6 @@ from sqlalchemy import text as sql
 from sqlalchemy.exc import OperationalError
 import docker
 import plone.testing
-import pytest
 import requests
 import sqlalchemy
 import transaction
@@ -320,7 +319,6 @@ class TestCase(zeit.cms.testing.FunctionalTestCase):
         )
 
 
-@pytest.mark.slow()
 class ConnectorTest(TestCase):
     layer = REAL_CONNECTOR_LAYER
     level = 2
@@ -341,14 +339,6 @@ class SQLTest(TestCase):
 def FunctionalDocFileSuite(*paths, **kw):
     kw['package'] = 'zeit.connector'
     return zeit.cms.testing.FunctionalDocFileSuite(*paths, **kw)
-
-
-def mark_doctest_suite(suite, mark):
-    # Imitate pytest magic, see _pytest.python.transfer_markers
-    for test in suite:
-        func = test.runTest.__func__
-        mark(func)
-        test.runTest = func.__get__(test)
 
 
 def print_tree(connector, base):

--- a/core/src/zeit/connector/tests/test_doctest.py
+++ b/core/src/zeit/connector/tests/test_doctest.py
@@ -1,7 +1,5 @@
 import unittest
 
-import pytest
-
 import zeit.cms.testing
 import zeit.connector.connector
 import zeit.connector.testing
@@ -23,7 +21,6 @@ def test_suite():
         'invalidation-events.txt',
         layer=zeit.connector.testing.ZOPE_CONNECTOR_LAYER,
     )
-    zeit.connector.testing.mark_doctest_suite(functional, pytest.mark.slow)
     suite.addTest(functional)
 
     suite.addTest(zeit.cms.testing.DocFileSuite('search.txt', package='zeit.connector'))

--- a/core/src/zeit/connector/tests/test_doctest2.py
+++ b/core/src/zeit/connector/tests/test_doctest2.py
@@ -1,5 +1,3 @@
-import pytest
-
 import zeit.cms.testing
 import zeit.connector.connector
 import zeit.connector.testing
@@ -8,7 +6,7 @@ import zeit.connector.testing
 def test_suite():
     # Need to put this into a separate file, otherwise gocept.pytestlayers
     # does not tear down other layers before running this.
-    suite = zeit.connector.testing.FunctionalDocFileSuite(
+    return zeit.connector.testing.FunctionalDocFileSuite(
         'locking.txt',
         'resource.txt',
         'search-ft.txt',
@@ -17,5 +15,3 @@ def test_suite():
         # 'stressing.txt',
         layer=zeit.connector.testing.REAL_CONNECTOR_LAYER,
     )
-    zeit.connector.testing.mark_doctest_suite(suite, pytest.mark.slow)
-    return suite

--- a/core/src/zeit/pytest.py
+++ b/core/src/zeit/pytest.py
@@ -18,9 +18,4 @@ def pytest_configure(config):
     config.addinivalue_line(
         'markers', 'integration: Thirdparty integration tests are not run by default.'
     )
-    config.addinivalue_line(
-        'markers',
-        'slow: This is a non-unit test and thus is not run by '
-        'default. Use ``-m slow`` to run these, or ``-m 1`` to run all tests.',
-    )
     config.addinivalue_line('markers', 'selenium: Selenium tests are not run by default.')


### PR DESCRIPTION
I noticed that no doctests are collected when running with our default of `bin/test -m 'not slow'`, which is way more harmful for developing than maybe having to explicitly select some tests in zeit.connector.