### PR TITLE
ZO-4165: Replace commentjson with rapidjson and support comments

### DIFF
--- a/core/docs/changelog/ZO-4165.change
+++ b/core/docs/changelog/ZO-4165.change
@@ -1,0 +1,1 @@
+ZO-4165: Replace commentjson with rapidjson and support comments

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "btrees",
     "bugsnag",
     "collective.monkeypatcher",
-    "commentjson",
     "cryptography",  # so pyjwt can offer rsa
     "elasticsearch >=7.16.0, <8.0.0",  # ZO-2516
     "filetype",
@@ -32,6 +31,7 @@ dependencies = [
     "prometheus-client",
     "pyjwt>=2.0.0",
     "pyramid_dogpile_cache2",
+    "python-rapidjson",
     "pytz",
     "pyyaml",
     "requests",

--- a/core/src/zeit/content/text/browser/json.py
+++ b/core/src/zeit/content/text/browser/json.py
@@ -1,7 +1,7 @@
-import commentjson
 import pygments
 import pygments.formatters
 import pygments.lexers
+import rapidjson
 import zope.component
 import zope.formlib.form
 import zope.formlib.textwidgets
@@ -38,7 +38,7 @@ class JSONInputWidget(zope.formlib.textwidgets.TextAreaWidget):
     def _toFieldValue(self, input):
         value = super()._toFieldValue(input)
         try:
-            commentjson.loads(value)
+            rapidjson.loads(value, parse_mode=rapidjson.PM_COMMENTS)
         except Exception as e:
             raise zope.app.form.interfaces.ConversionError(e)
         return value

--- a/core/src/zeit/content/text/browser/tests/test_json.py
+++ b/core/src/zeit/content/text/browser/tests/test_json.py
@@ -17,7 +17,7 @@ class JSONBrowserTest(zeit.content.text.testing.BrowserTestCase):
         b.getControl('File name').value = 'foo'
         b.getControl('Content').value = '{"foo":'
         b.getControl('Add').click()
-        self.assertEllipsis('...Unexpected token...', b.contents)
+        self.assertEllipsis('...Parse error at offset...: Invalid value...', b.contents)
 
         b.getControl('Content').value = '{"foo": "bar"}'
         b.getControl('Add').click()

--- a/core/src/zeit/content/text/json.py
+++ b/core/src/zeit/content/text/json.py
@@ -1,10 +1,10 @@
 import logging
 
 from referencing.jsonschema import DRAFT202012
-import commentjson
 import grokcore.component as grok
 import jsonschema
 import openapi_schema_validator
+import rapidjson
 import referencing
 import requests
 import requests_file
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 class JSON(zeit.content.text.text.Text):
     @property
     def data(self):
-        return commentjson.loads(self.text)
+        return rapidjson.loads(self.text, parse_mode=rapidjson.PM_COMMENTS)
 
 
 class JSONType(zeit.content.text.text.TextType):

--- a/core/src/zeit/content/text/tests/test_json.py
+++ b/core/src/zeit/content/text/tests/test_json.py
@@ -1,3 +1,4 @@
+import zeit.cms.checkout.helper
 import zeit.content.text.interfaces
 import zeit.content.text.json
 import zeit.content.text.testing
@@ -44,3 +45,15 @@ class JSONValidationTestCase(zeit.content.text.testing.FunctionalTestCase):
         validation.schema_url = zeit.content.text.testing.schema_url
         validation.field_name = 'overlord'
         validation.validate()
+
+
+class JSONTestCase(zeit.content.text.testing.FunctionalTestCase):
+    def test_json_supports_comments(self):
+        json_content = zeit.content.text.json.JSON()
+        json_content.text = '// this is a comment\n["{urn:uuid:d995ba5a}"]'
+        self.repository['json'] = json_content
+        with zeit.cms.checkout.helper.checked_out(self.repository['json']):
+            pass
+        content = self.repository['json']
+        self.assertEqual(content.text, '// this is a comment\n["{urn:uuid:d995ba5a}"]')
+        self.assertEqual(content.data, ['{urn:uuid:d995ba5a}'])


### PR DESCRIPTION
die Fehlermeldung war vorher auch nicht übersetzt.
DEPLOYMENT_BRANCH=ZO-4165_rm_commentjson

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![boom](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExamUwYWMwOHQ3YWpncTZ4dm9kcTBvdHhiY3kzZWU4dGtzOHk5dGRpMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MJQJow1uUbNDy/giphy.gif)