### PR TITLE
ZO-4919: Use batch APIs for sql connector where possible

### DIFF
--- a/core/docs/changelog/ZO-4919.change
+++ b/core/docs/changelog/ZO-4919.change
@@ -1,0 +1,1 @@
+ZO-4919: Use batch APIs for sql connector where possible

--- a/core/src/zeit/connector/configure.zcml
+++ b/core/src/zeit/connector/configure.zcml
@@ -3,7 +3,7 @@
   xmlns:grok="http://namespaces.zope.org/grok">
 
   <include package="grokcore.component" file="meta.zcml" />
-  <grok:grok package="." />
+  <grok:grok package="." exclude="gcsemulator testing" />
 
   <!-- security -->
   <class class=".resource.WebDAVProperties">

--- a/core/src/zeit/connector/gcsemulator.py
+++ b/core/src/zeit/connector/gcsemulator.py
@@ -1,0 +1,52 @@
+from copy import deepcopy
+import json
+import secrets
+import string
+
+from gcp_storage_emulator.exceptions import Conflict, NotFound
+from gcp_storage_emulator.objects import NOT_FOUND, _delete, _patch
+
+
+def batch(request, response, storage, *args, **kwargs):
+    boundary = 'batch_' + ''.join(
+        secrets.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+        for _ in range(32)
+    )
+    response['Content-Type'] = 'multipart/mixed; boundary={}'.format(boundary)
+    for item in request.data:
+        resp_data = None
+        response.write('--{}\r\nContent-Type: application/http\r\n'.format(boundary))
+        method = item.get('method')
+        bucket_name = item.get('bucket_name')
+        object_id = item.get('object_id')
+        meta = item.get('meta')
+        if method == 'PATCH':
+            resp_data = _patch(storage, bucket_name, object_id, meta)
+            if resp_data:
+                response.write('HTTP/1.1 200 OK\r\n')
+                response.write('Content-Type: application/json; charset=UTF-8\r\n')
+                response.write(json.dumps(resp_data))
+                response.write('\r\n\r\n')
+        if method == 'DELETE':
+            if object_id:
+                resp_data = _delete(storage, bucket_name, object_id)
+            else:
+                try:
+                    storage.delete_bucket(bucket_name)
+                    resp_data = True
+                except (Conflict, NotFound):
+                    pass
+            if resp_data:
+                response.write('HTTP/1.1 204 No Content\r\n')
+                response.write('Content-Type: application/json; charset=UTF-8\r\n')
+        if not resp_data:
+            msg = 'No such object: {}/{}'.format(bucket_name, object_id)
+            resp_data = deepcopy(NOT_FOUND)
+            resp_data['error']['message'] = msg
+            resp_data['error']['errors'][0]['message'] = msg
+            response.write('HTTP/1.1 404 Not Found\r\n')
+            response.write('Content-Type: application/json; charset=UTF-8\r\n\r\n')
+            response.write(json.dumps(resp_data))
+            response.write('\r\n\r\n')
+
+    response.write('--{}--'.format(boundary))

--- a/core/src/zeit/connector/gcsemulator.py
+++ b/core/src/zeit/connector/gcsemulator.py
@@ -3,8 +3,16 @@ import json
 import secrets
 import string
 
+from gcp_storage_emulator import settings
 from gcp_storage_emulator.exceptions import Conflict, NotFound
-from gcp_storage_emulator.objects import NOT_FOUND, _delete, _patch
+from gcp_storage_emulator.handlers.objects import (
+    NOT_FOUND,
+    _checksums,
+    _delete,
+    _make_object_resource,
+    _patch,
+)
+import gcp_storage_emulator.server
 
 
 def batch(request, response, storage, *args, **kwargs):
@@ -39,6 +47,21 @@ def batch(request, response, storage, *args, **kwargs):
             if resp_data:
                 response.write('HTTP/1.1 204 No Content\r\n')
                 response.write('Content-Type: application/json; charset=UTF-8\r\n')
+        if method == 'POST':  # kludgy heuristics, luckily we only use COPY
+            if object_id:
+                resp_data = _copy(
+                    request.base_url,
+                    storage,
+                    bucket_name,
+                    object_id,
+                    item['dest_bucket_name'],
+                    item['dest_object_id'],
+                )
+            if resp_data:
+                response.write('HTTP/1.1 200 OK\r\n')
+                response.write('Content-Type: application/json; charset=UTF-8\r\n')
+                response.write(json.dumps(resp_data))
+                response.write('\r\n\r\n')
         if not resp_data:
             msg = 'No such object: {}/{}'.format(bucket_name, object_id)
             resp_data = deepcopy(NOT_FOUND)
@@ -50,3 +73,48 @@ def batch(request, response, storage, *args, **kwargs):
             response.write('\r\n\r\n')
 
     response.write('--{}--'.format(boundary))
