### PR TITLE
ZO-5125: Cache lock data in property cache for sql connector

### DIFF
--- a/core/docs/changelog/ZO-5125.change
+++ b/core/docs/changelog/ZO-5125.change
@@ -1,0 +1,1 @@
+ZO-5125: Cache lock data in property cache for sql connector, just like dav does

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -417,8 +417,7 @@ class Connector:
                 self.move(f'{old_uniqueid}/{name}', f'{new_uniqueid}/{name}')
             self.child_name_cache.pop(old_uniqueid, None)
 
-        path = self.session.get(Path, self._pathkey(old_uniqueid))
-        (path.parent_path, path.name) = self._pathkey(new_uniqueid)
+        (content.path.parent_path, content.path.name) = self._pathkey(new_uniqueid)
         # unlock checks if locked and unlocks if necessary
         self.unlock(new_uniqueid)
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -159,10 +159,10 @@ class Connector:
         if uniqueid in self.property_cache:
             return self.property_cache[uniqueid]
 
-        path = self.session.get(Path, self._pathkey(uniqueid))
-        if path is None:
+        content = self._get_content(uniqueid)
+        if content is None:
             raise KeyError(f'The resource {uniqueid} does not exist.')
-        properties = path.content.to_webdav()
+        properties = content.to_webdav()
         self.property_cache[uniqueid] = properties
         return properties
 
@@ -175,8 +175,7 @@ class Connector:
         if uniqueid in self.body_cache:
             return self.body_cache[uniqueid]
 
-        path = self.session.get(Path, self._pathkey(uniqueid))
-        content = path.content
+        content = self._get_content(uniqueid)
         if content.is_collection:
             body = b''
         elif content.binary_body:
@@ -523,13 +522,13 @@ class Connector:
                     yield (item.uniqueid, value)
 
     def invalidate_cache(self, uniqueid):
-        path = self.session.get(Path, self._pathkey(uniqueid))
-        if path is None:
+        content = self._get_content(uniqueid)
+        if content is None:
             self.property_cache.pop(uniqueid, None)
             self.child_name_cache.pop(uniqueid, None)
         else:
-            self.property_cache[uniqueid] = path.content.to_webdav()
-            if path.content.is_collection:
+            self.property_cache[uniqueid] = content.to_webdav()
+            if content.is_collection:
                 self._reload_child_name_cache(uniqueid)
         parent = os.path.split(uniqueid)[0]
         self._reload_child_name_cache(parent)

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -454,9 +454,9 @@ class Connector:
         return lock.token
 
     def lock(self, uniqueid, principal, until):
+        uniqueid = self._normalize(uniqueid)
         if uniqueid not in self:
             raise KeyError(f'The resource {uniqueid} does not exist.')
-
         content = self._get_content(uniqueid)
         match content.lock_status:
             case LockStatus.NONE | LockStatus.TIMED_OUT:
@@ -467,6 +467,7 @@ class Connector:
                 raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
 
     def unlock(self, uniqueid):
+        uniqueid = self._normalize(uniqueid)
         lock = self._get_content(uniqueid).lock
         if not lock:
             return
@@ -476,6 +477,7 @@ class Connector:
         self._update_lock_cache(uniqueid, None)
 
     def _unlock(self, uniqueid, token):
+        uniqueid = self._normalize(uniqueid)
         lock = self._get_content(uniqueid).lock
         if not lock or not lock.token == token:
             return
@@ -492,6 +494,7 @@ class Connector:
         self.property_cache[uniqueid] = properties
 
     def locked(self, uniqueid):
+        uniqueid = self._normalize(uniqueid)
         lock = self._get_cached_lock(uniqueid)
         match lock.status:
             case LockStatus.NONE | LockStatus.TIMED_OUT:

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -406,6 +406,9 @@ class Connector:
                 old_uniqueid,
                 f'Could not move {old_uniqueid} to {new_uniqueid}, because target already exists.',
             )
+        # unlock checks if locked and unlocks if necessary
+        self.unlock(old_uniqueid)
+
         if content.is_collection:
             if self._foreign_child_lock_exists(old_uniqueid):
                 raise LockedByOtherSystemError(
@@ -418,8 +421,6 @@ class Connector:
             self.child_name_cache.pop(old_uniqueid, None)
 
         (content.path.parent_path, content.path.name) = self._pathkey(new_uniqueid)
-        # unlock checks if locked and unlocks if necessary
-        self.unlock(new_uniqueid)
 
         self.property_cache.pop(old_uniqueid, None)
         self.property_cache[new_uniqueid] = content.to_webdav()

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -152,6 +152,10 @@ class Connector:
     property_cache = TransactionBoundCache('_v_property_cache', zeit.connector.cache.PropertyCache)
 
     def _get_properties(self, uniqueid):
+        if uniqueid == ID_NAMESPACE:
+            content = Content(id='root', type='folder', is_collection=True, unsorted={})
+            return content.to_webdav()
+
         if uniqueid in self.property_cache:
             return self.property_cache[uniqueid]
 
@@ -165,6 +169,9 @@ class Connector:
     body_cache = TransactionBoundCache('_v_body_cache', zeit.connector.cache.ResourceCache)
 
     def _get_body(self, uniqueid):
+        if uniqueid == ID_NAMESPACE:
+            return BytesIO(b'')
+
         if uniqueid in self.body_cache:
             return self.body_cache[uniqueid]
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -600,15 +600,15 @@ class Content(DBObject):
         lazy='joined',
         back_populates='content',
         cascade='all, delete-orphan',
-        passive_deletes=True,
+        passive_deletes=True,  # Handled in DB, Path.id has ondelete=cascade
     )
     lock = relationship(
         'Lock',
         uselist=False,
         lazy='joined',
         back_populates='content',
-        cascade='all, delete-orphan',
-        passive_deletes=True,
+        cascade='delete, delete-orphan',  # Propagate `del content.lock` to DB
+        passive_deletes=True,  # Disable any heuristics, only ever explicitly delete Locks
     )
 
     @property

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -27,7 +27,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import relationship
 import google.api_core.exceptions
 import opentelemetry.instrumentation.sqlalchemy
 import opentelemetry.metrics
