### PR TITLE
ZO-4801: Display request errors that occur in JS forms

### DIFF
--- a/core/docs/changelog/ZO-4801-error.change
+++ b/core/docs/changelog/ZO-4801-error.change
@@ -1,1 +1,1 @@
-ZO-4801: Display request errors that occur in JS forms
+ZO-4801: Display request errors that occur in JS forms (toggle: `inlineform_alert_error`)

--- a/core/docs/changelog/ZO-4801-error.change
+++ b/core/docs/changelog/ZO-4801-error.change
@@ -1,0 +1,1 @@
+ZO-4801: Display request errors that occur in JS forms

--- a/core/src/zeit/cms/browser/js/base.js
+++ b/core/src/zeit/cms/browser/js/base.js
@@ -282,6 +282,7 @@ zeit.cms.with_lock = function(callable) {
     });
     d.addErrback(function(error) {
         zeit.cms.log_error(error);
+        return error;
     });
     d.addBoth(function(result_or_error) {
         zeit.cms.request_lock.release();

--- a/core/src/zeit/cms/browser/js/form.js
+++ b/core/src/zeit/cms/browser/js/form.js
@@ -94,7 +94,9 @@ zeit.cms.SubPageForm = gocept.Class.extend({
         d.addCallbacks(
             MochiKit.Base.bind(self.replace_content, self),
             function(error) {
-                alert('Ein Systemfehler ist aufgetreten: ' + error.req.responseText);
+                if (window.feature_toggles.inlineform_alert_error) {
+                    alert('Ein Systemfehler ist aufgetreten: ' + error.req.responseText);
+                }
             });
         d.addCallback(MochiKit.Base.bind(self.process_post_result, self));
         d.addCallback(function(result) {

--- a/core/src/zeit/cms/browser/js/form.js
+++ b/core/src/zeit/cms/browser/js/form.js
@@ -94,7 +94,6 @@ zeit.cms.SubPageForm = gocept.Class.extend({
         d.addCallbacks(
             MochiKit.Base.bind(self.replace_content, self),
             function(error) {
-                logError(error.req.status, error.req.statusText);
                 var parser = new DOMParser();
                 var doc = parser.parseFromString(
                     error.req.responseText, "text/xml");

--- a/core/src/zeit/cms/browser/js/form.js
+++ b/core/src/zeit/cms/browser/js/form.js
@@ -94,10 +94,7 @@ zeit.cms.SubPageForm = gocept.Class.extend({
         d.addCallbacks(
             MochiKit.Base.bind(self.replace_content, self),
             function(error) {
-                var parser = new DOMParser();
-                var doc = parser.parseFromString(
-                    error.req.responseText, "text/xml");
-                document.firstChild.nextSibling.nextSibling.innerHTML = doc.firstChild.nextSibling.innerHTML;
+                alert('Ein Systemfehler ist aufgetreten: ' + error.req.responseText);
             });
         d.addCallback(MochiKit.Base.bind(self.process_post_result, self));
         d.addCallback(function(result) {

--- a/core/src/zeit/cms/browser/main_template.pt
+++ b/core/src/zeit/cms/browser/main_template.pt
@@ -37,6 +37,7 @@
         <script type="text/javascript" tal:content="string:
           var application_url = '${request/getApplicationURL}';
           var context_url = '${context/@@absolute_url}';
+          var feature_toggles = ${context/@@standard_macros/toggles_as_json};
         "/>
         <tal:comment condition="nothing">
           Make sure that application_url and context_url are available

--- a/core/src/zeit/cms/browser/standardmacros.py
+++ b/core/src/zeit/cms/browser/standardmacros.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import json
 
 import zope.app.appsetup.product
 import zope.app.basicskin.standardmacros
@@ -6,6 +7,7 @@ import zope.component
 import zope.location.interfaces
 import zope.security.proxy
 
+from zeit.cms.content.sources import FEATURE_TOGGLES
 import zeit.cms.browser
 import zeit.cms.browser.interfaces
 import zeit.cms.browser.resources
@@ -68,3 +70,7 @@ class StandardMacros(zope.app.basicskin.standardmacros.StandardMacros):
             return importlib.metadata.version('vivi.core')
         except Exception:
             return 'version not found'
+
+    @property
+    def toggles_as_json(self):
+        return json.dumps(FEATURE_TOGGLES.factory._values())

--- a/core/src/zeit/cms/browser/tests/test_standardmacros.py
+++ b/core/src/zeit/cms/browser/tests/test_standardmacros.py
@@ -1,0 +1,18 @@
+from zeit.cms.content.sources import FEATURE_TOGGLES
+import zeit.cms.testing
+
+
+class MainTemplateTest(zeit.cms.testing.ZeitCmsBrowserTestCase):
+    def test_passes_feature_toggles_to_javascript(self):
+        b = self.browser
+        b.open('/repository')
+        self.assertEllipsis(
+            '...var feature_toggles = {..."article_agencies": true, ...};...', b.contents
+        )
+
+        # Test overrides also work
+        FEATURE_TOGGLES.unset('article_agencies')
+        b.open('/repository')
+        self.assertEllipsis(
+            '...var feature_toggles = {..."article_agencies": false, ...};...', b.contents
+        )

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -5,6 +5,7 @@
   <author_lookup_in_hdok>true</author_lookup_in_hdok>
   <content_caching>true</content_caching>
   <embed_cmp_thirdparty>true</embed_cmp_thirdparty>
+  <inlineform_alert_error>true</inlineform_alert_error>
   <breakingnews_with_channel>true</breakingnews_with_channel>
   <push_new_articles_ua_author_tag>true</push_new_articles_ua_author_tag>
   <reference_index>true</reference_index>

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -481,6 +481,15 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
     def _overrides(self):
         return {}
 
+    def getValues(self, context):
+        return [k for k, v in self._values().items() if v]
+
+    def _values(self):
+        tree = self._get_tree()
+        result = {node.tag: bool(node) for node in tree.xpath('//*') if not node.getchildren()}
+        result.update(self._overrides())
+        return result
+
 
 FEATURE_TOGGLES = FeatureToggleSource()(None)
 


### PR DESCRIPTION
We'll regret this if the server ever sends a full error page with styles and everything...