### PR TITLE
ZO-5779: Skip XML comments in BigQuery JSON serialization

### DIFF
--- a/core/docs/changelog/ZO-5779.change
+++ b/core/docs/changelog/ZO-5779.change
@@ -1,0 +1,1 @@
+ZO-5779: Skip XML comments in BigQuery JSON serialization

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -157,6 +157,10 @@ def badgerfish(node):
         result[f'@{key}'] = value
 
     for child in children:
+        # https://lxml.de/FAQ.html#how-can-i-find-out-if-an-element-is-a-comment-or-pi
+        if not isinstance(child.tag, str):
+            continue
+
         child_tag = lxml.etree.QName(child.tag).localname
         sub = badgerfish(child)[child_tag]
         existing = result.get(child_tag)

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -543,3 +543,6 @@ class BadgerfishTest(unittest.TestCase):
             {'a': {'$': 'before child'}}, self.badgerfish('<a>before <b>child</b></a>')
         )
         self.assertEqual({'a': {'$': 'child after'}}, self.badgerfish('<a><b>child</b> after</a>'))
+
+    def test_comment_is_removed(self):
+        self.assertEqual({'a': {}}, self.badgerfish('<a><!-- comment --></a>'))


### PR DESCRIPTION
### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~