### PR TITLE
ZO-5276: Use sql index to query unsorted properties

### DIFF
--- a/core/docs/changelog/ZO-5276.change
+++ b/core/docs/changelog/ZO-5276.change
@@ -1,0 +1,1 @@
+ZO-5276: Use sql index to query unsorted properties


### PR DESCRIPTION
Bis wir Mechanik für Schema-Migrationen haben, hab ich mir das `CREATE INDEX` Statement [mit diesem sqlalchemy-Rezept](https://docs.sqlalchemy.org/en/20/faq/metadata_schema.html#how-can-i-get-the-create-table-drop-table-output-as-a-string) ausgeben lassen, und führe daher gleich `CREATE INDEX ix_properties_unsorted ON properties USING gin (unsorted jsonb_path_ops)` mal manuell aus.