### PR TITLE
ZO-5672: Try using ltree for path column

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "requests",
     "requests_file",
     "sqlalchemy>=2.0.0.dev0",
+    "sqlalchemy-utils",
     "transaction",
     "webob",
     "werkzeug",

--- a/core/src/zeit/connector/ltree.py
+++ b/core/src/zeit/connector/ltree.py
@@ -1,0 +1,43 @@
+from sqlalchemy import cast
+from sqlalchemy_utils import Ltree, LtreeType
+from sqlalchemy_utils.types.ltree import LQUERY
+
+from zeit.connector.interfaces import ID_NAMESPACE
+
+
+class ltree(Ltree):
+    def __init__(self, value):
+        if value.startswith(ID_NAMESPACE):
+            value = value.replace(ID_NAMESPACE, '', 1)
+            value = self._escape(value)
+            value = value.replace('/', '.')
+        super().__init__(value)
+
+    @staticmethod
+    def _escape(value):
+        return value.replace('.', '__dot__')
+
+    @staticmethod
+    def _unescape(value):
+        return value.replace('__dot__', '.')
+
+    def to_uniqueid(self):
+        return ID_NAMESPACE + '/'.join([self._unescape(x) for x in self.path.split('.')])
+
+
+def coerce_with_our_value_class(self, value):
+    if value:
+        return ltree(value)
+
+
+LtreeType._coerce = coerce_with_our_value_class
+
+
+def lquery_with_cast(self, other):  # That upstream omits this seems like a bug
+    if not isinstance(other, list):
+        other = cast(other, LQUERY)
+    return orig_lquery(self, other)
+
+
+orig_lquery = LtreeType.comparator_factory.lquery
+LtreeType.comparator_factory.lquery = lquery_with_cast

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -231,13 +231,10 @@ class Connector:
                 self.child_name_cache.pop(uniqueid, None)
                 return
             path_parent = '/'.join(self._pathkey(uniqueid))
-        result = [
-            (x.path_name, x.uniqueid)
-            for x in self.session.execute(
-                select(Content).where(Content.path_parent == path_parent)
-            ).scalars()
-        ]
-        self.child_name_cache[uniqueid] = set(x[1] for x in result)
+        result = self.session.execute(
+            select(Content).where(Content.path_parent == path_parent)
+        ).scalars()
+        self.child_name_cache[uniqueid] = set(x.uniqueid for x in result)
 
     def _update_parent_child_name_cache(self, uniqueid, operation):
         parent = os.path.split(uniqueid)[0]

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -286,6 +286,7 @@ class SQLDatabaseLayer(plone.testing.Layer):
         c = self['sql_connection']
         t = c.begin()
         zeit.connector.postgresql.METADATA.drop_all(c)
+        c.execute(sql('CREATE EXTENSION IF NOT EXISTS ltree'))
         zeit.connector.postgresql.METADATA.create_all(c)
         t.commit()
 

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -865,14 +865,14 @@ class SQLProtocol:
         self.connector.session.delete(content)
 
     def add_in_storage(self, name):
-        from zeit.connector.postgresql import Content
+        from zeit.connector.postgresql import Content, ltree
 
         resource = self.get_resource(name)
         content = Content()
         content.from_webdav(resource.properties)
         content.type = resource.type
         content.is_collection = resource.is_collection
-        (content.path_parent, content.path_name) = self.connector._pathkey(resource.id)
+        content.path = ltree(resource.id)
         self.connector.session.add(content)
 
     def has_body_cache(self, uniqueid):

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -865,16 +865,15 @@ class SQLProtocol:
         self.connector.session.delete(content)
 
     def add_in_storage(self, name):
-        from zeit.connector.postgresql import Content, Path
+        from zeit.connector.postgresql import Content
 
         resource = self.get_resource(name)
         content = Content()
-        path = Path(content=content)
         content.from_webdav(resource.properties)
         content.type = resource.type
         content.is_collection = resource.is_collection
-        (path.parent_path, path.name) = self.connector._pathkey(resource.id)
-        self.connector.session.add(path)
+        (content.path_parent, content.path_name) = self.connector._pathkey(resource.id)
+        self.connector.session.add(content)
 
     def has_body_cache(self, uniqueid):
         return uniqueid in self.connector.body_cache

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -33,8 +33,8 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         )
         self.connector.add(res)
         props = self.connector._get_content(res.id)
-        self.assertEqual('foo', props.path.name)
-        self.assertEqual('/testing', props.path.parent_path)
+        self.assertEqual('foo', props.path_name)
+        self.assertEqual('/testing', props.path_parent)
         self.assertEqual('testing', props.type)
         self.assertEqual(False, props.is_collection)
         self.assertEqual('deadbeaf-c5aa-4232-837a-ae6701270436', props.id)
@@ -141,7 +141,7 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
             del self.connector[res.id]
 
     def test_delete_removes_rows_from_all_tables(self):
-        from zeit.connector.postgresql import Content, Path
+        from zeit.connector.postgresql import Content
 
         res = self.get_resource('foo', b'mybody')
         self.connector.add(res)
@@ -149,7 +149,6 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         uuid = props.id
         del self.connector[res.id]
         transaction.commit()
-        self.assertEqual(None, self.connector.session.get(Path, self.connector._pathkey(res.id)))
         self.assertEqual(None, self.connector.session.get(Content, uuid))
 
     def test_search_for_uuid_uses_indexed_column(self):
@@ -234,8 +233,8 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
 
     def test_delete_content_with_lock_raises(self):
         """We intentionally have not declared `ON DELETE CASCADE` from Lock to
-        Content (there is one for Path though), to prevent accidental deletions
-        of locked content when operating directly on the DB.
+        Content, to prevent accidental deletions of locked content when
+        operating directly on the DB.
         """
         self._create_lock(1)
         content = self.connector._get_content('http://xml.zeit.de/testing/foo-1')


### PR DESCRIPTION
Hauptsächlich zu Archivzwecken, stellt sich nämlich raus, für "Dateinamen" ist ltree nicht wirklich gedacht und daher halt auch nicht geeignet (es erlaubt nur `A-Za-z0-9_`, insb kein `.` oder `-`).