### PR TITLE
ZO-5548: add index now configuration

### DIFF
--- a/core/docs/changelog/ZO-5548.change
+++ b/core/docs/changelog/ZO-5548.change
@@ -1,0 +1,1 @@
+ZO-5548: add IndexNow implementation for publish article and publish centerpage

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -404,3 +404,23 @@ class PublisherData(grok.Adapter):
         if FEATURE_TOGGLES.find(f'disable_publisher_{name}'):
             return True
         return False
+
+
+class IndexNowMixin(LiveUrlMixin):
+    def publish_json(self):
+        return {'url': self.live_url}
+
+    def retract_json(self):
+        return None
+
+
+@grok.implementer(zeit.workflow.interfaces.IPublisherData)
+class ArticleIndexNow(grok.Adapter, IndexNowMixin):
+    grok.context(zeit.content.article.interfaces.IArticle)
+    grok.name('indexnow')
+
+
+@grok.implementer(zeit.workflow.interfaces.IPublisherData)
+class CenterPageIndexNow(grok.Adapter, IndexNowMixin):
+    grok.context(zeit.content.cp.interfaces.ICenterPage)
+    grok.name('indexnow')

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -107,7 +107,14 @@ class AuthorDashboard(grok.Adapter):
         return None
 
 
-class BigQueryMixin:
+class LiveUrlMixin:
+    @property
+    def live_url(self):
+        live_prefix = zeit.cms.config.required('zeit.cms', 'live-prefix')
+        return self.context.uniqueId.replace(zeit.cms.interfaces.ID_NAMESPACE, live_prefix)
+
+
+class BigQueryMixin(LiveUrlMixin):
     def publish_json(self):
         tms = zeit.retresco.interfaces.ITMSRepresentation(self.context)()
         if tms is None:
@@ -128,11 +135,6 @@ class BigQueryMixin:
                 'document': {'uuid': uuid.id},
             }
         }
-
-    @property
-    def live_url(self):
-        live_prefix = zeit.cms.config.required('zeit.cms', 'live-prefix')
-        return self.context.uniqueId.replace(zeit.cms.interfaces.ID_NAMESPACE, live_prefix)
 
 
 def badgerfish(node):

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -541,3 +541,17 @@ class BadgerfishTest(unittest.TestCase):
 
     def test_comment_is_removed(self):
         self.assertEqual({'a': {}}, self.badgerfish('<a><!-- comment --></a>'))
+
+
+class IndexNowPayloadTest(zeit.workflow.testing.FunctionalTestCase):
+    def test_index_now_payload_article(self):
+        article = self.repository['testcontent']
+        zope.interface.alsoProvides(article, zeit.content.article.interfaces.IArticle)
+        data = zeit.workflow.testing.publish_json(article, 'indexnow')
+        self.assertEqual('http://localhost/live-prefix/testcontent', data['url'])
+
+    def test_index_now_payload_centerpage(self):
+        article = self.repository['testcontent']
+        zope.interface.alsoProvides(article, zeit.content.cp.interfaces.ICenterPage)
+        data = zeit.workflow.testing.publish_json(article, 'indexnow')
+        self.assertEqual('http://localhost/live-prefix/testcontent', data['url'])

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -111,3 +111,12 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         )
         payload = data_factory.retract_json()
         assert payload is None
+
+    def test_index_now_retract(self):
+        article = self.repository['testcontent']
+        zope.interface.alsoProvides(article, zeit.content.cp.interfaces.ICenterPage)
+        data_factory = zope.component.getAdapter(
+            article, zeit.workflow.interfaces.IPublisherData, name='indexnow'
+        )
+        data = data_factory.retract_json()
+        assert data is None


### PR DESCRIPTION
Neuen Publisher-Workflow für [IndexNow](https://www.bing.com/indexnow) hinzugefügt.
[Ticket: ZO-5548](https://zeit-online.atlassian.net/browse/ZO-5548)
Vault-PR: https://github.com/ZeitOnline/vault/pull/250
### Checklist

- [x] Documentation ➡️ Siehe https://github.com/ZeitOnline/publisher/pull/442
- [x] Changelog
- [x] Tests

### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExemgyM2Z3enN3YXk5M3gyZDVqcmxzNGdxM2g1aXJ4a2I4bnR6cmRxbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tKTPMNIms2icA989i2/giphy-downsized.gif)