### PR TITLE
ZO-5305: commit transactions before running publish inside celery tasks

### DIFF
--- a/core/docs/changelog/ZO-5305.change
+++ b/core/docs/changelog/ZO-5305.change
@@ -1,0 +1,1 @@
+ZO-5305: commit transactions before running publish inside celery tasks

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -6,7 +6,7 @@ import zope.lifecycleevent
 
 from zeit.brightcove.convert import DeletedVideo
 from zeit.cms.content.sources import FEATURE_TOGGLES
-from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
+from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish, IPublishInfo
 from zeit.content.video.interfaces import IVideo
 import zeit.brightcove.convert
 import zeit.brightcove.session
@@ -85,7 +85,7 @@ class import_video(import_base):
             return False
         self._add()
         if self.bcobj.state == 'ACTIVE':
-            IPublish(self.cmsobj).publish(background=False)
+            IPublish(self.cmsobj).publish(priority=PRIORITY_LOW)
             log.info('Publishing %s' % self.bcobj.uniqueId)
         return True
 
@@ -124,7 +124,7 @@ class import_video(import_base):
         self._update()
         if self.bcobj.state == 'ACTIVE':
             try:
-                IPublish(self.cmsobj).publish(background=False)
+                IPublish(self.cmsobj).publish(priority=PRIORITY_LOW)
             except z3c.celery.celery.HandleAfterAbort as e:
                 try:
                     error = e.c_args[0][1]  # Our API is a bit clumsy.

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -85,7 +85,8 @@ class import_video(import_base):
             return False
         self._add()
         if self.bcobj.state == 'ACTIVE':
-            IPublish(self.cmsobj).publish(priority=PRIORITY_LOW)
+            # XXX countdown is workaround race condition between celery/redis BUG-796
+            IPublish(self.cmsobj).publish(priority=PRIORITY_LOW, countdown=5)
             log.info('Publishing %s' % self.bcobj.uniqueId)
         return True
 
@@ -124,7 +125,8 @@ class import_video(import_base):
         self._update()
         if self.bcobj.state == 'ACTIVE':
             try:
-                IPublish(self.cmsobj).publish(priority=PRIORITY_LOW)
+                # XXX countdown is workaround race condition between celery/redis BUG-796
+                IPublish(self.cmsobj).publish(priority=PRIORITY_LOW, countdown=5)
             except z3c.celery.celery.HandleAfterAbort as e:
                 try:
                     error = e.c_args[0][1]  # Our API is a bit clumsy.

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -185,7 +185,8 @@ class Simplecast:
             log.info('Podcast Episode %s successfully updated.', episode.uniqueId)
 
     def publish(self, audio):
-        IPublish(audio).publish(priority=PRIORITY_LOW)
+        # XXX countdown is workaround race condition between celery/redis BUG-796
+        IPublish(audio).publish(priority=PRIORITY_LOW, countdown=5)
         log.info('Podcast Episode %s successfully published.', audio.uniqueId)
 
     def _retract(self, audio):

--- a/core/src/zeit/simplecast/connection.py
+++ b/core/src/zeit/simplecast/connection.py
@@ -7,7 +7,7 @@ import zope.component
 import zope.interface
 
 from zeit.cms.content.interfaces import ISemanticChange
-from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
+from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish, IPublishInfo
 from zeit.connector.search import SearchVar
 from zeit.content.audio.interfaces import IAudio, IPodcastEpisodeInfo
 import zeit.cms.checkout.helper
@@ -185,7 +185,7 @@ class Simplecast:
             log.info('Podcast Episode %s successfully updated.', episode.uniqueId)
 
     def publish(self, audio):
-        IPublish(audio).publish(background=False)
+        IPublish(audio).publish(priority=PRIORITY_LOW)
         log.info('Podcast Episode %s successfully published.', audio.uniqueId)
 
     def _retract(self, audio):

--- a/core/src/zeit/sourcepoint/javascript.py
+++ b/core/src/zeit/sourcepoint/javascript.py
@@ -8,7 +8,7 @@ import requests
 import zope.event
 
 from zeit.cms.repository.interfaces import ObjectReloadedEvent
-from zeit.cms.workflow.interfaces import IPublish
+from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish
 import zeit.cms.interfaces
 import zeit.content.text.text
 
@@ -72,7 +72,7 @@ class JavaScript:
         log.info('Storing new contents as %s/%s', self.folder_id, filename)
         obj.text = content
         self.folder[filename] = obj
-        IPublish(self.folder[filename]).publish(background=False)
+        IPublish(self.folder[filename]).publish(priority=PRIORITY_LOW)
 
     def sweep(self, keep):
         zope.event.notify(ObjectReloadedEvent(self.folder))  # XXX

--- a/core/src/zeit/sourcepoint/javascript.py
+++ b/core/src/zeit/sourcepoint/javascript.py
@@ -72,7 +72,8 @@ class JavaScript:
         log.info('Storing new contents as %s/%s', self.folder_id, filename)
         obj.text = content
         self.folder[filename] = obj
-        IPublish(self.folder[filename]).publish(priority=PRIORITY_LOW)
+        # XXX countdown is workaround race condition between celery/redis BUG-796
+        IPublish(self.folder[filename]).publish(priority=PRIORITY_LOW, countdown=5)
 
     def sweep(self, keep):
         zope.event.notify(ObjectReloadedEvent(self.folder))  # XXX

--- a/core/src/zeit/speech/connection.py
+++ b/core/src/zeit/speech/connection.py
@@ -99,7 +99,8 @@ class Speech:
         self._add_audio_reference(speech)
 
     def _add_audio_reference(self, speech: IAudio):
