### PR TITLE
ZO-4886: check locking

### DIFF
--- a/core/docs/changelog/ZO-4886.change
+++ b/core/docs/changelog/ZO-4886.change
@@ -1,0 +1,1 @@
+ZO-4886: Do not write to locked object

--- a/core/src/zeit/cms/content/template.py
+++ b/core/src/zeit/cms/content/template.py
@@ -1,5 +1,6 @@
 import persistent
 import zc.sourcefactory.basic
+import zope.annotation
 import zope.container.btree
 import zope.container.contained
 import zope.interface

--- a/core/src/zeit/connector/lock.py
+++ b/core/src/zeit/connector/lock.py
@@ -1,0 +1,15 @@
+from zope.component import queryUtility
+
+
+def lock_is_foreign(principal):
+    try:
+        import zope.authentication.interfaces  # UI-only dependency
+
+        authentication = queryUtility(zope.authentication.interfaces.IAuthentication)
+    except ImportError:
+        return True
+    try:
+        authentication.getPrincipal(principal)
+    except zope.authentication.interfaces.PrincipalLookupError:
+        return True
+    return False

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -107,6 +107,9 @@ class Connector(zeit.connector.filesystem.Connector):
     def __setitem__(self, id, object):
         resource = zeit.connector.interfaces.IResource(object)
         id = self._get_cannonical_id(id)
+        (_, _, mylock) = self.locked(id)
+        if id in self._locked and not mylock:
+            raise LockedByOtherSystemError(id, '')
         iscoll = resource.type == 'collection' or resource.contentType == 'httpd/unix-directory'
         if iscoll and not id.endswith('/'):
             id = CannonicalId(id + '/')

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -210,7 +210,8 @@ class Connector(zeit.connector.filesystem.Connector):
 
     def move(self, old_id, new_id):
         self._prevent_overwrite(old_id, new_id, MoveError)
-        if old_id in self._locked and lock_is_foreign(self._locked[old_id][0]):
+        (_, _, mylock) = self.locked(old_id)
+        if id in self._locked and not mylock:
             raise LockedByOtherSystemError(old_id, '')
         r = self[old_id]
 
@@ -225,7 +226,8 @@ class Connector(zeit.connector.filesystem.Connector):
         if not new_id.endswith('/'):
             new_id = new_id + '/'
         for name, uid in self.listCollection(old_id):
-            if uid in self._locked and lock_is_foreign(self._locked[uid][0]):
+            (_, _, mylock) = self.locked(uid)
+            if id in self._locked and not mylock:
                 raise LockedByOtherSystemError(uid, '')
             self.move(uid, urllib.parse.urljoin(new_id, name))
         del self[old_id]

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -206,6 +206,8 @@ class Connector(zeit.connector.filesystem.Connector):
 
     def move(self, old_id, new_id):
         self._prevent_overwrite(old_id, new_id, MoveError)
+        if old_id in self._locked and self._locked[old_id][0] != 'zope.user':
+            raise LockedByOtherSystemError(old_id, '')
         r = self[old_id]
 
         if new_id in self:

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -259,7 +259,7 @@ class Connector(zeit.connector.filesystem.Connector):
     def lock(self, id, principal, until):
         """Lock resource for principal until a given datetime."""
         id = self._get_cannonical_id(id)
-        my_lock = not lock_is_foreign(principal)
+        (_, _, my_lock) = self.locked(id)
         if id in self._locked:
             raise LockingError('Resource is already locked by another principal')
         self._locked[id] = (principal, until, my_lock)
@@ -273,7 +273,10 @@ class Connector(zeit.connector.filesystem.Connector):
 
     def locked(self, id):
         id = self._get_cannonical_id(id)