+
+
+gcp_storage_emulator.server.HANDLERS = (
+    gcp_storage_emulator.server.HANDLERS[:-4]
+    + ((r'^{}$'.format(settings.BATCH_API_ENDPOINT), {'POST': batch}),)
+    + gcp_storage_emulator.server.HANDLERS[-3:]
+)
+
+
+def _copy(base_url, storage, bucket_name, object_id, dest_bucket_name, dest_object_id):
+    try:
+        obj = storage.get_file_obj(bucket_name, object_id)
+    except NotFound:
+        return None
+
+    dest_obj = _make_object_resource(
+        base_url,
+        dest_bucket_name,
+        dest_object_id,
+        obj['contentType'],
+        obj['size'],
+        obj,
+    )
+
+    file = storage.get_file(bucket_name, object_id)
+    try:
+        dest_obj = _checksums(file, dest_obj)
+        storage.create_file(
+            dest_bucket_name,
+            dest_object_id,
+            file,
+            dest_obj,
+        )
+        return dest_obj
+    except NotFound:
+        return None
+    # except Conflict as err:
+    #     _handle_conflict(response, err)
+
+
+gcp_storage_emulator.server.BATCH_HANDLERS += (
+    r'^(?P<method>[\w]+).*{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>[^\?]+[^/])/copyTo/b/(?P<dest_bucket_name>[-.\w]+)/o/(?P<dest_object_id>[^\?]+[^/])([\?].*)?$'.format(
+        settings.API_ENDPOINT
+    ),
+)

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -401,15 +401,6 @@ class Connector:
         parent_path = parent_path.rstrip('/')
         return (parent_path, name)
 
-    def _clone_row(self, row, ignored_columns=None):
-        if ignored_columns is None:
-            ignored_columns = []
-        clone = type(row)()
-        for column in row.__table__.columns:
-            if column.name not in ignored_columns:
-                setattr(clone, column.name, getattr(row, column.name))
-        return clone
-
     def copy(self, old_uniqueid, new_uniqueid):
         old_uniqueid = self._normalize(old_uniqueid)
         new_uniqueid = self._normalize(new_uniqueid)
@@ -460,6 +451,15 @@ class Connector:
             if content.is_collection:
                 self.child_name_cache[content.uniqueid] = set()
             self._update_parent_child_name_cache(content.uniqueid, 'add')
+
+    def _clone_row(self, row, ignored_columns=None):
+        if ignored_columns is None:
+            ignored_columns = []
+        clone = type(row)()
+        for column in row.__table__.columns:
+            if column.name not in ignored_columns:
+                setattr(clone, column.name, getattr(row, column.name))
+        return clone
 
     def _bulk_insert(self, cls, items):
         columns = [c.key for c in sqlalchemy.orm.class_mapper(cls).columns]

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -325,7 +325,7 @@ class Connector:
             for _, child_uid in self.listCollection(uniqueid):
                 del self[child_uid]
         elif content.binary_body:
-            self._delete_binary(content)
+            self._delete_binary(content.id)
         self.session.delete(content)
 
         self.property_cache.pop(uniqueid, None)
@@ -333,17 +333,17 @@ class Connector:
         self.child_name_cache.pop(uniqueid, None)
         self._update_parent_child_name_cache(uniqueid, 'remove')
 
-    def _delete_binary(self, content):
-        blob = self.bucket.blob(content.id)
+    def _delete_binary(self, id):
+        blob = self.bucket.blob(id)
         with zeit.cms.tracing.use_span(
             __name__ + '.tracing',
             'gcs',
-            attributes={'db.operation': 'delete', 'id': content.id},
+            attributes={'db.operation': 'delete', 'id': id},
         ):
             try:
                 blob.delete()
             except google.api_core.exceptions.NotFound:
-                log.info('Ignored NotFound while deleting GCS blob %s', content.uniqueid)
+                log.info('Ignored NotFound while deleting GCS blob %s', id)
 
     def _get_content(self, uniqueid, getlock=True):
         parent, name = self._pathkey(uniqueid)

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -460,7 +460,7 @@ class Connector:
         self._update_parent_child_name_cache(new_uniqueid, 'add')
 
     def _foreign_child_lock_exists(self, uniqueid):
-        (parent, _) = self._pathkey(uniqueid)
+        parent = uniqueid.replace(ID_NAMESPACE, '', 1)
         stmt = (
             select(Lock).join(Path, Lock.id == Path.id).filter(Path.parent_path.startswith(parent))
         )

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -18,6 +18,7 @@ import zope.testing.renormalizing
 
 import zeit.cms.testing
 import zeit.connector.connector
+import zeit.connector.gcsemulator  # activate monkey patches
 import zeit.connector.interfaces
 import zeit.connector.mock
 

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -181,6 +181,14 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         self.assertEqual(source_props.id, target_props.id)
         self.assertEqual(source_blob.name, target_blob.name)
 
+    def test_regression_delitem_only_checks_locked_children_not_siblings(self):
+        self.mkdir('folder')
+        res = self.add_resource('foo')
+        self.connector.lock(res.id, 'external', datetime.now(pytz.UTC) + timedelta(hours=2))
+        transaction.commit()
+        with self.assertNothingRaised():
+            del self.connector['http://xml.zeit.de/testing/folder']
+
     def _create_lock(self, minutes):
         res = self.get_resource(f'foo-{minutes}', b'mybody')
         self.connector.add(res)


### PR DESCRIPTION
- Für gcp-storage-emulator stell ich die Tage dann noch einen PR, falls der akzeptiert wird, können wir die Monkey-Patches hier dann wieder rauswerfen
- Ich hab keine naheliegende Idee, wie man das testen würde, dass das wirklich alles brav gebatched wird. Denn ich hab so ein Gefühl, dass wir uns eher _keinen_ Gefallen tun, wenn wir jetzt z.B. anfangen würden, SQL-Queries bzw GCS-Requests zu zählen (übers Tracing oder so). Denn das wird ja sehr schnell voller magischer Zahlen, wie viele Queries welche Operation ausführt.