### PR TITLE
ZO-4267: Update ZopeConnector to changed unlock() API

### DIFF
--- a/core/docs/changelog/ZO-4267-unlock.change
+++ b/core/docs/changelog/ZO-4267-unlock.change
@@ -1,0 +1,1 @@
+ZO-4267-unlock: Fix unlock API for zope cache connector

--- a/core/src/zeit/connector/connector.py
+++ b/core/src/zeit/connector/connector.py
@@ -407,6 +407,7 @@ class Connector:
         if locktoken:
             self._unlock(id, locktoken)
             self._invalidate_cache(id)
+        return locktoken  # Needed for cleanup in ZopeConnector
 
     def _unlock(self, id, locktoken):
         url = self._id2loc(self._get_cannonical_id(id))

--- a/core/src/zeit/connector/connector.py
+++ b/core/src/zeit/connector/connector.py
@@ -370,12 +370,18 @@ class Connector:
 
         # Update property cache
         del properties[('cached-time', 'INTERNAL')]
+        remove = []
+        for key, value in properties.items():
+            if value is zeit.connector.interfaces.DeleteProperty:
+                remove.append(key)
         try:
             cached_properties = self.property_cache[id]
         except KeyError:
             pass
         else:
             cached_properties.update(properties)
+            for key in remove:
+                del cached_properties[key]
             self.property_cache[id] = cached_properties
 
     def lock(self, id, principal, until):

--- a/core/src/zeit/connector/locking.txt
+++ b/core/src/zeit/connector/locking.txt
@@ -1,18 +1,6 @@
 Locking tests
 =============
 
-Setup
-+++++
-
-Make unlock visible:
-
->>> from zeit.connector.dav.davconnection import DAVConnection
->>> orig_unlock = DAVConnection.unlock
->>> def unlock_print(self, url, locktoken, headers=None):
-...     print(locktoken)
-...     orig_unlock(self, url, locktoken, headers)
->>> DAVConnection.unlock = unlock_print
-
 Simple case
 +++++++++++
 
@@ -28,7 +16,6 @@ Simple case
 ...     BytesIO(b'Pop goes the weasel!'),
 ...     contentType='text/plain')
 >>> connector.add(res)
-opaquelocktoken:...
 >>> connector.lock(res.id, 'zope.user', until=None)
 'opaquelocktoken:...'
 
@@ -38,7 +25,7 @@ Traceback (most recent call last):
 LockingError: http://xml.zeit.de/testing.../lt1 is already locked.
 
 >>> connector.unlock(res.id)
-opaquelocktoken:...
+'opaquelocktoken:...'
 >>> del connector[res.id]
 
 Timeout of locks
@@ -71,9 +58,7 @@ We unlock the resource under the hood and of course expect that we can add it:
 >>> token = connector.lock(res.id, 'zope.user', until=None)
 >>> ignore = connector[res.id]  # fill cache again
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 >>> connector.add(res)
-opaquelocktoken:...
 >>> connector.unlock(res.id)
 >>> del connector[res.id]
 
@@ -81,13 +66,10 @@ Edge case 1.1: With existing resource:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge1.1'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> token = connector.lock(res.id, 'zope.user', until=None)
 >>> ignore = connector[res.id]  # fill cache again
->>> dummy = connector._unlock(res.id, token)
-opaquelocktoken:...
+>>> connector._unlock(res.id, token)
 >>> connector.add(res)
-opaquelocktoken:...
 >>> connector.unlock(res.id)
 >>> del connector[res.id]
 
@@ -95,11 +77,9 @@ Edge case 1.2: Unlocking:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge1.2'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> token = connector.lock(res.id, 'zope.user', until=None)
 >>> ignore = connector[res.id]  # fill cache again
->>> dummy = connector._unlock(res.id, token)
-opaquelocktoken:...
+>>> connector._unlock(res.id, token)
 >>> connector.unlock(res.id)
 >>> del connector[res.id]
 
