### PR TITLE
ZO-4687: Make date_last_modified independent of DAV server

### DIFF
--- a/core/docs/changelog/ZO-4687.change
+++ b/core/docs/changelog/ZO-4687.change
@@ -1,0 +1,1 @@
+ZO-4687: Make date_last_modified independent of DAV server

--- a/core/src/zeit/cms/content/dublincore.py
+++ b/core/src/zeit/cms/content/dublincore.py
@@ -2,7 +2,9 @@ import grokcore.component as grok
 import pendulum
 import zope.dublincore.interfaces
 
+from zeit.cms.content.interfaces import WRITEABLE_LIVE
 import zeit.cms.content.dav
+import zeit.cms.interfaces
 import zeit.cms.repository.interfaces
 import zeit.cms.workingcopy.interfaces
 
@@ -15,7 +17,10 @@ class RepositoryDCTimes(zeit.cms.content.dav.DAVPropertiesAdapter):
         zope.dublincore.interfaces.IDCTimes['created'], 'DAV:', 'creationdate'
     )
     modified = zeit.cms.content.dav.DAVProperty(
-        zope.dublincore.interfaces.IDCTimes['modified'], 'DAV:', 'getlastmodified'
+        zope.dublincore.interfaces.IDCTimes['modified'],
+        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
+        'date-last-modified',
+        writeable=WRITEABLE_LIVE,
     )
 
 


### PR DESCRIPTION
Let's inspect all the failing tests 🤞 the [connector](https://github.com/ZeitOnline/vivi/blob/main/core/src/zeit/connector/connector.py#L210) is suspicious
### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

### gif
![jawdrapping](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGZsdG5kemVjNGQwMjQ5emF5YXV6dGpsMjJheG1sZXI1ajd5eDE3dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7WTMQQfvtQ2LKisM/giphy.gif)