### PR TITLE
ZO-4776: changelog entry for ZO-4776_replace-forwared-links-by-their-…

### DIFF
--- a/core/docs/changelog/ZO-4776.change
+++ b/core/docs/changelog/ZO-4776.change
@@ -1,0 +1,1 @@
+ZO-4776: replace rankings.zeit.de URLs by studiengaenge.zeit.de (vivi-deployment)


### PR DESCRIPTION
changes for https://github.com/ZeitOnline/vivi-deployment/pull/870