### PR TITLE
MAINT: Setup-python action with broken archive, pin to 3.12.3

### DIFF
--- a/.github/workflows/testrunner.yaml
+++ b/.github/workflows/testrunner.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v5.1.0
         with:
-          python-version: "3.12"
+          python-version: "3.12.3"
           cache: "pip"
           cache-dependency-path: |
               deployment/components/source/*.txt


### PR DESCRIPTION
siehe https://github.com/actions/setup-python/issues/886

DEPLOYMENT_BRANCH = MAINT_setup-python-issues