### PR TITLE
ZO-4053: Update to current openapi-schema-validator API

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "markdown",
     "markdownify",
     "martian",
-    "openapi-schema-validator<=0.5.0.dev0",  # ZO-4053
+    "openapi-schema-validator<=0.6.0",  # ZO-4053
     "opentelemetry-api>=1.23.0.dev.0",
     "opentelemetry-instrumentation-sqlalchemy>=0.38b0",
     "pendulum>=3.0.0.dev0",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "markdown",
     "markdownify",
     "martian",
-    "openapi-schema-validator<=0.6.0",  # ZO-4053
+    "openapi-schema-validator>=0.6.0.dev0",
     "opentelemetry-api>=1.23.0.dev.0",
     "opentelemetry-instrumentation-sqlalchemy>=0.38b0",
     "pendulum>=3.0.0.dev0",

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -68,17 +68,9 @@ class ValidationSchema(zeit.cms.content.dav.DAVPropertiesAdapter):
         try:
             response = self.request('GET', self.schema_url)
             schema = yaml.safe_load(response.text)
-            definitions = self._absolute_references(schema['components']['schemas'])
-            print(definitions)
-            registry = referencing.Registry().with_resources(
-                [
-                    (
-                        f'{self.schema_url}#/components/schemas/{k}',
-                        referencing.Resource.from_contents(v, default_specification=DRAFT202012),
-                    )
-                    for k, v in definitions.items()
-                ]
-            )
+            schema = self._absolute_references(schema)
+            resource = referencing.Resource.from_contents(schema, default_specification=DRAFT202012)
+            registry = referencing.Registry().with_resource(uri=self.schema_url, resource=resource)
             response.close()
             return schema, registry
         except requests.exceptions.RequestException as err:

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -18,10 +18,13 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
         validation.schema_url = zeit.content.text.testing.schema_url
         validation.field_name = 'uuid'
 
-        schema, ref_resolver = validation._get()
+        schema, registry = validation._get()
         pattern = '^((\\{urn:uuid:)?([a-f0-9]{8})\\}?)$'
         self.assertEqual(pattern, schema['components']['schemas']['uuid']['pattern'])
-        self.assertEqual(pattern, ref_resolver.referrer['components']['schemas']['uuid']['pattern'])
+        self.assertEqual(
+            pattern,
+            registry[validation.schema_url].contents['components']['schemas']['uuid']['pattern'],
+        )
 
     def test_validate_data_against_schema(self):
         json_content = zeit.content.text.json.JSON()


### PR DESCRIPTION
Aktualisierung der API-Nutzung von openapi-schema-validator um die aktuellen Versionen verwenden zu können.

Der folgende Deployment-Branch hat die entsprechend neuen Pins:
DEPLOYMENT_BRANCH=ZO-4053-2