### PR TITLE
FIX: Adjust image-encoders.xml config file format so it actually works

### DIFF
--- a/core/docs/changelog/encoder.fix
+++ b/core/docs/changelog/encoder.fix
@@ -1,0 +1,1 @@
+Fix image-encoders.xml config file format so it actually works

--- a/core/src/zeit/content/image/interfaces.py
+++ b/core/src/zeit/content/image/interfaces.py
@@ -435,7 +435,7 @@ class EncoderParameters(zeit.cms.content.sources.CachedXMLBase):
     def values(self):
         result = {}
         for encoder in self._get_tree().iterfind('encoder'):
-            result[encoder.get('name')] = params = {}
+            result[encoder.get('format')] = params = {}
             for node in encoder.iterfind('param'):
                 params[node.get('name')] = node.pyval
         return result

--- a/core/src/zeit/content/image/tests/fixtures/encoders.xml
+++ b/core/src/zeit/content/image/tests/fixtures/encoders.xml
@@ -2,7 +2,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <encoder type="jpg">
-    <param name="quality" xsi:type="xsd:int">85</param>
+    <param name="quality" xsi:type="xsd:int">50</param>
     <param name="optimize" xsi:type="xsd:boolean">true</param>
     <param name="progressive" xsi:type="xsd:boolean">true</param>
   </encoder>

--- a/core/src/zeit/content/image/tests/fixtures/encoders.xml
+++ b/core/src/zeit/content/image/tests/fixtures/encoders.xml
@@ -1,12 +1,12 @@
 <encoders
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <encoder type="jpg">
+  <encoder format="JPEG">
     <param name="quality" xsi:type="xsd:int">50</param>
     <param name="optimize" xsi:type="xsd:boolean">true</param>
     <param name="progressive" xsi:type="xsd:boolean">true</param>
   </encoder>
-  <encoder type="webp">
+  <encoder format="WEBP">
     <param name="quality" xsi:type="xsd:int">85</param>
   </encoder>
 </encoders>

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -1,5 +1,6 @@
 from pprint import pformat
 import importlib.resources
+import io
 
 import PIL.Image
 import PIL.ImageDraw
@@ -264,3 +265,15 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
         variant = Variant(id='wide', focus_x=0.5, focus_y=0.5, zoom=1, aspect_ratio='1:1')
         image = self.transform.create_variant_image(variant, size=(0, 0), fill_color='ffffff')
         self.assertEqual((8, 8), image.getImageSize())
+
+    def test_encoder_parameters_are_configurable(self):
+        group = zeit.content.image.testing.create_image_group_with_master_image()
+        transform = zeit.content.image.interfaces.ITransform(group['master-image.jpg'])
+        highquality = io.BytesIO()
+        img = transform.image.copy()
+        img.thumbnail((200, 200))
+        img.save(highquality, 'JPEG', quality=75)
+        highquality.seek(0)
+        configured = transform.thumbnail(200, 200)
+
+        self.assertLess(len(configured.open().read()), len(highquality.read()))


### PR DESCRIPTION
### Checklist

- [x] Documentation: https://github.com/ZeitOnline/vivi-deployment/commit/7c2e37cbdf53fd43c38ca974146f3ba748f7abaf
- [x] Changelog
- [x] Tests
- [x] ~Translations~