### PR TITLE
ZO-4800: Remove obsolete class (belongs to a353c2c)

### DIFF
--- a/core/docs/changelog/ZO-4800.fix
+++ b/core/docs/changelog/ZO-4800.fix
@@ -1,0 +1,1 @@
+ZO-4800: Remove obsolete class

--- a/core/src/zeit/content/image/image.py
+++ b/core/src/zeit/content/image/image.py
@@ -24,24 +24,6 @@ import zeit.workflow.interfaces
 import zeit.workflow.timebased
 
 
-class FakeWriteableCachedProperty(zope.cachedescriptors.property.Lazy):
-    def __get__(self, inst, class_):
-        if inst is None:
-            return self
-
-        func, name = self.data
-        # Because we define __set__, we take precedence over the instance dict
-        if name in inst.__dict__:
-            return inst.__dict__[name]
-
-        value = func(inst)
-        inst.__dict__[name] = value
-        return value
-
-    def __set__(self, inst, value):
-        pass
-
-
 class BaseImage:
     def __init__(self, uniqueId=None):
         super().__init__(uniqueId)


### PR DESCRIPTION
![farewell](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHpmeTZxc2U2djljYW82eWU4Nmp3MjFlNDZpa2l0a2xzem5jMjFiZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Jev4iU72S9RYc/giphy.gif)