@@ -118,13 +98,11 @@ Traceback (most recent call last):
     ...
 zeit.connector.interfaces.LockedByOtherSystemError: ('external', datetime.datetime(...))
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 
 Edge case 2.1: With existing resource:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge2.1'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> ignore = connector[res.id]  # fill cache again
 >>> url = connector._id2loc(res.id)
 >>> token = connector.get_connection().lock(
@@ -134,14 +112,12 @@ Traceback (most recent call last):
     ...
 zeit.connector.interfaces.LockedByOtherSystemError: ('external', datetime.datetime(...))
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 Edge case 2.2: Locking
 
 >>> res.id = 'http://xml.zeit.de/testing/edge2.2'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> ignore = connector[res.id]  # fill cache again
 >>> url = connector._id2loc(res.id)
 >>> token = connector.get_connection().lock(
@@ -151,14 +127,12 @@ Traceback (most recent call last):
     ...
 LockingError: http://xml.zeit.de/testing.../edge2.2 is already locked.
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 Edge case 2.3: PROPATCH
 
 >>> res.id = 'http://xml.zeit.de/testing/edge2.3'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> ignore = connector[res.id]  # fill cache again
 >>> url = connector._id2loc(res.id)
 >>> token = connector.get_connection().lock(
@@ -171,7 +145,6 @@ zeit.connector.dav.interfaces.DAVLockedError: (423, 'Locked',
     '<!DOCTYPE...
 
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 
@@ -185,7 +158,6 @@ API to create an anonymous lock. Create a resource first:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge3'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> ignore = connector[res.id]  # fill cache again
 
 Now lock:
@@ -203,7 +175,6 @@ LockedByOtherSystemError: (None, datetime.datetime(9998, 12, 31, 23, 59, 59, 999
 Unlock the resource and remove it:
 
 >>> dummy = connector.get_connection().unlock(dav_url, token)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 
@@ -212,13 +183,11 @@ Edge case 4: We think the resource is locked but it is by somebody else
 
 >>> res.id = 'http://xml.zeit.de/testing/edge4'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> ignore = connector[res.id]  # fill cache again
 >>> token = connector.lock(res.id, 'zope.user', until=None)
 >>> r2 = connector[res.id]
 >>> url = connector._id2loc(res.id)
 >>> dummy = connector.get_connection().unlock(url, token)
-opaquelocktoken:...
 >>> new_token = connector.get_connection().lock(
 ...     url, owner='external', depth=0, timeout=20)
 >>> connector.add(res)
@@ -226,9 +195,7 @@ Traceback (most recent call last):
     ...
 zeit.connector.interfaces.LockedByOtherSystemError: ('external', datetime.datetime(...))
 >>> connector._unlock(res.id, new_token)
-opaquelocktoken:...
 >>> connector.add(res)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 Edge case 5: Null resouce locks
@@ -240,7 +207,7 @@ Edge case 5: Null resouce locks
 >>> connector[res.id].data
 <...BytesIO object at 0x...>
 >>> connector.unlock(res.id)
-opaquelocktoken:...
+'opaquelocktoken:...'
 
 
 Locking with timeout:
@@ -249,7 +216,6 @@ Locking with timeout:
 >>> import pytz
 >>> res.id = 'http://xml.zeit.de/testing/edge6'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> connector.lock(res.id, 'zope.user',
 ...     datetime.datetime.now(pytz.UTC) + datetime.timedelta(seconds=120))
 'opaquelocktoken:...'
@@ -269,7 +235,6 @@ Create resource:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge6'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> connector[res.id].data.read()
 b'Pop goes the weasel!'
 
@@ -299,7 +264,7 @@ b''
 True
 
 >>> connector.unlock(res.id)
-opaquelocktoken:...
+'opaquelocktoken:...'
 
 
 Edge case 7: Getting the lock information when the lockinfo got lost
@@ -330,7 +295,6 @@ When we don't know the principal, the resource will be "LockedByOtherSystem":
 
 >>> res.id = 'http://xml.zeit.de/testing/edge7.1'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> token = connector.lock(res.id, 'external', until=None)
 >>> connector.locked(res.id)
 ('external', datetime.datetime(9998, 12, 31, 23, 59, 59, 999999, tzinfo=<UTC>),
@@ -340,14 +304,12 @@ Traceback (most recent call last):
     ...
 LockedByOtherSystemError: ('external', datetime.datetime(...))
 >>> connector._unlock(res.id, token)
-opaquelocktoken:...
 >>> del connector[res.id]
 
 When we know the principal, it is "our" lock:
 
 >>> res.id = 'http://xml.zeit.de/testing/edge7.2'
 >>> connector.add(res)
-opaquelocktoken:...
 >>> token = connector.lock(res.id, 'internal', until=None)
 >>> connector.locked(res.id)
 ('internal', datetime.datetime(9998, 12, 31, 23, 59, 59, 999999, tzinfo=<UTC>),
@@ -355,9 +317,3 @@ opaquelocktoken:...
 >>> del connector[res.id]
 >>> gsm.unregisterUtility(auth)
 True
-
-
-Teardown
-++++++++
-
->>> DAVConnection.unlock = orig_unlock

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -352,6 +352,22 @@ class ContractDAV(
     copy_inherited_functions(ContractSearch, locals())
 
 
+class ContractZopeDAV(
+    ContractReadWrite,
+    ContractCopyMove,
+    ContractLock,
+    ContractSearch,
+    zeit.connector.testing.ConnectorTest,
+):
+    layer = zeit.connector.testing.ZOPE_CONNECTOR_LAYER
+    shortened_uuid = False
+
+    copy_inherited_functions(ContractReadWrite, locals())
+    copy_inherited_functions(ContractCopyMove, locals())
+    copy_inherited_functions(ContractLock, locals())
+    copy_inherited_functions(ContractSearch, locals())
+
+
 class ContractMock(
     ContractReadWrite,
     ContractCopyMove,

--- a/core/src/zeit/connector/zopeconnector.py
+++ b/core/src/zeit/connector/zopeconnector.py
@@ -51,8 +51,8 @@ class ZopeConnector(zeit.connector.connector.Connector):
         datamanager.add_cleanup(self._unlock, id, locktoken)
         return locktoken
 
-    def unlock(self, id, locktoken=None):
-        locktoken = super().unlock(id, locktoken)
+    def unlock(self, id):
+        locktoken = super().unlock(id)
         self.get_datamanager().remove_cleanup(self._unlock, id, locktoken)
         return locktoken
 


### PR DESCRIPTION
See https://app.bugsnag.com/zeit-online-gmbh/vivi/errors/65ce29c518f4b10008a1f621
```
  File "/srv/vivi/deployment/work/app/lib/python3.10/site-packages/zeit/workflow/publish.py", line 346,
in unlock
    lockable.unlock()
  File "/srv/vivi/deployment/work/app/lib/python3.10/site-packages/zope/app/locking/adapter.py", line 87
, in unlock
    self.storage.delLock(self.context)
  File "/srv/vivi/deployment/work/app/lib/python3.10/site-packages/zeit/cms/locking/locking.py", line 62
, in delLock
    self.connector.unlock(object.uniqueId)
  File "/srv/vivi/deployment/work/app/lib/python3.10/site-packages/zeit/connector/zopeconnector.py", lin
e 55, in unlock
    locktoken = super().unlock(id, locktoken)
TypeError: Connector.unlock() takes 2 positional arguments but 3 were given
```

### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~