### PR TITLE
ZO-5358: Replace invalidate-based wait_for_commit helper with commit_with_retry

### DIFF
--- a/core/docs/changelog/ZO-5358.change
+++ b/core/docs/changelog/ZO-5358.change
@@ -1,0 +1,1 @@
+ZO-5358: Replace invalidate-based wait_for_commit helper with commit_with_retry

--- a/core/src/zeit/cms/testing.py
+++ b/core/src/zeit/cms/testing.py
@@ -931,6 +931,35 @@ class TestCatalog:
         pass
 
 
+class NoopDatamanager:
+    """Datamanager which does nothing."""
+
+    def abort(self, trans):
+        pass
+
+    def commit(self, trans):
+        pass
+
+    def tpc_begin(self, trans):
+        pass
+
+    def tpc_abort(self, trans):
+        pass
+
+    def sortKey(self):
+        return 'anything'
+
+
+class CommitExceptionDataManager(NoopDatamanager):
+    """DataManager which raises an exception in tpc_vote."""
+
+    def __init__(self, error):
+        self.error = error
+
+    def tpc_vote(self, trans):
+        raise self.error
+
+
 def copy_inherited_functions(base, locals):
     """py.test annotates the test function object with data, e.g. required
     fixtures. Normal inheritance means that there is only *one* function object

--- a/core/src/zeit/cms/tests/test_cli.py
+++ b/core/src/zeit/cms/tests/test_cli.py
@@ -1,0 +1,38 @@
+from ZODB.POSException import ConflictError
+import transaction
+
+from zeit.cms.checkout.helper import checked_out
+from zeit.cms.cli import commit_with_retry
+from zeit.cms.testing import CommitExceptionDataManager
+import zeit.cms.testing
+
+
+class RetryOnConflictTest(zeit.cms.testing.ZeitCmsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.content = self.repository['testcontent']
+
+    def test_commits_and_returns_on_success(self):
+        for _ in commit_with_retry():
+            with checked_out(self.content) as co:
+                co.ressort = 'Deutschland'
+        self.assertEqual('Deutschland', self.content.ressort)
+
+    def test_aborts_and_raises_after_max_attempts(self):
+        transaction.get().join(CommitExceptionDataManager(ConflictError()))
+
+        with self.assertRaises(ConflictError):
+            for _ in commit_with_retry(attempts=1):
+                with checked_out(self.content) as co:
+                    co.ressort = 'Deutschland'
+        # XXX mock connector writes immediately, so cannot check abort this way
+        # self.assertNotEqual('Deutschland', self.content.ressort)
+
+    def test_retries_the_specified_amount_of_times(self):
+        for i in commit_with_retry(attempts=3):
+            if i < 3:
+                transaction.get().join(CommitExceptionDataManager(ConflictError()))
+
+            with checked_out(self.content) as co:
+                co.ressort = 'Deutschland'
+        self.assertEqual('Deutschland', self.content.ressort)

--- a/core/src/zeit/wochenmarkt/ingredients.py
+++ b/core/src/zeit/wochenmarkt/ingredients.py
@@ -6,7 +6,7 @@ import lxml.etree
 import zope.component
 
 from zeit.cms.checkout.helper import checked_out
-from zeit.cms.cli import wait_for_commit
+from zeit.cms.cli import commit_with_retry
 from zeit.cms.interfaces import CONFIG_CACHE, ICMSContent
 from zeit.cms.workflow.interfaces import PRIORITY_LOW, IPublish
 import zeit.cms.cli
@@ -139,9 +139,9 @@ def collect_used():
     ingredients = zope.component.getUtility(zeit.wochenmarkt.interfaces.IIngredientsWhitelist)
     used = ingredients.collect_used()
 
-    source = ICMSContent('http://xml.zeit.de/data/ingredients_in_use.xml')
-    with checked_out(source) as co:
-        co.xml = used
+    for _ in commit_with_retry():
+        source = ICMSContent('http://xml.zeit.de/data/ingredients_in_use.xml')
+        with checked_out(source) as co:
+            co.xml = used
 
-    wait_for_commit(source)
     IPublish(source).publish(priority=PRIORITY_LOW)

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -20,6 +20,7 @@ from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.interfaces import ICMSContent
 from zeit.cms.related.interfaces import IRelatedContent
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
+from zeit.cms.testing import CommitExceptionDataManager
 from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
 import zeit.cms.related.interfaces
 import zeit.cms.testing
@@ -99,35 +100,6 @@ class PublishTest(zeit.workflow.testing.FunctionalTestCase):
 
         with self.assertRaises(ConflictError):
             IPublish(article).publish(background=False)
-
-
-class NoopDatamanager:
-    """Datamanager which does nothing."""
-
-    def abort(self, trans):
-        pass
-
-    def commit(self, trans):
-        pass
-
-    def tpc_begin(self, trans):
-        pass
-
-    def tpc_abort(self, trans):
-        pass
-
-    def sortKey(self):
-        return 'anything'
-
-
-class CommitExceptionDataManager(NoopDatamanager):
-    """DataManager which raises an exception in tpc_vote."""
-
-    def __init__(self, error):
-        self.error = error
-
-    def tpc_vote(self, trans):
-        raise self.error
 
 
 class FakePublishTask(zeit.workflow.publish.PublishRetractTask):

--- a/core/src/zeit/workflow/timebased.py
+++ b/core/src/zeit/workflow/timebased.py
@@ -6,7 +6,7 @@ import pytz
 import zope.component
 import zope.interface
 
-from zeit.cms.cli import wait_for_commit
+from zeit.cms.cli import commit_with_retry
 from zeit.cms.content.interfaces import WRITEABLE_ALWAYS
 from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.workflow.interfaces import PRIORITY_TIMEBASED
@@ -205,6 +205,6 @@ def retract_overdue_objects():
             tms.delete_id(item['doc_id'])
         else:
             publish = zeit.cms.workflow.interfaces.IPublish(content)
-            publish.retract(background=False)
-            log.info('Retracting %s', content)
-            wait_for_commit(content)
+            for _ in commit_with_retry():
+                log.info('Retracting %s', content)
+                publish.retract(background=False)


### PR DESCRIPTION
### Checklist

- [x] Documentation: naja, jedenfalls https://github.com/ZeitOnline/vivi-deployment/pull/990
- [x] Changelog
- [x] Tests
- [x] ~Translations~