### PR TITLE
MAINT: Rm obsolete namespaces

### DIFF
--- a/core/docs/changelog/namespaces.maint
+++ b/core/docs/changelog/namespaces.maint
@@ -1,0 +1,1 @@
+DEV-852, ZO-5801: Remove obsolete namespaces

--- a/core/src/zeit/cms/interfaces.py
+++ b/core/src/zeit/cms/interfaces.py
@@ -17,9 +17,7 @@ import zeit.cms.config
 
 DOCUMENT_SCHEMA_NS = 'http://namespaces.zeit.de/CMS/document'
 META_SCHEMA_NS = 'http://namespaces.zeit.de/CMS/meta'
-QPS_SCHEMA_NS = 'http://namespaces.zeit.de/QPS/attributes'
 ID_NAMESPACE = 'http://xml.zeit.de/'
-TEASER_NAMESPACE = 'http://xml.zeit.de/CMS/Teaser'
 PRINT_NAMESPACE = 'http://namespaces.zeit.de/CMS/print'
 IR_NAMESPACE = 'http://namespaces.zeit.de/CMS/interred'
 ZEITWEB_NAMESPACE = 'http://namespaces.zeit.de/CMS/zeit.web'

--- a/core/src/zeit/content/cp/interfaces.py
+++ b/core/src/zeit/content/cp/interfaces.py
@@ -31,7 +31,6 @@ log = logging.getLogger(__name__)
 
 
 DAV_NAMESPACE = 'http://namespaces.zeit.de/CMS/zeit.content.cp'
-TEASER_ID_NAMESPACE = 'http://teaser.vivi.zeit.de/'
 
 
 zope.security.checker.BasicTypes[fractions.Fraction] = zope.security.checker.NoProxy


### PR DESCRIPTION
![goodbye](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2lmMXlpemoycWdvdThkZXo1eXNzbzBtcHM2ZDMzdWl3YmFsajI1cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fX5cZemSfX1cMZYuUJ/giphy.gif)

related https://github.com/ZeitOnline/vivi/commit/90cb829c9c1fabc3d82879fa75efb4d7f0be0ba5 and https://zeit-online.atlassian.net/browse/DEV-852