### PR TITLE
ZO-4978: test concurrency of connector

### DIFF
--- a/core/docs/changelog/ZO-4978.change
+++ b/core/docs/changelog/ZO-4978.change
@@ -1,0 +1,1 @@
+ZO-4978: test concurrency of connector

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -262,6 +262,15 @@ class SQLDatabaseLayer(plone.testing.Layer):
         super().__init__(name=name, module=module, bases=bases)
 
     def setUp(self):
+        zope.component.provideUtility(
+            zeit.connector.cache.PropertyCache(), zeit.connector.interfaces.IPropertyCache
+        )
+        zope.component.provideUtility(
+            zeit.connector.cache.ChildNameCache(), zeit.connector.interfaces.IChildNameCache
+        )
+        zope.component.provideUtility(
+            zeit.connector.cache.ResourceCache(), zeit.connector.interfaces.IResourceCache
+        )
         connector = zope.component.getUtility(zeit.connector.interfaces.IConnector)
         engine = connector.engine
         try:


### PR DESCRIPTION
Keine gute Lösung gefunden, aber grundsätzlich wäre `upsert` für insert/update und row locking für `copy`, `move` und `del` ne gute Idee.

Lohnt sich vielleicht nochmal mit Blick auf https://zeit-online.atlassian.net/browse/ZO-5176

