### PR TITLE
ZO-4687: Remove publish grace workaround

### DIFF
--- a/core/src/zeit/cms/workflow/interfaces.py
+++ b/core/src/zeit/cms/workflow/interfaces.py
@@ -15,14 +15,6 @@ CAN_RETRACT_WARNING = 'can-retract-warning'
 CAN_RETRACT_SUCCESS = 'can-retract-success'
 
 
-# During the checkout/checkin cycle() while publishing the object will be most
-# likely changed. It therefore would have a modified timestamp _after_ the
-# publication timestamp and would be shown as "published with changes", so we
-# need to be a little more lenient. (Since we cannot change `modified`, which
-# belongs to the DAV server and cannot be written by clients).
-PUBLISH_DURATION_GRACE = 60
-
-
 class PublishingError(Exception):
     """Raised when object publishing fails."""
 

--- a/core/src/zeit/cms/workflow/status.py
+++ b/core/src/zeit/cms/workflow/status.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import grokcore.component as grok
 import zope.component
 import zope.interface
@@ -20,12 +18,7 @@ class PublicationStatus(grok.Adapter):
         if not info.published:
             return 'not-published'
         modified = zeit.cms.workflow.interfaces.IModified(self.context).date_last_modified
-        grace = zeit.cms.workflow.interfaces.PUBLISH_DURATION_GRACE
-        if (
-            not modified
-            or not info.date_last_published
-            or info.date_last_published + timedelta(seconds=grace) > modified
-        ):
+        if not modified or not info.date_last_published or info.date_last_published > modified:
             return 'published'
         return 'published-with-changes'
 

--- a/core/src/zeit/cms/workflow/status.txt
+++ b/core/src/zeit/cms/workflow/status.txt
@@ -12,13 +12,10 @@ fudge factor. For this test we remove that (to increase readability):
 >>> zeit.cms.testing.set_site()
 >>> principal = zeit.cms.testing.create_interaction()
 
->>> import zeit.cms.workflow.interfaces
->>> old_grace = zeit.cms.workflow.interfaces.PUBLISH_DURATION_GRACE
->>> zeit.cms.workflow.interfaces.PUBLISH_DURATION_GRACE = 0
-
 Initially content is not published:
 
 >>> import zeit.cms.interfaces
+>>> import zeit.cms.workflow.interfaces
 >>> content = zeit.cms.interfaces.ICMSContent(
 ...     'http://xml.zeit.de/testcontent')
 >>> status = zeit.cms.workflow.interfaces.IPublicationStatus(content)
@@ -62,4 +59,3 @@ Clean up
 
 >>> zeit.cms.workflow.mock._published.clear()
 >>> zeit.cms.workflow.mock._publish_times.clear()
->>> zeit.cms.workflow.interfaces.PUBLISH_DURATION_GRACE = old_grace


### PR DESCRIPTION
We now control the modified timestamp ourselves (and intentionally do not update it at the publishing cycle checkin)