### PR TITLE
ZO-5272: Add smoketest for publishing an imagegroup

### DIFF
--- a/.github/workflows/nightwatch.yaml
+++ b/.github/workflows/nightwatch.yaml
@@ -23,7 +23,11 @@ jobs:
         --override-type=json --overrides='[
           {"op": "add", "path": "/spec/serviceAccount", "value": "baseproject"},
           {"op": "add", "path": "/spec/containers/0/env", "value": [
-            {"name": "HTTPS_PROXY", "value": "http://static-ip-proxy.ops.zeit.de:3128"}
+            {"name": "HTTPS_PROXY", "value": "http://static-ip-proxy.ops.zeit.de:3128"},
+            {"name": "VIVI_XMLRPC_PASSWORD", "valueFrom": {"secretKeyRef": {
+              "name": "principals",
+              "key": "vivi_zeit.cms.principals_system.nightwatch"
+            }}}
           ]}
         ]'
 

--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,19 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+function vault_read() {
+    local path=$1
+    local field=$2
+
+    if [[ -z "$VAULT_TOKEN" ]]; then
+        VAULT_TOKEN=$(<"$HOME/.vault-token")
+    fi
+    curl --silent -H "X-Vault-Token: $VAULT_TOKEN" \
+         "${VAULT_ADDR%/}/v1/zon/v1/${path}" | \
+        sed -e "s+^.*\"${field}\":\"\([^\"]*\).*$+\1+"
+}
+
+
 COMMAND=$1
 case $COMMAND in
     smoke)
@@ -20,6 +33,7 @@ case $COMMAND in
                 < k8s/base/kustomization.yaml)
         docker buildx build --output type=docker --quiet --tag $image .
         docker run --rm -it \
+            -e VIVI_XMLRPC_PASSWORD=$(vault_read vivi/$environment/nightwatch password) \
             $image \
             --nightwatch-environment=$environment "$@"
         ;;

--- a/smoketest/k8s/base/kustomization.yaml
+++ b/smoketest/k8s/base/kustomization.yaml
@@ -5,6 +5,20 @@ components:
 - github.com/ZeitOnline/kustomize/components/nightwatch?ref=1.3
 - versions
 
+patches:
+- target:
+    kind: Deployment
+    name: nightwatch
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/env
+      value:
+        - name: VIVI_XMLRPC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: principals
+              key: vivi_zeit.cms.principals_system.nightwatch
+
 # See https://github.com/ZeitOnline/gh-action-workflows/blob/main/.github/workflows/nightwatch-build.yaml
 images:
 - name: nightwatch

--- a/smoketest/test_publisher.py
+++ b/smoketest/test_publisher.py
@@ -58,3 +58,18 @@ def test_publisher_updates_metadata(vivi, http, config, content):
             break
     else:
         pytest.fail('%s did not increase after %s seconds' % (current, timeout))
+
+
+def test_publish_image_works(vivi, config):
+    image = '/wirtschaft/2010-01/china-exportschlager'
+    job = vivi.publish(image)
+
+    timeout = 60
+    for _ in range(timeout):
+        sleep(1)
+        if vivi.job_status(job) == 'SUCCESS':
+            break
+    else:
+        pytest.fail(
+            'Publish returned error after %s seconds:\n%s' % (timeout, vivi.job_result(job))
+        )


### PR DESCRIPTION
Achtung, das funktioniert erst, wenn #749 deployed ist.

Staging ist deployed, aber Production noch nicht, dh ich trag mal eine [Silence für Production ein](https://alertmanager.ops.zeit.de/#/silences/6a49780c-1151-457c-9790-f277c4d4c514), bis das nächste Woche dann deployed wird.