### PR TITLE
ZO-5282: retract overdue images

### DIFF
--- a/core/docs/changelog/ZO-5282.change
+++ b/core/docs/changelog/ZO-5282.change
@@ -1,0 +1,1 @@
+ZO-5282: retract overdue images

--- a/core/src/zeit/workflow/timebased.py
+++ b/core/src/zeit/workflow/timebased.py
@@ -1,5 +1,4 @@
 import datetime
-import functools
 import logging
 
 import grokcore.component as grok
@@ -206,6 +205,6 @@ def retract_overdue_objects():
             tms.delete_id(item['doc_id'])
         else:
             publish = zeit.cms.workflow.interfaces.IPublish(content)
-            retract = functools.partial(publish.retract, background=False)
+            publish.retract(background=False)
             log.info('Retracting %s', content)
-            wait_for_commit(retract)
+            wait_for_commit(content)


### PR DESCRIPTION
eb4164e7f0615fa0f271a153548cabb7b1adfe5c introduced a breaking change to the arguments, therefore the function was never executed

... ich habs kaputt gemacht, hmpf

### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

### gif
![]()