### PR TITLE
ZO-5022: Enable tracing with sampling for sql connector

### DIFF
--- a/core/docs/changelog/ZO-5022.change
+++ b/core/docs/changelog/ZO-5022.change
@@ -1,0 +1,1 @@
+ZO-5022: Enable tracing with sampling for sql connector

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -22,6 +22,7 @@ import zope.publisher.browser
 from zeit.cms.tracing import anonymize
 import zeit.cms.cli
 import zeit.cms.relstorage
+import zeit.cms.tracing
 import zeit.cms.wsgi
 import zeit.cms.zope
 
@@ -180,7 +181,12 @@ class OpenTelemetryMiddleware(opentelemetry.instrumentation.wsgi.OpenTelemetryMi
 
 
 def otel_request_hook(span, environ):
-    context = zeit.cms.relstorage.apply_samplerate()
+    context = zeit.cms.tracing.apply_samplerate_productconfig(
+        'zeit.cms.relstorage', 'zeit.cms', 'samplerate-zodb'
+    )
+    context = zeit.cms.tracing.apply_samplerate_productconfig(
+        'zeit.connector.postgresql.tracing', 'zeit.cms', 'samplerate-sql'
+    )
     if context is not None:
         environ['zeit.cms.tracing'] = opentelemetry.context.attach(context)
 

--- a/core/src/zeit/cms/application.py
+++ b/core/src/zeit/cms/application.py
@@ -84,7 +84,10 @@ class Application:
             ] + pipeline
         app = zeit.cms.wsgi.wsgi_pipeline(app, pipeline, settings)
         app = OpenTelemetryMiddleware(
-            app, ExcludeList(['/@@health-check$', '/metrics$']), request_hook=otel_request_hook
+            app,
+            ExcludeList(['/@@health-check$', '/metrics$']),
+            request_hook=otel_request_hook,
+            response_hook=otel_response_hook,
         )
         return app
 
@@ -177,7 +180,10 @@ class OpenTelemetryMiddleware(opentelemetry.instrumentation.wsgi.OpenTelemetryMi
 
 
 def otel_request_hook(span, environ):
-    zeit.cms.relstorage.apply_samplerate(span, environ)
+    context = zeit.cms.relstorage.apply_samplerate()
+    if context is not None:
+        environ['zeit.cms.tracing'] = opentelemetry.context.attach(context)
+
     clientip = environ.get('HTTP_X_FORWARDED_FOR', '').split(',')[0]
     span.set_attribute('net.peer.ip', anonymize(clientip))
 
@@ -188,6 +194,12 @@ def otel_request_hook(span, environ):
     if len(path) >= 3 and path[1] == 'workingcopy':
         path[2] = anonymize(path[2])
         span.set_attribute('http.target', '/'.join(path))
+
+
+def otel_response_hook(span, environ, status, headers):
+    token = environ.get('zeit.cms.tracing')
+    if token is not None:
+        opentelemetry.context.detach(token)
 
 
 @grok.subscribe(zope.publisher.interfaces.IEndRequestEvent)

--- a/core/src/zeit/cms/celery.py
+++ b/core/src/zeit/cms/celery.py
@@ -50,6 +50,7 @@ else:
 
     from zeit.cms.tracing import anonymize
     import zeit.cms.relstorage
+    import zeit.cms.tracing
     import zeit.cms.zope
 
     @celery.signals.setup_logging.connect(weak=False)
@@ -196,7 +197,12 @@ else:
 
     @celery.signals.task_prerun.connect(weak=False)
     def apply_samplerate(*args, **kw):
-        context = zeit.cms.relstorage.apply_samplerate()
+        context = zeit.cms.tracing.apply_samplerate_productconfig(
+            'zeit.cms.relstorage', 'zeit.cms', 'samplerate-zodb'
+        )
+        context = zeit.cms.tracing.apply_samplerate_productconfig(
+            'zeit.connector.postgresql.tracing', 'zeit.cms', 'samplerate-sql'
+        )
         if context is not None:
             token = opentelemetry.context.attach(context)
             task = otel_celery.retrieve_task(kw)

--- a/core/src/zeit/cms/relstorage.py
+++ b/core/src/zeit/cms/relstorage.py
@@ -92,12 +92,12 @@ class RelStorageInstrumentor(BaseInstrumentor):
 
         @functools.wraps(wrapped_call)
         def instrumented_call(self, *args, **kw):
-            if logging.getLogger(__name__).isEnabledFor(logging.DEBUG):
-                config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
+            samplerate = opentelemetry.context.get_value(__name__)
+            if samplerate:
                 operation = self.stat_name or self._compute_stat(args)
                 with tracer.start_as_current_span(
                     operation,
-                    attributes={'span.kind': 'client', 'SampleRate': config['samplerate-zodb']},
+                    attributes={'span.kind': 'client', 'SampleRate': samplerate},
                 ):
                     return wrapped_call(self, *args, **kw)
             else:
@@ -118,10 +118,8 @@ class RelStorageInstrumentor(BaseInstrumentor):
 
 def apply_samplerate(*args, **kw):
     config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
-    zodb = logging.getLogger(__name__)
-    # XXX It would be cleaner to use the otel context to transmit this
-    # information, but that's mechanically difficult due to attach/detach API.
-    if random.random() <= 1 / int(config.get('samplerate-zodb', 1)):
-        zodb.setLevel(logging.DEBUG)
+    samplerate = int(config.get('samplerate-zodb', 1))
+    if random.random() <= 1 / samplerate:
+        return opentelemetry.context.set_value(__name__, samplerate)
     else:
-        zodb.setLevel(logging.NOTSET)
+        return None

--- a/core/src/zeit/cms/relstorage.py
+++ b/core/src/zeit/cms/relstorage.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import random
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from perfmetrics.metric import _AbstractMetricImpl as MetricImpl
@@ -9,7 +8,6 @@ import opentelemetry.trace
 import perfmetrics._util
 import ZODB.serialize
 import zodburi
-import zope.app.appsetup.product
 
 import zeit.cms.cli
 
@@ -114,12 +112,3 @@ class RelStorageInstrumentor(BaseInstrumentor):
                     continue
                 original = func.__wrapped__
                 setattr(cls, name, original)
-
-
-def apply_samplerate(*args, **kw):
-    config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
-    samplerate = int(config.get('samplerate-zodb', 1))
-    if random.random() <= 1 / samplerate:
-        return opentelemetry.context.set_value(__name__, samplerate)
-    else:
-        return None


### PR DESCRIPTION
### Checklist

- [x] Documentation: ZeitOnline/vivi-deployment@2eafb80b
- [x] Config: ZeitOnline/vivi-deployment@4f35e817
- [x] Changelog
- [x] ~Tests~ in den Tests verwenden wir weder echte ZODB noch echten Connector, habe es daher einmal manuell ausprobiert, und den Rest sehen wir in Staging/Production
- [x] ~Translations~