### PR TITLE
ZO-4668: Do not break in zeit.web on missing ui dependencies

### DIFF
--- a/core/docs/changelog/foreign_lock.fix
+++ b/core/docs/changelog/foreign_lock.fix
@@ -1,0 +1,1 @@
+ZO-4886: Do not break on missing ui dependencies

--- a/core/src/zeit/connector/lock.py
+++ b/core/src/zeit/connector/lock.py
@@ -1,12 +1,20 @@
-from zope.component import queryUtility
+from zope.component import getUtility
+
+
+try:
+    import zope.authentication.interfaces  # UI-only dependency
+except ImportError:
+    HAVE_AUTH = False
+else:
+    HAVE_AUTH = True
 
 
 def lock_is_foreign(principal):
+    if not HAVE_AUTH:
+        return True
     try:
-        import zope.authentication.interfaces  # UI-only dependency
-
-        authentication = queryUtility(zope.authentication.interfaces.IAuthentication)
-    except ImportError:
+        authentication = getUtility(zope.authentication.interfaces.IAuthentication)
+    except LookupError:
         return True
     try:
         authentication.getPrincipal(principal)

--- a/core/src/zeit/connector/tests/test_mock.py
+++ b/core/src/zeit/connector/tests/test_mock.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import io
 import logging
 
@@ -44,3 +45,9 @@ Searching: (:and
   (:eq "http://namespaces.zeit.de/CMS/document" "author" "pm"))...""",
             self.log.getvalue(),
         )
+
+    def test_foreign_lock_does_not_break_if_utility_is_missing(self):
+        from zeit.connector.lock import lock_is_foreign
+
+        with mock.patch('zeit.connector.lock.HAVE_AUTH', new=False):
+            self.assertTrue(lock_is_foreign('zope.user'))


### PR DESCRIPTION
Achtung während des [Umzugs](https://github.com/ZeitOnline/vivi/blob/main/core/src/zeit/connector/connector.py#L444) von `lock_is_foreign` haben wir das Vorzeichen umgedreht. Vorher hieß es `mylock = True` jetzt heißt es `lock_is_foreign = True` siehe [mock](https://github.com/ZeitOnline/vivi/blob/d6d69a64e352e6ed51a719ad504a1b7c137a4e80/core/src/zeit/connector/mock.py#L272)

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### ACHTUNG weiteres Vorgehen
- [ ] PR mergen
- [ ] vivi nach staging deployen
- [ ] neue Version ins [friedbert-deployment](https://github.com/ZeitOnline/friedbert-deployment/pull/1362) eintragen
- [ ] Tests abwarten
- [ ] changelog für vivi update
- [ ] [PR](https://github.com/ZeitOnline/zeit.web/pull/7667) mergen
- [ ] friedbert-deployment PR mergen
- [ ] zeit.web nach staging deployen und so Deployment entblocken!
- [ ] Kolleg:innen im #engineering channel informieren

### gif
![where](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamdtNDI3c2dqODM5a2xubmdtaXQ2dzR4cmRyMXFnNHZzbTFwdHd1OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/c7Ky8hMkjO45q/giphy.gif)