### PR TITLE
ZO-4726: Adds summy publish task

### DIFF
--- a/core/docs/changelog/ZO-4726.change
+++ b/core/docs/changelog/ZO-4726.change
@@ -1,0 +1,1 @@
+ZO-4726: Adds summy publish task

--- a/core/src/zeit/connector/testcontent/zeit-magazin/wochenmarkt/rezept
+++ b/core/src/zeit/connector/testcontent/zeit-magazin/wochenmarkt/rezept
@@ -28,6 +28,7 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="access">abo</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="artbox_thema">no</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="author">Eva Biringer</attribute>
+    <attribute ns="http://namespaces.zeit.de/CMS/document" name="avoid_create_summary">no</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="banner">yes</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="banner_content">yes</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="channels">zeit-magazin essen-trinken</attribute>

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -198,6 +198,18 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
         body.updateOrder(ids)
         return image_block
 
+    def get_body(self):
+        body = []
+        elements = self.body.xml.xpath('(//division/* | //division/ul/*)')
+        for elem in elements:
+            if elem.tag not in ('intertitle', 'li', 'p'):
+                continue
+            text = elem.xpath('.//text()')
+            if not text:
+                continue
+            body.append({'content': ' '.join([x.strip() for x in text]), 'type': elem.tag})
+        return body
+
 
 class NoMainImageBlockReference(zeit.cms.content.reference.EmptyReference):
     """We need someone who can create references, even when the reference is

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -520,7 +520,7 @@ class Speechbert(zeit.cms.content.dav.DAVPropertiesAdapter):
         if speechbert.ignore('publish'):
             return
         checksum = hashlib.md5(usedforsecurity=False)
-        body = json.dumps(speechbert.get_body(), ensure_ascii=False).encode('utf-8')
+        body = json.dumps(self.context.get_body(), ensure_ascii=False).encode('utf-8')
         checksum.update(body)
         return checksum.hexdigest()
 

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -316,21 +316,17 @@ class Summy(grok.Adapter):
     def ignore(self, method):
         config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow') or {}
         if method == 'publish':
-            ignore_genres = [x.lower() for x in config.get('summy-ignore-genres', '').split()]
+            ignore_genres = config.get('summy-ignore-genres', '').lower().split()
             genre = self.context.genre
             if genre and genre.lower() in ignore_genres:
                 return True
 
-            ignore_templates = [
-                x.lower() for x in config.get('summy-ignore-templates', '').split()
-            ]
+            ignore_templates = config.get('summy-ignore-templates', '').lower().split()
             template = self.context.template
             if template is not None and template.lower() in ignore_templates:
                 return True
 
-            ignore_ressorts = [
-                x.lower() for x in config.get('summy-ignore-ressorts', '').split()
-            ]
+            ignore_ressorts = config.get('summy-ignore-ressorts', '').lower().split()
             ressort = self.context.ressort
             if ressort and ressort.lower() in ignore_ressorts:
                 return True
@@ -352,10 +348,7 @@ class Summy(grok.Adapter):
         return body
 
     def _json(self):
-        return {
-            'text': self.get_body(),
-            'avoid_create_summary': self.context.avoid_create_summary
-        }
+        return {'text': self.get_body(), 'avoid_create_summary': self.context.avoid_create_summary}
 
     def publish_json(self):
         if self.ignore('publish'):

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -301,6 +301,30 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         json = zeit.workflow.testing.publish_json(article, 'speechbert')
         assert json is None
 
+    def test_summy_ignore_genre_list(self):
+        article = ICMSContent('http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
+        config['summy-ignore-genres'] = 'rezept-vorstellung'
+        payload = zeit.workflow.testing.publish_json(article, 'summy')
+        assert payload == {}
+
+    def test_summy_ignore_ressort_list(self):
+        article = ICMSContent('http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
+        config['summy-ignore-ressorts'] = 'zeit-magazin'
+        payload = zeit.workflow.testing.publish_json(article, 'summy')
+        assert payload == {}
+
+    def test_summy_payload(self):
+        article = ICMSContent('http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow')
+        config['summy-ignore-ressorts'] = 'valid_ressort'
+        config['summy-ignore-genres'] = 'valid_genre'
+        payload = zeit.workflow.testing.publish_json(article, 'summy')
+        assert payload['text'][0] == {'content': 'Als Beilage passt gedämpfter Brokkoli.', 'type': 'p'}
+        assert payload['text'][5] == {'content': '  Rezept von Compliment to the Chef   ', 'type': 'p'}
+        assert payload['avoid_create_summary'] == False
+
 
 class SpeechbertPayloadTest(zeit.workflow.testing.FunctionalTestCase):
     layer = zeit.content.article.testing.LAYER

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -321,9 +321,10 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         config['summy-ignore-ressorts'] = 'valid_ressort'
         config['summy-ignore-genres'] = 'valid_genre'
         payload = zeit.workflow.testing.publish_json(article, 'summy')
-        assert payload['text'][0] == {'content': 'Als Beilage passt gedämpfter Brokkoli.', 'type': 'p'}
-        assert payload['text'][5] == {'content': '  Rezept von Compliment to the Chef   ', 'type': 'p'}
-        assert payload['avoid_create_summary'] == False
+        parts = payload['text']
+        assert parts[0] == {'content': 'Als Beilage passt gedämpfter Brokkoli.', 'type': 'p'}
+        assert parts[5] == {'content': '  Rezept von Compliment to the Chef   ', 'type': 'p'}
+        assert payload['avoid_create_summary'] is False
 
 
 class SpeechbertPayloadTest(zeit.workflow.testing.FunctionalTestCase):


### PR DESCRIPTION
Dieser PR fügt einen weitere Publish-Task hinzu, der eine Payload an den Publisher schickt, die von [diesem Summy PR](https://github.com/ZeitOnline/summy/pull/22) ausgewertet wird.

In der Payload sollten immer die Keys `uuid, uniqueId, summy` vorhanden sein.

Ein ignorierter Artikel hat ein leeres Objekt also summy-Key in der Payload: `"summy": {}`

### Checklist

[Dazugehöriger Deployment-PR](https://github.com/ZeitOnline/vivi-deployment/pull/897)

Ticket: [ZO-4726](https://zeit-online.atlassian.net/browse/ZO-4726)

- [x] Documentation
- [X] Changelog
- [X] Tests
- [ ] Translations

### gif
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWR1dnI5M3BzNDUzbzVtdTJkaDczeWdkYmRxZTlwYWlxcXl3cjV3eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1flAwtHCYosL6LWnHr/giphy-downsized.gif)

[ZO-4726]: https://zeit-online.atlassian.net/browse/ZO-4726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