### PR TITLE
ZO-5231: use correct namespace for property renameable

### DIFF
--- a/core/docs/changelog/ZO-5231.change
+++ b/core/docs/changelog/ZO-5231.change
@@ -1,0 +1,1 @@
+ZO-5231: use correct namespace for property renameable

--- a/core/src/zeit/cms/interfaces.py
+++ b/core/src/zeit/cms/interfaces.py
@@ -16,6 +16,7 @@ from zeit.cms.i18n import MessageFactory as _
 
 
 DOCUMENT_SCHEMA_NS = 'http://namespaces.zeit.de/CMS/document'
+META_SCHEMA_NS = 'http://namespaces.zeit.de/CMS/meta'
 QPS_SCHEMA_NS = 'http://namespaces.zeit.de/QPS/attributes'
 ID_NAMESPACE = 'http://xml.zeit.de/'
 TEASER_NAMESPACE = 'http://xml.zeit.de/CMS/Teaser'

--- a/core/src/zeit/cms/repository/checkout.py
+++ b/core/src/zeit/cms/repository/checkout.py
@@ -72,7 +72,7 @@ class AutomaticallyRenameable(zeit.cms.content.dav.DAVPropertiesAdapter):
 
     zeit.cms.content.dav.mapProperties(
         zeit.cms.repository.interfaces.IAutomaticallyRenameable,
-        'http//namespaces.zeit.de/CMS/meta',
+        zeit.cms.interfaces.META_SCHEMA_NS,
         ('renameable', 'rename_to'),
     )
 


### PR DESCRIPTION
### Checklist

- [ ] Documentation
- [ ] Changelog
- [ ] Tests
- [ ] Translations

### gif
![]()