### PR TITLE
ZO-5193: fix json representation of article body with whitespaces

### DIFF
--- a/core/docs/changelog/ZO-5193.change
+++ b/core/docs/changelog/ZO-5193.change
@@ -1,0 +1,1 @@
+ZO-5193: handle also whitespaces including XML for Big Query JSON transformation

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -145,11 +145,12 @@ def badgerfish(node):
     result = {}
     children = list(node.iterchildren())
 
-    if children and (node.text or any(x.tail for x in children)):
+    node_text = node.text.strip() if node.text else False
+    if children and (node_text or any(x.tail.strip() for x in children if x.tail)):
         result['$'] = ' '.join([x.strip() for x in node.xpath('.//text()')])
         children = []
-    elif node.text:
-        result['$'] = node.text
+    elif node_text:
+        result['$'] = node_text
 
     for key, value in node.attrib.items():
         key = lxml.etree.QName(key).localname

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -494,9 +494,16 @@ class BigQueryPayloadTest(zeit.workflow.testing.FunctionalTestCase):
         )
 
     def test_converts_body_to_badgerfish_json(self):
+        # fmt: off
+        body_string = """<body>
+<division><p>one</p>
+<p>two</p>\r  </division>
+</body>
+"""
+        # fmt: on
         self.article.xml.replace(
             self.article.xml.find('body'),
-            lxml.etree.fromstring('<body><division><p>one</p><p>two</p></division></body>'),
+            lxml.etree.fromstring(body_string),
         )
         data = zeit.workflow.testing.publish_json(self.article, 'bigquery')
         self.assertEqual({'division': {'p': [{'$': 'one'}, {'$': 'two'}]}}, data['body'])


### PR DESCRIPTION
### Checklist

- [ ] ~Documentation~ [gibt's bereits](https://docs.zeit.de/publisher/tasks/bigquery.html#bigquery)
- [x] Changelog
- [x] Tests
- [ ] ~Translations~ (nicht notwendig)

