### PR TITLE
ZO-4943: changes for vivi-deployment

### DIFF
--- a/core/docs/changelog/ZO-4943.change
+++ b/core/docs/changelog/ZO-4943.change
@@ -1,0 +1,1 @@
+ZO-4943: script for fixing xml only by checkin and checkout contents


### PR DESCRIPTION
see https://github.com/ZeitOnline/vivi-deployment/pull/921