-        IPublish(speech).publish(priority=PRIORITY_LOW)
+        # XXX countdown is workaround race condition between celery/redis BUG-796
+        IPublish(speech).publish(priority=PRIORITY_LOW, countdown=5)
         article = self._assert_article_unchanged(speech)
         if speech in IAudioReferences(article).items:
             log.debug('%s already references %s', article, speech)
@@ -108,7 +109,8 @@ class Speech:
             references = IAudioReferences(co)
             references.add(speech)
         log.info('Added reference from %s to %s', article, speech)
-        IPublish(article).publish(priority=PRIORITY_LOW)
+        # XXX countdown is workaround race condition between celery/redis BUG-796
+        IPublish(article).publish(priority=PRIORITY_LOW, countdown=5)
 
     def _article(self, speech: IAudio) -> IArticle:
         return zeit.cms.interfaces.ICMSContent(

--- a/core/src/zeit/speech/connection.py
+++ b/core/src/zeit/speech/connection.py
@@ -11,7 +11,7 @@ import zope.interface
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.interfaces import IUUID, ISemanticChange
 from zeit.cms.repository.interfaces import IFolder
-from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
+from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish, IPublishInfo
 from zeit.connector.search import SearchVar
 from zeit.content.article.interfaces import IArticle
 from zeit.content.audio.audio import AUDIO_SCHEMA_NS, Audio
@@ -99,8 +99,6 @@ class Speech:
         self._add_audio_reference(speech)
 
     def _add_audio_reference(self, speech: IAudio):
-        IPublish(speech).publish(background=False)
-
         article = self._assert_article_unchanged(speech)
         if speech in IAudioReferences(article).items:
             log.debug('%s already references %s', article, speech)
@@ -109,7 +107,8 @@ class Speech:
             references = IAudioReferences(co)
             references.add(speech)
         log.info('Added reference from %s to %s', article, speech)
-        IPublish(article).publish(background=False)
+        IPublish(speech).publish(priority=PRIORITY_LOW)
+        IPublish(article).publish(priority=PRIORITY_LOW)
 
     def _article(self, speech: IAudio) -> IArticle:
         return zeit.cms.interfaces.ICMSContent(

--- a/core/src/zeit/speech/connection.py
+++ b/core/src/zeit/speech/connection.py
@@ -99,6 +99,7 @@ class Speech:
         self._add_audio_reference(speech)
 
     def _add_audio_reference(self, speech: IAudio):
+        IPublish(speech).publish(priority=PRIORITY_LOW)
         article = self._assert_article_unchanged(speech)
         if speech in IAudioReferences(article).items:
             log.debug('%s already references %s', article, speech)
@@ -107,7 +108,6 @@ class Speech:
             references = IAudioReferences(co)
             references.add(speech)
         log.info('Added reference from %s to %s', article, speech)
-        IPublish(speech).publish(priority=PRIORITY_LOW)
         IPublish(article).publish(priority=PRIORITY_LOW)
 
     def _article(self, speech: IAudio) -> IArticle:

--- a/core/src/zeit/speech/tests/test_connection.py
+++ b/core/src/zeit/speech/tests/test_connection.py
@@ -85,7 +85,7 @@ class TestSpeech(FunctionalTestCase):
         article = ICMSContent(self.article_uid)
         audio = ICMSContent(self.unique_id)
         assert zeit.cms.workflow.mock._publish_count[article.uniqueId] == 2
-        assert zeit.cms.workflow.mock._publish_count[audio.uniqueId] == 1
+        assert zeit.cms.workflow.mock._publish_count[audio.uniqueId] == 2
 
     def test_if_article_changed_do_not_add_reference(self):
         IPublish(self.article).publish(background=False)

--- a/core/src/zeit/speech/tests/test_connection.py
+++ b/core/src/zeit/speech/tests/test_connection.py
@@ -85,7 +85,7 @@ class TestSpeech(FunctionalTestCase):
         article = ICMSContent(self.article_uid)
         audio = ICMSContent(self.unique_id)
         assert zeit.cms.workflow.mock._publish_count[article.uniqueId] == 2
-        assert zeit.cms.workflow.mock._publish_count[audio.uniqueId] == 2
+        assert zeit.cms.workflow.mock._publish_count[audio.uniqueId] == 1
 
     def test_if_article_changed_do_not_add_reference(self):
         IPublish(self.article).publish(background=False)

--- a/core/src/zeit/wochenmarkt/ingredients.py
+++ b/core/src/zeit/wochenmarkt/ingredients.py
@@ -8,7 +8,7 @@ import zope.component
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.cli import wait_for_commit
 from zeit.cms.interfaces import CONFIG_CACHE, ICMSContent
-from zeit.cms.workflow.interfaces import IPublish
+from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish
 import zeit.cms.cli
 import zeit.retresco.interfaces
 import zeit.wochenmarkt.interfaces
@@ -143,5 +143,5 @@ def collect_used():
     with checked_out(source) as co:
         co.xml = used
 
-    publish = IPublish(source)
-    wait_for_commit(lambda: publish.publish(background=False))
+    wait_for_commit(source)
+    IPublish(source).publish(priority=PRIORITY_LOW)


### PR DESCRIPTION
Es existieren noch 3 `publish(background=False)`

`core/src/zeit/push/banner.py` hat ein `publish`, aber die Eilmeldung ist in keinem celery Task, sofern ich mich da nicht verguckt habe.

Sonst nur noch im `update_topiclist` cronjob, aber kann als unabhängige CLI selbständig commits machen.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()