### PR TITLE
ZO-5176: workaround to unblock deployments until ZO-5795 is implemented

### DIFF
--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -43,6 +43,7 @@ import sqlalchemy
 import sqlalchemy.event
 import sqlalchemy.orm
 import transaction
+import zope.app.appsetup.product
 import zope.component
 import zope.interface
 import zope.sqlalchemy
@@ -79,7 +80,8 @@ def feature_toggle(key):
 
     Using feature toggles from a file which is stored inside the database
     inside the connector is unfortunately not possible"""
-    return os.environ.get(key) is not None
+    config = zope.app.appsetup.product.getProductConfiguration('zeit.connector')
+    return config.get(key) is not None
 
 
 class LockStatus(Enum):

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -9,7 +9,6 @@ import google.api_core.exceptions
 import pytz
 import transaction
 
-from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.repository.interfaces import ConflictError
 from zeit.connector.interfaces import INTERNAL_PROPERTY
 from zeit.connector.postgresql import Lock, _unlock_overdue_locks
@@ -32,8 +31,8 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
                 ('bar', 'http://namespaces.zeit.de/CMS/two'): 'bar',
             },
         )
-        FEATURE_TOGGLES.set('write_to_new_columns_name_parent_path')
-        self.connector.add(res)
+        with mock.patch('zeit.connector.postgresql.feature_toggle', return_value=True):
+            self.connector.add(res)
         props = self.connector._get_content(res.id)
         self.assertEqual('foo', props.path.name)
         self.assertEqual('/testing', props.path.parent_path)


### PR DESCRIPTION
Unblocking PR bis ZO-5795 implementiert

### Checklist

- [x] Documentation
- [ ] ~~Changelog~~ -> Changelog vom vorherigen PR existiert noch
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()