### PR TITLE
ZO-5086: Update path and filename

### DIFF
--- a/core/docs/changelog/ZO-5086.change
+++ b/core/docs/changelog/ZO-5086.change
@@ -1,0 +1,1 @@
+ZO-5086: Update default filename

--- a/core/src/zeit/contentquery/interfaces.py
+++ b/core/src/zeit/contentquery/interfaces.py
@@ -98,7 +98,7 @@ class TopicpageFilterSource(
 
     product_configuration = 'zeit.content.cp'
     config_url = 'topicpage-filter-source'
-    default_filename = 'topicpage-filters.json'
+    default_filename = 'topicpage-filters-config-upload.json'
 
     def json_data(self):
         result = collections.OrderedDict()


### PR DESCRIPTION
das Config Repo läd die Dateien nun in den `/data` Ordner, damit man sie von der dort manuell gepflegten Datei unterscheiden kann, heißt sie entsprechend `config-upload` 😬 
### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] ~~Tests~~
- [ ] ~~Translations~~

### gif
![hide](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHhpMmF4b2xkZXd3azhucXFidGszaG4yczJqb3JyZDFkOGhuMW04ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HGHt1wNBZyVjy/giphy.gif)