### PR TITLE
FIX: repair image encoder parameters not loading

### DIFF
--- a/core/docs/changelog/encoder-parameters-not-loading.fix
+++ b/core/docs/changelog/encoder-parameters-not-loading.fix
@@ -1,0 +1,1 @@
+FIX: repair image encoder parameters not loading from xml

--- a/core/src/zeit/content/image/interfaces.py
+++ b/core/src/zeit/content/image/interfaces.py
@@ -435,7 +435,7 @@ class EncoderParameters(zeit.cms.content.sources.CachedXMLBase):
     def values(self):
         result = {}
         for encoder in self._get_tree().iterfind('encoder'):
-            result[encoder.get('name')] = params = {}
+            result[encoder.get('type')] = params = {}
             for node in encoder.iterfind('param'):
                 params[node.get('name')] = node.pyval
         return result

--- a/core/src/zeit/content/image/tests/fixtures/encoders.xml
+++ b/core/src/zeit/content/image/tests/fixtures/encoders.xml
@@ -9,4 +9,7 @@
   <encoder type="webp">
     <param name="quality" xsi:type="xsd:int">85</param>
   </encoder>
+  <encoder type="avif">
+    <param name="quality" xsi:type="xsd:int">85</param>
+  </encoder>
 </encoders>

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -264,3 +264,21 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
         variant = Variant(id='wide', focus_x=0.5, focus_y=0.5, zoom=1, aspect_ratio='1:1')
         image = self.transform.create_variant_image(variant, size=(0, 0), fill_color='ffffff')
         self.assertEqual((8, 8), image.getImageSize())
+
+    def test_encoder_parameters_configuration_loads_correctly(self):
+        configuration = zeit.content.image.interfaces.ENCODER_PARAMETERS.values()
+        self.assertEqual(
+            {
+                'jpg': {'quality': 85, 'optimize': True, 'progressive': True},
+                'webp': {'quality': 85},
+                'avif': {'quality': 85},
+            },
+            configuration,
+        )
+
+    def test_encoder_parameters_are_configurable(self):
+        group = zeit.content.image.testing.create_image_group_with_master_image()
+        variants = group.create_variant_image(
+            zeit.content.image.interfaces.IVariants(group)['default'], format='JPEG'
+        )
+        self.assertLess(variants.size, group['master-image.jpg'].size)


### PR DESCRIPTION
Es gab einen kleinen Typo beim Laden der `encoders.xml`, die für die Einstellungen der Kompression / Umwandlung für verschiedene Bildformate zuständig war. Dadurch wurde die Konfiguration nicht geladen, das wurde in diesem PR gefixt. Außerdem wurden Tests hinzugefügt.
### Checklist

- [x] Changelog
- [x] Tests


### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExamNodGNkanY4eDAxZHRjYW8yc3psbTR5am5wODNucGo3Z2JlazJydCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/11JA9axStWivLUyhsB/giphy-downsized.gif)