### PR TITLE
ZO-5471: Connector add must not overwrite without validating conflict…

### DIFF
--- a/core/docs/changelog/ZO-5471.change
+++ b/core/docs/changelog/ZO-5471.change
@@ -1,0 +1,2 @@
+ZO-5471: Connector add must check for inconsistencies before overwrite
+

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -4,6 +4,7 @@
   <article_image_animation>true</article_image_animation>
   <author_lookup_in_hdok>true</author_lookup_in_hdok>
   <content_caching>true</content_caching>
+  <content_checksum>false</content_checksum>
   <dpa_import_delete_image>true</dpa_import_delete_image>
   <embed_cmp_thirdparty>true</embed_cmp_thirdparty>
   <inlineform_alert_error>true</inlineform_alert_error>

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -781,7 +781,7 @@ class Content(DBObject):
         if self.is_collection:
             return None
 
-        alg = hashlib.md5(usedforsecurity=False)
+        alg = hashlib.sha256(usedforsecurity=False)
         meta = json.dumps(sorted(self.unsorted.items()), ensure_ascii=False)
         if self.binary_body:
             alg.update(meta.encode('utf-8'))

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -776,16 +776,14 @@ class Content(DBObject):
         """but now we have to get the body every time, we use to_webdav, sigh"""
         if self.is_collection:
             return None
-        if self.binary_body:
-            alg = hashlib.md5(usedforsecurity=False)
-            meta = json.dumps(sorted(self.unsorted.items()), ensure_ascii=False).encode('utf-8')
-            alg.update(meta)
-            return alg.hexdigest()
-        body = self.body
-        if not body:
-            return None
+
         alg = hashlib.md5(usedforsecurity=False)
-        alg.update(body.encode('utf-8'))
+        meta = json.dumps(sorted(self.unsorted.items()), ensure_ascii=False)
+        if self.binary_body:
+            alg.update(meta.encode('utf-8'))
+            return alg.hexdigest()
+        text = f'{meta}{self.body}'
+        alg.update(text.encode('utf-8'))
         return alg.hexdigest()
 
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -778,7 +778,7 @@ class Content(DBObject):
             return None
         if self.binary_body:
             alg = hashlib.md5(usedforsecurity=False)
-            meta = json.dumps(self.unsorted, ensure_ascii=False).encode('utf-8')
+            meta = json.dumps(sorted(self.unsorted.items()), ensure_ascii=False).encode('utf-8')
             alg.update(meta)
             return alg.hexdigest()
         body = self.body

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -46,6 +46,7 @@ import zope.component
 import zope.interface
 import zope.sqlalchemy
 
