### PR TITLE
ZO-5850: Don't wait if the DB revision is newer than what we know on disk

### DIFF
--- a/core/docs/changelog/ZO-5850.change
+++ b/core/docs/changelog/ZO-5850.change
@@ -1,0 +1,1 @@
+ZO-5850: Don't wait if the DB revision is newer than what we know on disk

--- a/core/src/zeit/connector/cli.py
+++ b/core/src/zeit/connector/cli.py
@@ -90,7 +90,7 @@ def _db_is_current(context):
     head_revision = script.as_revision_number('heads') or ()
     db_revision = context.get_current_heads()
     # Like alembic.script.base._upgrade_revs, but readonly
-    todo = script.iterate_revisions(head_revision, db_revision, implicit_base=True)
+    todo = script.iterate_revisions('head', db_revision, implicit_base=True)
     try:
         todo = len(list(todo))
     except ResolutionError:

--- a/core/src/zeit/connector/tests/fixtures/alembic/alembic.ini
+++ b/core/src/zeit/connector/tests/fixtures/alembic/alembic.ini
@@ -9,3 +9,6 @@ version_locations = %(here)s/two
 
 [three]
 version_locations = %(here)s/three
+
+[conflict]
+version_locations = %(here)s/conflict

--- a/core/src/zeit/connector/tests/fixtures/alembic/alembic.ini
+++ b/core/src/zeit/connector/tests/fixtures/alembic/alembic.ini
@@ -1,0 +1,11 @@
+[DEFAULT]
+# Unused, tests set up the connection themselves, and never run anything that
+# would need an env.py
+script_location = %(here)s
+file_template = %%(rev)s
+
+[two]
+version_locations = %(here)s/two
+
+[three]
+version_locations = %(here)s/three

--- a/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000001.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000001.py
@@ -1,0 +1,12 @@
+revision = '000000000001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000002.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000002.py
@@ -1,0 +1,12 @@
+revision = '000000000002'
+down_revision = '000000000001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000003.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/conflict/000000000003.py
@@ -1,0 +1,12 @@
+revision = '000000000003'
+down_revision = '000000000001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/three/000000000001.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/three/000000000001.py
@@ -1,0 +1,12 @@
+revision = '000000000001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/three/000000000002.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/three/000000000002.py
@@ -1,0 +1,12 @@
+revision = '000000000002'
+down_revision = '000000000001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/three/000000000003.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/three/000000000003.py
@@ -1,0 +1,12 @@
+revision = '000000000003'
+down_revision = '000000000002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/two/000000000001.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/two/000000000001.py
@@ -1,0 +1,12 @@
+revision = '000000000001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/fixtures/alembic/two/000000000002.py
+++ b/core/src/zeit/connector/tests/fixtures/alembic/two/000000000002.py
@@ -1,0 +1,12 @@
+revision = '000000000002'
+down_revision = '000000000001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -72,14 +72,14 @@ def alembic_upgrade(connection, name, **kw):
         ini_section=name,
     )
     script = alembic.script.ScriptDirectory.from_config(config)
-    with EnvironmentContext(config, script, as_sql=connection is None) as context:
-        context.configure(
-            connection=connection,
-            fn=lambda rev, context: script._upgrade_revs('head', rev),
-            transaction_per_migration=True,
-            **kw,
-        )
-        context.run_migrations()
+    context = EnvironmentContext(config, script, as_sql=connection is None)
+    context.configure(
+        connection=connection,
+        fn=lambda rev, context: script._upgrade_revs('head', rev),
+        transaction_per_migration=True,
+        **kw,
+    )
+    context.run_migrations()
 
     if connection is not None:
         connection.execute(sql('DROP TABLE alembic_version'))

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -168,3 +168,10 @@ class MigrationsWait(DBTestCase):
         context.run_migrations()
         context = self.alembic_context('two')
         self.assertTrue(_db_is_current(context.get_context()))
+
+    def test_db_is_current_raises_when_revisions_conflict(self):
+        from alembic.script.revision import MultipleHeads
+
+        context = self.alembic_context('conflict')
+        with self.assertRaises(MultipleHeads):
+            _db_is_current(context.get_context())

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -14,6 +14,7 @@ import alembic.config
 import alembic.script
 import sqlalchemy
 
+from zeit.connector.cli import _db_is_current
 import zeit.connector.testing
 
 
@@ -125,3 +126,45 @@ class MigrationsLint(unittest.TestCase):
         if proc.returncode:
             output = stdout.decode('utf-8') + stderr.decode('utf-8')
             self.fail('squawk returned errors:\n' + output)
+
+
+class MigrationsWait(DBTestCase):
+    def setUp(self):
+        super().setUp()
+        self.createdb()
+        self.connection = self.engine.connect()
+
+    def tearDown(self):
+        self.connection.close()
+        self.dropdb()
+        super().tearDown()
+
+    def alembic_context(self, name):
+        config = alembic.config.Config(
+            importlib.resources.files(zeit.connector) / 'tests/fixtures/alembic/alembic.ini',
+            ini_section=name,
+        )
+        script = alembic.script.ScriptDirectory.from_config(config)
+        context = EnvironmentContext(config, script)
+        context.target = []  # Kludgy closure-based API
+        context.configure(
+            connection=self.connection,
+            fn=lambda rev, _: script._upgrade_revs(context.target[0], rev),
+        )
+        return context
+
+    def test_db_is_current_when_disk_revision_matches_exactly(self):
+        context = self.alembic_context('two')
+        context.target = ['000000000001']
+        context.run_migrations()
+        self.assertFalse(_db_is_current(context.get_context()))
+        context.target = ['000000000002']
+        context.run_migrations()
+        self.assertTrue(_db_is_current(context.get_context()))
+
+    def test_db_is_current_when_db_revision_is_unknown_on_disk(self):
+        context = self.alembic_context('three')
+        context.target = ['000000000003']
+        context.run_migrations()
+        context = self.alembic_context('two')
+        self.assertTrue(_db_is_current(context.get_context()))

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -72,7 +72,7 @@ def alembic_upgrade(connection, name, **kw):
         ini_section=name,
     )
     script = alembic.script.ScriptDirectory.from_config(config)
-    with EnvironmentContext(config=config, script=script, as_sql=connection is None) as context:
+    with EnvironmentContext(config, script, as_sql=connection is None) as context:
         context.configure(
             connection=connection,
             fn=lambda rev, context: script._upgrade_revs('head', rev),


### PR DESCRIPTION
Since we don't always update the code in lock-step with the DB in different systems, we need to be more lenient here.

### Checklist

- [x] Basiert auf #807 (wegen Testsetup), den also zuerst mergen.
- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~