### PR TITLE
ZO-4800: Use constants for internal properties

### DIFF
--- a/core/docs/changelog/ZO-4800.change
+++ b/core/docs/changelog/ZO-4800.change
@@ -1,0 +1,1 @@
+ZO-4800: Don't copy internal properties to XML

--- a/core/src/zeit/cms/content/xmlsupport.py
+++ b/core/src/zeit/cms/content/xmlsupport.py
@@ -94,7 +94,7 @@ def veto_dav(event):
 
 @grok.subscribe(zeit.cms.content.interfaces.ISynchronisingDAVPropertyToXMLEvent)
 def veto_internal(event):
-    if event.namespace == 'INTERNAL':
+    if event.namespace == zeit.connector.interfaces.INTERNAL_PROPERTY:
         event.veto()
 
 

--- a/core/src/zeit/cms/content/xmlsupport.txt
+++ b/core/src/zeit/cms/content/xmlsupport.txt
@@ -91,10 +91,10 @@ INTERNAL namespace are *not* mapped:
 ...     repository['testcontent'])
 >>> properties.register_live_property('am-i', 'under-the-hood', WRITEABLE_LIVE)
 >>> properties.register_live_property('foobar', 'DAV:', WRITEABLE_LIVE)
->>> properties.register_live_property('foobar', 'INTERNAL', WRITEABLE_LIVE)
+>>> properties.register_live_property('foobar', zeit.connector.interfaces.INTERNAL_PROPERTY, WRITEABLE_LIVE)
 >>> properties[('am-i', 'under-the-hood')] = '4711'
 >>> properties[('foobar', 'DAV:')] = 'no-dav-sync'
->>> properties[('foobar', 'INTERNAL')] = 'no-dav-sync'
+>>> properties[('foobar', zeit.connector.interfaces.INTERNAL_PROPERTY)] = 'no-dav-sync'
 >>> print(zeit.cms.testing.xmltotext(content.xml))
 <testtype>
   <head>

--- a/core/src/zeit/connector/cache.py
+++ b/core/src/zeit/connector/cache.py
@@ -18,6 +18,7 @@ import zope.interface
 import zope.security.proxy
 
 from zeit.cms.content.sources import FEATURE_TOGGLES
+from zeit.connector.interfaces import CACHED_TIME_PROPERTY
 import zeit.cms.cli
 import zeit.connector.interfaces
 
@@ -410,8 +411,8 @@ class Properties(persistent.mapping.PersistentMapping):
         commited_data = commited['data']
         newstate_data = newstate['data'].copy()
 
-        commited_data.pop(('cached-time', 'INTERNAL'), None)
-        newstate_data.pop(('cached-time', 'INTERNAL'), None)
+        commited_data.pop(CACHED_TIME_PROPERTY, None)
+        newstate_data.pop(CACHED_TIME_PROPERTY, None)
         if newstate_data == commited_data:
             return newstate
         # Completely invalidate cache entry when we cannot resolve.

--- a/core/src/zeit/connector/cache.txt
+++ b/core/src/zeit/connector/cache.txt
@@ -533,9 +533,10 @@ Note that the cached time of the transaction wins which is commited last:
 
 >>> import datetime
 >>> import pytz
