### PR TITLE
ZO-4940: feature toggle to disable transaction commit workaround for multi publish

### DIFF
--- a/core/docs/changelog/ZO-4940.change
+++ b/core/docs/changelog/ZO-4940.change
@@ -1,0 +1,1 @@
+ZO-4940: feature toggle to disable transaction commit workaround for multi publish

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -15,6 +15,7 @@ import zope.i18n
 
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.interfaces import IUUID
+from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.interfaces import ICMSContent
 from zeit.cms.related.interfaces import IRelatedContent
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
@@ -486,6 +487,7 @@ class MultiPublishRetractTest(zeit.workflow.testing.FunctionalTestCase):
             self.assertFalse(publish.called)
 
     def test_error_in_one_item_continues_with_other_items(self):
+        FEATURE_TOGGLES.set('enable-commit-on-multi-publish')
         context = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Querdax')
         c1 = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
         c2 = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/eta-zapatero')
@@ -515,6 +517,7 @@ class MultiPublishRetractTest(zeit.workflow.testing.FunctionalTestCase):
             [
                 '${name}: ${new_value}',
                 'Collective Publication of ${count} objects',
+                'Published',
                 'Error during publish/retract: ${exc}: ${message}',
             ],
             [x.message for x in log.get_log()],


### PR DESCRIPTION
Damit wir es im staging testen können, aber abgesichert mit feature toggle

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()