### PR TITLE
ZO-5141: Ignore summy service during publish

### DIFF
--- a/core/docs/changelog/ZO-5141.change
+++ b/core/docs/changelog/ZO-5141.change
@@ -1,0 +1,1 @@
+ZO-5141: Ignore summy service during publish

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -335,7 +335,7 @@ class Summy(grok.Adapter, IgnoreMixin):
 class PublisherData(grok.Adapter):
     grok.context(zeit.cms.interfaces.ICMSContent)
 
-    ignore = ()  # extension point e.g. for bulk publish scripts
+    ignore = ('summy',)  # extension point e.g. for bulk publish scripts
 
     def __call__(self, action):
         uuid = zeit.cms.content.interfaces.IUUID(self.context)


### PR DESCRIPTION
Summy is broken, therefore we want to ignore it until further notice and not remove the manual Hotfix by deploying a new version to production.

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [ ] ~~Tests~~
- [ ] ~~Translations~~

### gif
![never](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjlha3k4MzI1MjRhMndscTdzaGoyNHQ3d3N2YmVzdGM2NHJ0ampvYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SnBYDBxzYKJeU/giphy.gif)