### PR TITLE
MAINT: rename JENKINS_BATOU_BRANCH to DEPLOYMENT_BRANCH in testrunner

### DIFF
--- a/.github/workflows/testrunner.yaml
+++ b/.github/workflows/testrunner.yaml
@@ -34,7 +34,7 @@ jobs:
                 branch="main"
             else
                 branch=$(echo -e "${{github.event.pull_request.body}}" | \
-                    sed -ne '/JENKINS_BATOU_BRANCH=/s/JENKINS_BATOU_BRANCH=//p' | \
+                    sed -ne '/DEPLOYMENT_BRANCH=/s/DEPLOYMENT_BRANCH=//p' | \
                     tr --delete ' \r\n')
                 if [[ -z "$branch" ]]; then
                     branch=main


### PR DESCRIPTION
Die Variable um auf den richtigen Friedbert Deployment Branch zu verweisen heißt noch JENKINS_BATOU_BRANCH. Lass uns lieber was allgemeineres nehmen wie z.B. DEPLOYMENT_BRANCH