### PR TITLE
ZO-5697: only read from new columns name and parent_path from Content table

### DIFF
--- a/core/docs/changelog/ZO-5697.change
+++ b/core/docs/changelog/ZO-5697.change
@@ -1,0 +1,1 @@
+ZO-5697: only read from new columns name and parent_path from Content table

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -865,16 +865,15 @@ class SQLProtocol:
         self.connector.session.delete(content)
 
     def add_in_storage(self, name):
-        from zeit.connector.postgresql import Content, Path
+        from zeit.connector.postgresql import Content
 
         resource = self.get_resource(name)
         content = Content()
-        path = Path(content=content)
         content.from_webdav(resource.properties)
         content.type = resource.type
         content.is_collection = resource.is_collection
-        (path.parent_path, path.name) = self.connector._pathkey(resource.id)
-        self.connector.session.add(path)
+        (content.parent_path, content.name) = self.connector._pathkey(resource.id)
+        self.connector.session.add(content)
 
     def has_body_cache(self, uniqueid):
         return uniqueid in self.connector.body_cache

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -31,11 +31,8 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
                 ('bar', 'http://namespaces.zeit.de/CMS/two'): 'bar',
             },
         )
-        with mock.patch('zeit.connector.postgresql.feature_toggle', return_value=True):
-            self.connector.add(res)
+        self.connector.add(res)
         props = self.connector._get_content(res.id)
-        self.assertEqual('foo', props.path.name)
-        self.assertEqual('/testing', props.path.parent_path)
         self.assertEqual('foo', props.name)
         self.assertEqual('/testing', props.parent_path)
         self.assertEqual('testing', props.type)
@@ -144,7 +141,7 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
             del self.connector[res.id]
 
     def test_delete_removes_rows_from_all_tables(self):
-        from zeit.connector.postgresql import Content, Path
+        from zeit.connector.postgresql import Content
 
         res = self.get_resource('foo', b'mybody')
         self.connector.add(res)
@@ -152,7 +149,6 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         uuid = props.id
         del self.connector[res.id]
         transaction.commit()
-        self.assertEqual(None, self.connector.session.get(Path, self.connector._pathkey(res.id)))
         self.assertEqual(None, self.connector.session.get(Content, uuid))
 
     def test_search_for_uuid_uses_indexed_column(self):
@@ -237,8 +233,8 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
 
     def test_delete_content_with_lock_raises(self):
         """We intentionally have not declared `ON DELETE CASCADE` from Lock to
-        Content (there is one for Path though), to prevent accidental deletions
-        of locked content when operating directly on the DB.
+        Content, to prevent accidental deletions of locked content when
+        operating directly on the DB.
         """
         self._create_lock(1)
         content = self.connector._get_content('http://xml.zeit.de/testing/foo-1')


### PR DESCRIPTION
-> geblockt durch https://github.com/ZeitOnline/vivi-deployment/pull/1076

siehe auch ZO-5176

### Checklist

- [x] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()