### PR TITLE
ZO-4751: Remove unused facebook newstab integration

### DIFF
--- a/core/docs/changelog/ZO-4751.change
+++ b/core/docs/changelog/ZO-4751.change
@@ -1,0 +1,1 @@
+ZO-4751: Remove unused facebook newstab integration

--- a/core/src/zeit/cms/workflow/cli.py
+++ b/core/src/zeit/cms/workflow/cli.py
@@ -9,7 +9,7 @@ import zeit.cms.cli
 
 
 log = logging.getLogger(__name__)
-IGNORE_SERVICES = ['speechbert', 'facebooknewstab']
+IGNORE_SERVICES = ['speechbert']
 
 
 @zeit.cms.cli.runner(principal=zeit.cms.cli.principal_from_args)

--- a/core/src/zeit/content/article/testing.py
+++ b/core/src/zeit/content/article/testing.py
@@ -62,7 +62,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         zeit.wochenmarkt.testing.CONFIG_LAYER,
     ),
     # XXX Kludge because we depend on zeit.workflow.publish_3rdparty in our tests
-    patches={'zeit.workflow': {'facebooknewstab-startdate': '2021-03-24'}},
+    patches={'zeit.workflow': {}},
 )
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -1,5 +1,4 @@
 from itertools import chain
-import datetime
 import logging
 
 import grokcore.component as grok
@@ -230,42 +229,6 @@ class GalleryComments(grok.Adapter, CommentsMixin):
 class VideoComments(grok.Adapter, CommentsMixin):
     grok.context(zeit.content.video.interfaces.IVideo)
     grok.name('comments')
-
-
-@grok.implementer(zeit.workflow.interfaces.IPublisherData)
-class FacebookNewstab(grok.Adapter):
-    grok.context(zeit.content.article.interfaces.IArticle)
-    grok.name('facebooknewstab')
-
-    def publish_json(self):
-        config = zope.app.appsetup.product.getProductConfiguration('zeit.workflow') or {}
-        if not config.get('facebooknewstab-enabled'):  # XXX
-            return None
-        ignore_ressorts = {
-            x.strip().lower() for x in config.get('facebooknewstab-ignore-ressorts', '').split(',')
-        }
-        ressort = self.context.ressort
-        if ressort.lower() in ignore_ressorts:
-            return None
-        product_id = self.context.product.id
-        ignore_products = {
-            x.strip().lower() for x in config.get('facebooknewstab-ignore-products', '').split(',')
-        }
-        if product_id.lower() in ignore_products:
-            return None
-        info = zeit.cms.workflow.interfaces.IPublishInfo(self.context)
-        date_first_released = info.date_first_released
-        facebooknewstab_startdate = datetime.datetime.strptime(
-            config['facebooknewstab-startdate'], '%Y-%m-%d'
-        ).replace(tzinfo=datetime.timezone.utc)
-        if date_first_released is not None:
-            if date_first_released < facebooknewstab_startdate:
-                # Ignore resources before the cut off date.
-                return None
-        return {}
-
-    def retract_json(self):
-        return self.publish_json()
 
 
 class IgnoreMixin:

--- a/core/src/zeit/workflow/testing.py
+++ b/core/src/zeit/workflow/testing.py
@@ -17,8 +17,6 @@ product_config = """
     dependency-publish-limit 100
     blacklist /blacklist
     publisher-base-url http://localhost:8060/test/
-    facebooknewstab-startdate 2021-03-24
-    facebooknewstab-enabled true
     speechbert-ignore-genres datenvisualisierung video quiz
     speechbert-ignore-templates zon-liveblog
 </product-config>


### PR DESCRIPTION
"Das bisschen" übriggebliebene Config wurde in https://github.com/ZeitOnline/vivi-deployment/commit/6fe718ef443bb708736c7d8188228591db79d33c entfernt.