### PR TITLE
ZO-5253: Preserve all properties during setitem

### DIFF
--- a/core/docs/changelog/ZO-5253.change
+++ b/core/docs/changelog/ZO-5253.change
@@ -1,0 +1,1 @@
+ZO-5253: Preserve all properties during setitem in postgresql connector

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -733,12 +733,20 @@ class Content(DBObject):
             self.path.id = id
 
         unsorted = collections.defaultdict(dict)
+        if self.unsorted:
+            previous = self.unsorted
+            for (k, ns), v in props.items():
+                if v is DeleteProperty:
+                    previous[ns.replace(self.NS, '', 1)].pop(k)
+            unsorted.update(previous)
+
         for (k, ns), v in props.items():
             if v is DeleteProperty:
                 continue
             if ns == INTERNAL_PROPERTY:
                 continue
             unsorted[ns.replace(self.NS, '', 1)][k] = v
+
         self.unsorted = unsorted
 
 

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -106,6 +106,22 @@ class ContractReadWrite:
         res = self.connector['http://xml.zeit.de/testing/foo']
         self.assertEqual(b'two', res.data.read())
 
+    def test_setitem_preserves_all_properties(self):
+        res = self.get_resource(
+            'foo',
+            properties={('foo', self.NS): 'foo'},
+        )
+        self.connector['http://xml.zeit.de/testing/foo'] = res
+        transaction.commit()
+        res = self.get_resource(
+            'foo',
+            properties={('bar', self.NS): 'bar'},
+        )
+        self.connector['http://xml.zeit.de/testing/foo'] = res
+        res = self.connector['http://xml.zeit.de/testing/foo']
+        self.assertEqual('foo', res.properties[('foo', self.NS)])
+        self.assertEqual('bar', res.properties[('bar', self.NS)])
+
     def test_add_is_convenience_for_setitem(self):
         self.connector.add(self.get_resource('foo'))
         res = self.connector['http://xml.zeit.de/testing/foo']


### PR DESCRIPTION
so we violated the contract in setitem, which requires updating the properties, instead of overwriting them 😭 

i do not like the first loop over properties, but trying to remove the deleted ones during the second loop raises the following error when running the contract test `test_changeProperties_updates_properties`
```
sqlalchemy.exc.StatementError: (builtins.TypeError) Object of type _DeleteProperty is not JSON serializable
[SQL: UPDATE properties SET unsorted=%(unsorted)s, last_updated=now() WHERE properties.id = %(properties_id)s::UUID]
[parameters: [{'unsorted': defaultdict(<class 'dict'>, {'testing': {'bar': 'bar', 'foo': 'qux', 'baz': DeleteProperty}, 'document': {'uuid': '{urn:uuid:99563698-e4d0-4c9d-a1c2-6ef5fb8f228a}'}, 'meta': {'type': 'testing'}}), 'properties_id': '99563698-e4d0-4c9d-a1c2-6ef5fb8f228a'}]]
```
### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
free fall 🎶 Don`t panic! (in large friendly letters)

![falling](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbm5xMHgzbDQ0aDZoMHBoNDV2dmxjdzJneDJoOHlpeTV0OTdoenZybSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1QfiAtGHd1CS4HzaiU/giphy.gif)