### PR TITLE
ZO-4799: Remove obsolete rules about force_mobile_image defaults

### DIFF
--- a/core/docs/changelog/ZO-4799.change
+++ b/core/docs/changelog/ZO-4799.change
@@ -1,0 +1,1 @@
+ZO-4799: Remove obsolete rules about force_mobile_image defaults

--- a/core/src/zeit/content/cp/blocks/automatic.py
+++ b/core/src/zeit/content/cp/blocks/automatic.py
@@ -12,12 +12,6 @@ class AutomaticTeaserBlock(
     zeit.content.cp.blocks.teaser.Layoutable, zeit.content.cp.blocks.block.Block
 ):
     type = 'auto-teaser'
-
-    # XXX copy&paste from TeaserBlock
-    force_mobile_image = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'force_mobile_image', zeit.content.cp.interfaces.ITeaserBlock['force_mobile_image']
-    )
-
     volatile = True  # Override to use default=True
 
     def __init__(self, context, xml):

--- a/core/src/zeit/content/cp/blocks/configure.zcml
+++ b/core/src/zeit/content/cp/blocks/configure.zcml
@@ -36,10 +36,10 @@
 
   <class class=".automatic.AutomaticTeaserBlock">
     <require
-      interface="..interfaces.IReadAutomaticTeaserBlock"
+      interface="..interfaces.IReadTeaserBlock"
       permission="zope.View"/>
     <require
-      set_schema="..interfaces.IReadAutomaticTeaserBlock"
+      set_schema="..interfaces.IReadTeaserBlock"
       permission="zeit.EditContent"/>
     <require
       interface="..interfaces.IWriteAutomaticTeaserBlock"

--- a/core/src/zeit/content/cp/blocks/teaser.py
+++ b/core/src/zeit/content/cp/blocks/teaser.py
@@ -108,14 +108,6 @@ def make_block_from_content(container, content, position):
     return block
 
 
-@grok.adapter(zeit.content.cp.interfaces.IArea, zeit.content.gallery.interfaces.IGallery, int)
-@grok.implementer(zeit.edit.interfaces.IElement)
-def make_block_from_gallery(container, content, position):
-    block = make_block_from_content(container, content, position)
-    block.force_mobile_image = True
-    return block
-
-
 @grok.adapter(zeit.content.cp.interfaces.ITeaserBlock)
 @grok.implementer(zeit.edit.interfaces.IElementReferences)
 def cms_content_iter(context):

--- a/core/src/zeit/content/cp/blocks/tests/test_automatic.py
+++ b/core/src/zeit/content/cp/blocks/tests/test_automatic.py
@@ -50,17 +50,3 @@ class AutomaticTeaserBlockTest(zeit.content.cp.testing.FunctionalTestCase):
         self.elastic.search.return_value.hits = 1
         teaser = duo_region.values()[0]
         self.assertEqual('two-side-by-side', teaser.layout.id)
-
-    def test_automatic_teaser_block_should_not_force_mobile_image(self):
-        self.repository['t1'] = ExampleContentType()
-        cp = self.repository['cp']
-        region = cp.body['feature'].create_item('area')
-        region.kind = 'major'
-        region.count = 1
-        region.automatic = True
-        region.automatic_type = 'query'
-
-        self.elastic.search.return_value = zeit.cms.interfaces.Result([{'url': '/t1'}])
-        self.elastic.search.return_value.hits = 1
-        teaser = region.values()[0]
-        self.assertFalse(teaser.force_mobile_image)

--- a/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
+++ b/core/src/zeit/content/cp/browser/blocks/tests/test_teaser.py
@@ -212,14 +212,6 @@ class FunctionalTeaserDisplayTest(zeit.content.cp.testing.FunctionalTestCase):
         self.assertEqual('Foo', view.teasers[0]['texts'][2]['content'])
         self.assertEqual('Zitat:', view.teasers[0]['texts'][1]['content'])
 
-    def test_gallery_teaser_forces_mobile_image(self):
-        self.repository['gallery'] = self.create_gallery()
-        container = self.cp.body.create_item('region').create_item('area')
-        block = zope.component.getMultiAdapter(
-            (container, self.repository['gallery'], 0), zeit.edit.interfaces.IElement
-        )
-        assert block.force_mobile_image
-
     def test_teaser_forces_mobile_image_per_default(self):
         assert self.create_teaserimage_block('large').force_mobile_image
 

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -572,12 +572,6 @@ class ILocalTeaserBlock(IReadLocalTeaserBlock, IWriteLocalTeaserBlock, ITeaserBl
     """Teaser module that allows overriding title/text/image"""
 
 
-class IReadAutomaticTeaserBlock(IReadTeaserBlock):
-    force_mobile_image = zope.schema.Bool(
-        title=_('Force image on mobile'), required=False, default=False
-    )
-
-
 class IWriteAutomaticTeaserBlock(IWriteTeaserBlock):
     def change_layout(layout):
         """Temporarily change the layout (for the duration of one area.values()
@@ -589,7 +583,7 @@ class IWriteAutomaticTeaserBlock(IWriteTeaserBlock):
         """
 
 
-class IAutomaticTeaserBlock(IReadAutomaticTeaserBlock, IWriteAutomaticTeaserBlock, ITeaserBlock):
+class IAutomaticTeaserBlock(IReadTeaserBlock, IWriteAutomaticTeaserBlock, ITeaserBlock):
     pass
 
 


### PR DESCRIPTION
### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~