-        return self._locked.get(id, (None, None, False))
+        (lock_principal, until, my_lock) = self._locked.get(id, (None, None, False))
+        if lock_principal:
+            my_lock = not lock_is_foreign(lock_principal)
+        return (lock_principal, until, my_lock)
 
     search_result_default = [
         'http://xml.zeit.de/online/2007/01/Somalia',

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -247,6 +247,9 @@ class Connector(zeit.connector.filesystem.Connector):
 
     def changeProperties(self, id, properties):
         id = self._get_cannonical_id(id)
+        (_, _, mylock) = self.locked(id)
+        if id in self._locked and not mylock:
+            raise LockedByOtherSystemError(id, '')
         properties.pop(zeit.connector.interfaces.UUID_PROPERTY, None)
         self._set_properties(id, properties)
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -248,6 +248,9 @@ class Connector:
         content = self._get_content(uniqueid)
         if content is None:
             raise KeyError(f'The resource {uniqueid} does not exist.')
+        status = self._get_lock_status(uniqueid)
+        if status == LockStatus.FOREIGN:
+            raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
         current = content.to_webdav()
         current.update(properties)
         content.from_webdav(current)

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -22,7 +22,6 @@ from sqlalchemy import (
     UnicodeText,
     UniqueConstraint,
     Uuid,
-    schema,
     select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -570,11 +569,17 @@ class Content(DBObject):
 class Lock(DBObject):
     __tablename__ = 'locks'
 
-    id = Column(Uuid(as_uuid=False), primary_key=True)
+    id = Column(Uuid(as_uuid=False), ForeignKey('properties.id'), primary_key=True)
     principal = Column(Unicode, nullable=False)
     until = Column(TIMESTAMP(timezone=True), nullable=False)
 
-    __table_args__ = (schema.ForeignKeyConstraint(['id'], ['properties.id']),)
+    content = relationship(
+        'Content',
+        uselist=False,
+        # Not used in code, but needed to let sqlalchemy know about
+        # relationship between mapped classes
+        lazy='noload',
+    )
 
     @property
     def token(self):

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -211,6 +211,9 @@ class Connector:
             self.session.add(path)
         else:
             path = content.path
+            status = self._get_lock_status(uniqueid)
+            if status == LockStatus.FOREIGN:
+                raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
 
         (path.parent_path, path.name) = self._pathkey(uniqueid)
         content.from_webdav(resource.properties)

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -195,9 +195,6 @@ class Connector:
 
     def __setitem__(self, uniqueid, resource):
         resource.id = uniqueid
-        status = self._get_lock_status(resource.id)
-        if status == LockStatus.FOREIGN:
-            raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
         self.add(resource)
 
     def add(self, resource, verify_etag=True):

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -195,6 +195,9 @@ class Connector:
 
     def __setitem__(self, uniqueid, resource):
         resource.id = uniqueid
+        status = self._get_lock_status(resource.id)
+        if status == LockStatus.FOREIGN:
+            raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
         self.add(resource)
 
     def add(self, resource, verify_etag=True):

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from io import BytesIO
 import contextlib
 import os
@@ -9,6 +10,7 @@ from sqlalchemy import text as sql
 from sqlalchemy.exc import OperationalError
 import docker
 import plone.testing
+import pytz
 import requests
 import sqlalchemy
 import transaction

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -325,6 +325,12 @@ class TestCase(zeit.cms.testing.FunctionalTestCase):
             rid, name, 'testing', BytesIO(body), properties=properties, contentType=contentType
         )
 
+    def add_resource(self, name, **kw):
+        r = self.get_resource(name, **kw)
+        r = self.connector[r.id] = r
+        transaction.commit()
+        return r
+
 
 class ConnectorTest(TestCase):
     layer = REAL_CONNECTOR_LAYER

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta
 from io import BytesIO
 import contextlib
 import os
@@ -10,7 +9,6 @@ from sqlalchemy import text as sql
 from sqlalchemy.exc import OperationalError
 import docker
 import plone.testing
-import pytz
 import requests
 import sqlalchemy
 import transaction

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -422,6 +422,18 @@ class ContractLock:
         with self.assertRaises(KeyError):
             self.connector['http://xml.zeit.de/testing/foo']
 
+    def test_changeProperties_on_locked_resource_raises(self):
+        self.add_resource('foo', properties={('foo', self.NS): 'foo', ('bar', self.NS): 'bar'})
+        res = self.connector['http://xml.zeit.de/testing/foo']
+        self.assertEqual('foo', res.properties[('foo', self.NS)])
+        self.connector.lock(res.id, 'zope.external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        with self.assertRaises(LockedByOtherSystemError):
+            self.connector.changeProperties(
+                'http://xml.zeit.de/testing/foo',
+                {('foo', self.NS): 'qux', ('baz', self.NS): DeleteProperty},
+            )
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -350,6 +350,15 @@ class ContractLock:
         self.connector._unlock('http://xml.zeit.de/testing/folder/one', token_1)
         self.connector.unlock('http://xml.zeit.de/testing/two')
 
+    def test_setitem_must_not_write_on_locked_object(self):
+        res = self.get_resource('foo', body=b'one')
+        self.connector['http://xml.zeit.de/testing/foo'] = res
+        self.connector.lock(res.id, 'external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        res = self.get_resource('foo', body=b'nope')
+        with self.assertRaises(LockedByOtherSystemError):
+            self.connector['http://xml.zeit.de/testing/foo'] = res
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -388,6 +388,15 @@ class ContractLock:
         with self.assertRaises(LockedByOtherSystemError):
             self.connector.move(uid, 'http://xml.zeit.de/testing/target')
 
+    def test_delete_locked_resource_raises(self):
+        uid = self.add_resource('foo', properties={('bar', self.NS): 'bar'}).id
+        self.connector.lock(uid, 'zope.external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        (principal, _, my_lock) = self.connector.locked('http://xml.zeit.de/testing/foo')
+        self.assertEqual((principal, my_lock), ('zope.external', False))
+        with self.assertRaises(LockedByOtherSystemError):
+            del self.connector['http://xml.zeit.de/testing/foo']
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -359,6 +359,16 @@ class ContractLock:
         with self.assertRaises(LockedByOtherSystemError):
             self.connector['http://xml.zeit.de/testing/foo'] = res
 
+    def test_set_property_on_own_lock_resources(self):
+        uid = self.add_resource('foo', properties={('bar', self.NS): 'bar'}).id
+        self.connector.lock(uid, 'zope.user', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        self.connector.changeProperties(
+            'http://xml.zeit.de/testing/foo',
+            {('bar', self.NS): 'foo'},
+        )
+        transaction.commit()
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -21,12 +21,6 @@ import zeit.connector.testing
 class ContractReadWrite:
     NS = 'http://namespaces.zeit.de/CMS/testing'
 
-    def add_resource(self, name, **kw):
-        r = self.get_resource(name, **kw)
-        r = self.connector[r.id] = r
-        transaction.commit()
-        return r
-
     def listCollection(self, id):  # XXX Why is this a generator?
         return list(self.connector.listCollection(id))
 

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -350,6 +350,13 @@ class ContractLock:
         self.connector._unlock('http://xml.zeit.de/testing/folder/one', token_1)
         self.connector.unlock('http://xml.zeit.de/testing/two')
 
+    def test_add_must_not_write_to_locked_unique_id(self):
+        res = self.add_resource('foo')
+        self.connector.lock(res.id, 'zope.external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        with self.assertRaises(LockedByOtherSystemError):
+            self.connector.add(self.get_resource('foo'))
+
     def test_setitem_must_not_write_on_locked_object(self):
         res = self.get_resource('foo', body=b'one')
         self.connector['http://xml.zeit.de/testing/foo'] = res

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -381,6 +381,13 @@ class ContractLock:
             self.connector.locked('http://xml.zeit.de/testing/target'), (None, None, False)
         )
 
+    def test_move_locked_resource_raises(self):
+        uid = self.add_resource('foo', properties={('bar', self.NS): 'bar'}).id
+        self.connector.lock(uid, 'zope.external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        with self.assertRaises(LockedByOtherSystemError):
+            self.connector.move(uid, 'http://xml.zeit.de/testing/target')
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -397,6 +397,24 @@ class ContractLock:
         with self.assertRaises(LockedByOtherSystemError):
             del self.connector['http://xml.zeit.de/testing/foo']
 
+    def test_delete_own_lock_resource(self):
+        uid = self.add_resource('foo', properties={('bar', self.NS): 'bar'}).id
+        self.connector.lock(uid, 'zope.user', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        (principal, _, my_lock) = self.connector.locked('http://xml.zeit.de/testing/foo')
+        self.assertEqual((principal, my_lock), ('zope.user', True))
+        del self.connector['http://xml.zeit.de/testing/foo']
+        transaction.commit()
+        with self.assertRaises(KeyError):
+            self.connector['http://xml.zeit.de/testing/foo']
+
+    def test_delete_resource(self):
+        self.add_resource('foo', properties={('bar', self.NS): 'bar'})
+        del self.connector['http://xml.zeit.de/testing/foo']
+        transaction.commit()
+        with self.assertRaises(KeyError):
+            self.connector['http://xml.zeit.de/testing/foo']
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -257,7 +257,6 @@ class ContractCopyMove:
 
 
 class ContractLock:
-
     def lock_resource(self, name, user, **kw):
         res = self.add_resource(name, **kw)
         self.connector.lock(res.id, user, datetime.now(pytz.UTC) + timedelta(hours=2))
@@ -360,6 +359,13 @@ class ContractLock:
         res = self.get_resource('foo', body=b'nope')
         with self.assertRaises(LockedByOtherSystemError):
             self.connector['http://xml.zeit.de/testing/foo'] = res
+
+    def test_setitem_on_own_locked_resource(self):
+        self.lock_resource('foo', user='zope.user', body=b'one')
+        res = self.get_resource('foo', body=b'nope')
+        self.connector['http://xml.zeit.de/testing/foo'] = res
+        foo = self.connector['http://xml.zeit.de/testing/foo']
+        self.assertEqual(b'nope', foo.data.read())
 
     def test_change_property_on_own_lock_resources(self):
         self.lock_resource('foo', user='zope.user', properties={('bar', self.NS): 'bar'})

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -369,6 +369,18 @@ class ContractLock:
         )
         transaction.commit()
 
+    def test_copy_locked_resource(self):
+        uid = self.add_resource('foo', properties={('bar', self.NS): 'bar'}).id
+        self.connector.lock(uid, 'zope.user', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        self.connector.copy('http://xml.zeit.de/testing/foo', 'http://xml.zeit.de/testing/target')
+        transaction.commit()
+        (principal, _, my_lock) = self.connector.locked('http://xml.zeit.de/testing/foo')
+        self.assertEqual((principal, my_lock), ('zope.user', True))
+        self.assertEqual(
+            self.connector.locked('http://xml.zeit.de/testing/target'), (None, None, False)
+        )
+
 
 class ContractSearch:
     def test_search_unknown_metadata(self):

--- a/core/src/zeit/content/article/README.txt
+++ b/core/src/zeit/content/article/README.txt
@@ -267,7 +267,7 @@ None
 Get an image from the repository and attach it:
 
 >>> import zeit.cms.testing
->>> _ = zeit.cms.testing.create_interaction('hans')
+>>> _ = zeit.cms.testing.create_interaction('zope.user')
 
 >>> import datetime
 >>> import zope.component

--- a/core/src/zeit/content/cp/tests/test_leadtime.py
+++ b/core/src/zeit/content/cp/tests/test_leadtime.py
@@ -79,7 +79,7 @@ class LeadTimeTest(zeit.content.cp.testing.FunctionalTestCase):
 
     def test_article_checked_out_by_somebody_else_steals_lock_first(self):
         zope.security.management.endInteraction()
-        zeit.cms.testing.create_interaction('other')
+        zeit.cms.testing.create_interaction('zope.producer')
         ICheckoutManager(self.repository['foo']).checkout()
         zope.security.management.endInteraction()
         zeit.cms.testing.create_interaction('zope.user')

--- a/core/src/zeit/speech/tests/test_connection.py
+++ b/core/src/zeit/speech/tests/test_connection.py
@@ -70,7 +70,7 @@ class TestSpeech(FunctionalTestCase):
         with zeit.cms.testing.interaction('zope.producer'):
             zeit.cms.checkout.interfaces.ICheckoutManager(article).checkout()
         with pytest.raises(zeit.cms.checkout.interfaces.CheckinCheckoutError):
-            with zeit.cms.testing.interaction('zeit.speech'):
+            with zeit.cms.testing.interaction('zope.user'):
                 self.create_audio(TTS_CREATED)
 
     def test_update_audio_without_touching_the_article(self):


### PR DESCRIPTION
dieser PR bezieht sich auf https://zeitverlagsgruppe.atlassian.net/wiki/spaces/Engineering/pages/3587440665/Sperren+von+Inhalten+im+Connector

Die Tests sind unter der Annahme geschrieben, dass sie nurnoch™️ Änderungen im Postgresql-Connector brauchen. Haben aber noch zu Anpassungen im MockConnector und in den Datenbanklassen geführt.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![aaaaaaah](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmRuczRvOHcwcDdqZGxqYjd3cDFzcTc5ZDF3ZjA0MjY1c2QzanAyeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/h8zDn6oE4TLfq/giphy.gif)