@@ -570,12 +570,7 @@ class Path(DBObject):
         nullable=False,
         index=True,
     )
-    content = relationship(
-        'Content',
-        uselist=False,
-        lazy='joined',
-        backref=backref('path', uselist=False, cascade='all, delete-orphan', passive_deletes=True),
-    )
+    content = relationship('Content', uselist=False, lazy='joined', back_populates='path')
 
     @property
     def uniqueid(self):
@@ -597,6 +592,23 @@ class Content(DBObject):
         TIMESTAMP(timezone=True),
         server_default=sqlalchemy.func.now(),
         onupdate=sqlalchemy.func.now(),
+    )
+
+    path = relationship(
+        'Path',
+        uselist=False,
+        lazy='joined',
+        back_populates='content',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+    )
+    lock = relationship(
+        'Lock',
+        uselist=False,
+        lazy='joined',
+        back_populates='content',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
     )
 
     @property
@@ -661,12 +673,7 @@ class Lock(DBObject):
     principal = Column(Unicode, nullable=False)
     until = Column(TIMESTAMP(timezone=True), nullable=False)
 
-    content = relationship(
-        'Content',
-        uselist=False,
-        lazy='joined',
-        backref=backref('lock', uselist=False, cascade='all, delete-orphan', passive_deletes=True),
-    )
+    content = relationship('Content', uselist=False, lazy='joined', back_populates='lock')
 
     @property
     def token(self):

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -305,6 +305,8 @@ class Connector:
         content = self._get_content(uniqueid)
         if content is None:
             raise KeyError(f'The resource {uniqueid} does not exist.')
+        # unlock checks if locked and unlocks if necessary
+        self.unlock(uniqueid)
 
         if content.is_collection:
             if self._foreign_child_lock_exists(uniqueid):
@@ -315,8 +317,6 @@ class Connector:
                 del self[child_uid]
         elif content.binary_body:
             self._delete_binary(content)
-        # unlock checks if locked and unlocks if necessary
-        self.unlock(uniqueid)
         self.session.delete(content)
 
         self.property_cache.pop(uniqueid, None)

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -246,6 +246,7 @@ class SQLConfigLayer(zeit.cms.testing.ProductConfigLayer):
             'dsn': self['dsn'],
             'storage-project': 'ignored_by_emulator',
             'storage-bucket': GCS_SERVER_LAYER.bucket,
+            'sql-locking': 'True',
         }
         os.environ.setdefault('PGDATABASE', 'vivi_test')
         super().setUp()

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -723,6 +723,19 @@ class ContractCache:
             with self.assertNothingRaised():
                 self.listCollection(res.id)
 
+    def test_locked_returns_cached_result(self):
+        res = self.add_resource('foo')
+        self.connector.lock(
+            res.id,
+            'zope.user',
+            datetime.now(pytz.UTC) + timedelta(hours=2),
+        )
+        transaction.commit()
+        with self.disable_storage():
+            with self.assertNothingRaised():
+                (principal, _, my_lock) = self.connector.locked(res.id)
+                self.assertEqual('zope.user', principal)
+
 
 class DAVProtocol:
     shortened_uuid = False

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -79,6 +79,12 @@ class ContractReadWrite:
             self.listCollection('http://xml.zeit.de/'),
         )
 
+    def test_getitem_works_for_root_folder(self):
+        res = self.connector['http://xml.zeit.de/']
+        self.assertEqual(self.folder_type, res.type)
+        with self.assertNothingRaised():
+            res.data.read()
+
     def test_setitem_stores_ressource(self):
         # Note: We're also testing this implicitly, due to self.add_resource().
         res = self.get_resource('foo')
@@ -720,6 +726,7 @@ class ContractCache:
 
 class DAVProtocol:
     shortened_uuid = False
+    folder_type = 'collection'
 
     def id_for_folder(self, id):
         if not id.endswith('/'):
@@ -816,6 +823,7 @@ class ContractMock(
 
 class SQLProtocol:
     shortened_uuid = True
+    folder_type = 'folder'
 
     def id_for_folder(self, id):
         return id

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -71,14 +71,9 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         props = self.connector._get_content(res.id)
         davprops = props.to_webdav()
         self.assertEqual(
-            {
-                ('uuid', 'http://namespaces.zeit.de/CMS/document'): '{urn:uuid:%s}' % props.id,
-                ('type', 'http://namespaces.zeit.de/CMS/meta'): 'testing',
-                ('foo', 'http://namespaces.zeit.de/CMS/testing'): 'foo',
-                ('is_collection', 'INTERNAL'): False,
-            },
-            davprops,
+            '{urn:uuid:%s}' % props.id, davprops[('uuid', 'http://namespaces.zeit.de/CMS/document')]
         )
+        self.assertEqual('testing', davprops[('type', 'http://namespaces.zeit.de/CMS/meta')])
 
     def test_provides_last_updated_column(self):
         # Properly we would test that the value of the last_updated column


### PR DESCRIPTION
Vermutlich am besten commitweise anschauen, enthält noch andere kleine Korrekturen.

### Checklist

- [x] Configuration: in ZeitOnline/vivi-deployment@77f2119
- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~