->>> c_1['id'][('cached-time', 'INTERNAL')] = datetime.datetime(
+>>> from zeit.connector.interfaces import CACHED_TIME_PROPERTY
+>>> c_1['id'][CACHED_TIME_PROPERTY] = datetime.datetime(
 ...     2008, 1, 1, tzinfo=pytz.UTC).isoformat()
->>> c_2['id'][('cached-time', 'INTERNAL')] = datetime.datetime(
+>>> c_2['id'][CACHED_TIME_PROPERTY] = datetime.datetime(
 ...     2009, 4, 7, tzinfo=pytz.UTC).isoformat()
 >>> transactionmanager_2.commit()
 >>> transactionmanager_1.commit()

--- a/core/src/zeit/connector/connector.py
+++ b/core/src/zeit/connector/connector.py
@@ -15,7 +15,7 @@ import pytz
 import zope.cachedescriptors.property
 import zope.interface
 
-from zeit.connector.interfaces import ID_NAMESPACE, IPersistentCache
+from zeit.connector.interfaces import CACHED_TIME_PROPERTY, ID_NAMESPACE, IPersistentCache
 import zeit.connector.cache
 import zeit.connector.dav.davconnection
 import zeit.connector.dav.davresource
@@ -191,9 +191,9 @@ class Connector:
             response_id = self._loc2id(urllib.parse.urljoin(self._roots['default'], path))
             properties = response.get_all_properties()
             cached_properties = dict(cache.get(response_id, {}))
-            cached_properties.pop(('cached-time', 'INTERNAL'), None)
+            cached_properties.pop(CACHED_TIME_PROPERTY, None)
             if cached_properties != properties:
-                properties[('cached-time', 'INTERNAL')] = now
+                properties[CACHED_TIME_PROPERTY] = now
                 cache[response_id] = properties
 
     def _update_child_id_cache(self, dav_response):
@@ -364,14 +364,14 @@ class Connector:
             locktoken = self._get_my_locktoken(id)
         davres = self._get_dav_resource(id)
         properties = dict(properties)
-        properties[('cached-time', 'INTERNAL')] = zeit.connector.interfaces.DeleteProperty
+        properties[CACHED_TIME_PROPERTY] = zeit.connector.interfaces.DeleteProperty
         properties.pop(zeit.connector.interfaces.UUID_PROPERTY, None)
         davres.change_properties(
             properties, delmark=zeit.connector.interfaces.DeleteProperty, locktoken=locktoken
         )
 
         # Update property cache
-        del properties[('cached-time', 'INTERNAL')]
+        del properties[CACHED_TIME_PROPERTY]
         remove = []
         for key, value in properties.items():
             if value is zeit.connector.interfaces.DeleteProperty:
@@ -646,7 +646,7 @@ class Connector:
                 # Better too much than not enough
                 timeout = TIME_ETERNITY
             else:
-                reftime = self[id].properties.get(('cached-time', 'INTERNAL'))
+                reftime = self[id].properties.get(CACHED_TIME_PROPERTY)
                 if not isinstance(reftime, datetime.datetime):
                     # XXX untested
                     reftime = datetime.datetime.now(pytz.UTC)

--- a/core/src/zeit/connector/interfaces.py
+++ b/core/src/zeit/connector/interfaces.py
@@ -36,6 +36,8 @@ ID_NAMESPACE = 'http://xml.zeit.de/'
 
 RESOURCE_TYPE_PROPERTY = ('type', 'http://namespaces.zeit.de/CMS/meta')
 UUID_PROPERTY = ('uuid', 'http://namespaces.zeit.de/CMS/document')
+INTERNAL_PROPERTY = 'INTERNAL'
+CACHED_TIME_PROPERTY = ('cached-time', INTERNAL_PROPERTY)
 
 
 class ConnectorError(Exception):

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -42,6 +42,7 @@ import zope.sqlalchemy
 
 from zeit.cms.interfaces import DOCUMENT_SCHEMA_NS
 from zeit.connector.interfaces import (
+    INTERNAL_PROPERTY,
     CopyError,
     DeleteProperty,
     LockedByOtherSystemError,
@@ -143,7 +144,7 @@ class Connector:
             properties.get(('type', Content.NS + 'meta'), 'unknown'),
             lambda: properties,
             partial(self._get_body, uniqueid),
-            is_collection=properties[('is_collection', 'internal')],
+            is_collection=properties[('is_collection', INTERNAL_PROPERTY)],
         )
 
     property_cache = TransactionBoundCache('_v_property_cache', dict)
@@ -552,7 +553,7 @@ class Content(DBObject):
 
         props[('uuid', self.NS + 'document')] = '{urn:uuid:%s}' % self.id
         props[('type', self.NS + 'meta')] = self.type
-        props[('is_collection', 'internal')] = self.is_collection
+        props[('is_collection', INTERNAL_PROPERTY)] = self.is_collection
 
         return props
 
@@ -571,7 +572,7 @@ class Content(DBObject):
         for (k, ns), v in props.items():
             if v is DeleteProperty:
                 continue
-            if ns == 'internal':
+            if ns == INTERNAL_PROPERTY:
                 continue
             unsorted[ns.replace(self.NS, '', 1)][k] = v
         self.unsorted = unsorted

--- a/core/src/zeit/connector/tests/test_connector.py
+++ b/core/src/zeit/connector/tests/test_connector.py
@@ -9,6 +9,7 @@ import pytz
 import transaction
 import zope.component
 
+from zeit.connector.interfaces import CACHED_TIME_PROPERTY
 from zeit.connector.testing import copy_inherited_functions
 import zeit.connector.connector
 import zeit.connector.interfaces
@@ -154,24 +155,22 @@ class TestConnectorCache(zeit.connector.testing.ConnectorTest):
         self.assertEqual([], list(children))
 
     def test_cache_time_is_not_stored_on_dav(self):
-        key = ('cached-time', 'INTERNAL')
         properties = self.connector[self.rid].properties
-        cache_time = properties[key]
-        self.connector.changeProperties(self.rid, {key: 'foo'})
+        cache_time = properties[CACHED_TIME_PROPERTY]
+        self.connector.changeProperties(self.rid, {CACHED_TIME_PROPERTY: 'foo'})
         properties = self.connector[self.rid].properties
-        self.assertNotEqual('foo', properties[key])
+        self.assertNotEqual('foo', properties[CACHED_TIME_PROPERTY])
         davres = self.connector._get_dav_resource(self.rid)
         davres.update()
-        self.assertTrue(key not in davres.get_all_properties())
+        self.assertTrue(CACHED_TIME_PROPERTY not in davres.get_all_properties())
         properties = self.connector[self.rid].properties
-        self.assertEqual(cache_time, properties[key])
+        self.assertEqual(cache_time, properties[CACHED_TIME_PROPERTY])
 
     def test_cache_time_is_not_stored_on_dav_with_add(self):
-        key = ('cached-time', 'INTERNAL')
         self.connector.add(self.connector[self.rid])
         davres = self.connector._get_dav_resource(self.rid)
         davres.update()
-        self.assertTrue(key not in davres.get_all_properties())
+        self.assertTrue(CACHED_TIME_PROPERTY not in davres.get_all_properties())
 
     def test_cache_handles_webdav_keys(self):
         key = zeit.connector.cache.WebDAVPropertyKey(('foo', 'bar'))

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -75,7 +75,7 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
                 ('uuid', 'http://namespaces.zeit.de/CMS/document'): '{urn:uuid:%s}' % props.id,
                 ('type', 'http://namespaces.zeit.de/CMS/meta'): 'testing',
                 ('foo', 'http://namespaces.zeit.de/CMS/testing'): 'foo',
-                ('is_collection', 'internal'): False,
+                ('is_collection', 'INTERNAL'): False,
             },
             davprops,
         )


### PR DESCRIPTION
This avoids typos, that e.g. lead to trying to copy interal properties to XML (which then breaks because is_collection is a bool not a str).