+from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.interfaces import DOCUMENT_SCHEMA_NS
 from zeit.cms.repository.interfaces import ConflictError
 from zeit.connector.interfaces import (
@@ -739,7 +740,9 @@ class Content(DBObject):
         props[('uuid', self.NS + 'document')] = '{urn:uuid:%s}' % self.id
         props[('type', self.NS + 'meta')] = self.type
         props[('is_collection', INTERNAL_PROPERTY)] = self.is_collection
-        props[CHECK_PROPERTY] = self._set_checksum()
+
+        if FEATURE_TOGGLES.find('content_checksum'):
+            props[CHECK_PROPERTY] = self._set_checksum()
 
         if self.lock:
             props[('lock_principal', INTERNAL_PROPERTY)] = self.lock.principal

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -777,7 +777,10 @@ class Content(DBObject):
         if self.is_collection:
             return None
         if self.binary_body:
-            return None
+            alg = hashlib.md5(usedforsecurity=False)
+            meta = json.dumps(self.unsorted, ensure_ascii=False).encode('utf-8')
+            alg.update(meta)
+            return alg.hexdigest()
         body = self.body
         if not body:
             return None

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -268,10 +268,11 @@ class Connector:
         (path.parent_path, path.name) = self._pathkey(uniqueid)
         current = content.to_webdav()
 
-        content_checksum = current.get(CHECK_PROPERTY)
-        resource_checksum = resource.properties.get(CHECK_PROPERTY)
-        if resource_checksum and content_checksum and resource_checksum != content_checksum:
-            raise ConflictError(uniqueid, f'{uniqueid} body has changed.')
+        if verify_etag:
+            content_checksum = current.get(CHECK_PROPERTY)
+            resource_checksum = resource.properties.get(CHECK_PROPERTY)
+            if resource_checksum and content_checksum and resource_checksum != content_checksum:
+                raise ConflictError(uniqueid, f'{uniqueid} body has changed.')
 
         current.update(resource.properties)
         content.from_webdav(current)

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -365,7 +365,8 @@ class TestCase(zeit.cms.testing.FunctionalTestCase):
 
     def add_resource(self, name, **kw):
         r = self.get_resource(name, **kw)
-        r = self.connector[r.id] = r
+        self.connector[r.id] = r
+        r = self.connector[r.id]
         transaction.commit()
         return r
 

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -303,9 +303,9 @@ class ContractValidation(zeit.connector.testing.SQLTest):
         folder = self.connector['http://xml.zeit.de/testing/folder']
         self.assertEqual(None, folder.properties[CHECK_PROPERTY])
 
-    def test_image_checksum_does_not_break(self):
-        res = self.get_resource('foo', b'mybody')
+    def test_create_image_generates_checksum(self):
+        res = self.get_resource('foo', b'mybody', properties={('foo', self.NS): 'bar'})
         res.type = 'file'
         self.connector.add(res)
         res = self.connector['http://xml.zeit.de/testing/foo']
-        self.assertEqual(None, res.properties[CHECK_PROPERTY])
+        self.assertEqual('d80f93b8617f4efdddcaa2729696bff4', res.properties[CHECK_PROPERTY])

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -308,4 +308,4 @@ class ContractValidation(zeit.connector.testing.SQLTest):
         res.type = 'file'
         self.connector.add(res)
         res = self.connector['http://xml.zeit.de/testing/foo']
-        self.assertEqual('d80f93b8617f4efdddcaa2729696bff4', res.properties[CHECK_PROPERTY])
+        self.assertEqual('ad705906dd2680277ea3ad7e109fb1a4', res.properties[CHECK_PROPERTY])

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -282,11 +282,11 @@ class ContractValidation(zeit.connector.testing.SQLTest):
 
     def test_setitem_generates_checksum(self):
         res = self.add_resource('foo', body=b'cookies', properties={('foo', self.NS): 'coffee'})
-        self.assertTrue(res.properties[CHECK_PROPERTY])
+        self.assertEqual('000ca6541faa17098d0a004afe35971c', res.properties[CHECK_PROPERTY])
 
     def test_empty_body_does_not_break_checksum(self):
         res = self.add_resource('foo', body=b'', properties={('foo', self.NS): 'coffee'})
-        self.assertEqual(None, res.properties[CHECK_PROPERTY])
+        self.assertEqual('57845fdbbb05eeaa9dca9de2f78d772b', res.properties[CHECK_PROPERTY])
 
     def test_conflicting_writes(self):
         self.connector.add(

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -284,12 +284,18 @@ class ContractValidation(zeit.connector.testing.SQLTest):
     def test_setitem_generates_checksum(self):
         FEATURE_TOGGLES.set('content_checksum')
         res = self.add_resource('foo', body=b'cookies', properties={('foo', self.NS): 'coffee'})
-        self.assertEqual('000ca6541faa17098d0a004afe35971c', res.properties[CHECK_PROPERTY])
+        self.assertEqual(
+            '4aa8c4d2a04ecdb13a745352677f261af9f92471af4152de2ee471fe2a6865ef',
+            res.properties[CHECK_PROPERTY],
+        )
 
     def test_empty_body_does_not_break_checksum(self):
         FEATURE_TOGGLES.set('content_checksum')
         res = self.add_resource('foo', body=b'', properties={('foo', self.NS): 'coffee'})
-        self.assertEqual('57845fdbbb05eeaa9dca9de2f78d772b', res.properties[CHECK_PROPERTY])
+        self.assertEqual(
+            '4fe7418985ce0d5c34cf69208ecde17c531c7bf900500bf2eebbd0b2f7c4c1ba',
+            res.properties[CHECK_PROPERTY],
+        )
 
     def test_conflicting_writes(self):
         FEATURE_TOGGLES.set('content_checksum')
@@ -314,4 +320,7 @@ class ContractValidation(zeit.connector.testing.SQLTest):
         res.type = 'file'
         self.connector.add(res)
         res = self.connector['http://xml.zeit.de/testing/foo']
-        self.assertEqual('ad705906dd2680277ea3ad7e109fb1a4', res.properties[CHECK_PROPERTY])
+        self.assertEqual(
+            '350f0ec7a03db95579f697056177e7a8ceba0a9c170e79d280fe78efda56f04f',
+            res.properties[CHECK_PROPERTY],
+        )


### PR DESCRIPTION
### Summary

Wir berechnen nun eine Checksumme aus Metadaten und Body um herauszufinden, ob es einen Konflikt zwischen dem Stand in der Datenbank und dem Stand der Resource zum Zeitpunkt des Auslesens  (z.B. Auschecken, alles was `__getitem__` sagt). 
Metadaten und Body werden berücksichtigt, um das Verhalten des DAV-Servers wiederherzustellen. Dort wurden die Metadaten ins xml kopiert, sodass es auch bei Änderungen der Metadaten einen neuen `('getetag', 'DAV:')` gab. 

Bei Inhalten vom Typ `binary-types` e.g. Bilder, etc. werden nur die Metadaten berücksichtigt, da der Body nicht in der Datenbank, sondern im Storage Bucket steht und auf keinen Fall jedesmal heruntergeladen werden soll.

- Fraglich, ist der Algorithmus sinnvoll? Oder sollte man was anderes in Richtung `repr(time.time()) + repr(random.random())` nehmen, oder doch lieber einen weiteren bzw. bestehenden Zeitstempel nutzen?
- Ist die Verortung sinnvoll? Jeder! nutzt `__getitem__` nicht nur vivi, sondern auch zeit.web

### Checklist

- [x] [Documentation](https://github.com/ZeitOnline/vivi-deployment/pull/1051)
- [x] Changelog
- [x] Tests
- [x] Feature Toggle in `staging` eintragen
- [x] Feature Toggle in `production` eintragen
- [ ] ~~Translations~~

### gif
![argh](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDBxNWF4a3hkang3dThxMGp5bmV1dDNzbWVvbDMxemp5MmU3NDgzMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qwqBucB9mSMec/giphy.gif)