### PR TITLE
ZO-5192: Report complete video url to google pub/sub

### DIFF
--- a/core/docs/changelog/ZO-5192.change
+++ b/core/docs/changelog/ZO-5192.change
@@ -1,0 +1,1 @@
+ZO-5192: Report complete video url including seo slug to google pub/sub

--- a/core/src/zeit/content/video/interfaces.py
+++ b/core/src/zeit/content/video/interfaces.py
@@ -61,6 +61,8 @@ class IVideo(IVideoContent):
 
     has_advertisement = zope.schema.Bool(title=_('Has advertisement'), default=True)
 
+    live_url_base = zope.schema.URI(title=_('URL'), required=False, readonly=True)
+
     type = zope.schema.Choice(title=_('Video type'), source=VideoTypeSource(), required=False)
 
 

--- a/core/src/zeit/content/video/video.py
+++ b/core/src/zeit/content/video/video.py
@@ -115,6 +115,10 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
         titles = (t for t in (self.supertitle, self.title) if t)
         return zeit.cms.interfaces.normalize_filename(' '.join(titles))
 
+    @property
+    def live_url_base(self):
+        return f'{self.uniqueId}/{self.seo_slug}'
+
 
 @zope.component.adapter(zeit.content.video.interfaces.IVideo)
 @zope.interface.implementer(zeit.content.image.interfaces.IImages)
@@ -158,4 +162,4 @@ class DependenciesImages(zeit.cms.workflow.dependency.DependencyBase):
 @grok.adapter(zeit.content.video.interfaces.IVideo)
 @grok.implementer(zeit.push.interfaces.IPushURL)
 def video_push_url(context):
-    return context.uniqueId + '/' + context.seo_slug
+    return context.live_url_base

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -121,6 +121,12 @@ class VideoBigQuery(grok.Adapter, BigQueryMixin):
     grok.context(zeit.content.video.interfaces.IVideo)
     grok.name('bigquery')
 
+    @property
+    def live_url(self):
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
+        live_prefix = config['live-prefix']
+        return self.context.live_url_base.replace(zeit.cms.interfaces.ID_NAMESPACE, live_prefix)
+
 
 class CommentsMixin:
     def publish_json(self):

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -90,6 +90,20 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
             )
         self.assertTrue(IPublishInfo(article).published)
 
+    def test_video_contains_seo_slug_in_url(self):
+        from zeit.content.video.video import Video
+
+        video = Video()
+        video.supertitle = 'seo slug'
+        video.title = 'cookies'
+        video.uniqueId = 'http://xml.zeit.de/video'
+        json = zope.component.getAdapter(
+            video, zeit.workflow.interfaces.IPublisherData, name='bigquery'
+        ).publish_json()
+        assert json['properties']['meta']['url'] == (
+            'http://localhost/live-prefix/video/seo-slug-cookies'
+        )
+
     def test_bigquery_adapters_are_registered(self):
         import zeit.content.article.article
         import zeit.content.cp.centerpage


### PR DESCRIPTION
[zeit.web](https://github.com/ZeitOnline/zeit.web/blob/main/src/zeit/web/core/template.py#L763-L765) baut sich Video URLs aus dem seo-slug und der uniqueId zusammen, genau so wie die [PushURL](https://github.com/ZeitOnline/vivi/blob/main/core/src/zeit/content/video/video.py#L158-L161).

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![waiting](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXNrZmgyNzNndGZyeG1pa3B4Mzk2dmZyYmthbDZlMXVuZWJrNjc4aCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l3ZrVw8NkxIly/giphy.gif)