### PR TITLE
ZO-5817-5884: script rm-outdated-parquet-areas.py

### DIFF
--- a/core/docs/changelog/ZO-5817-5884.change
+++ b/core/docs/changelog/ZO-5817-5884.change
@@ -1,0 +1,1 @@
+ZO-5817-5884: script rm-outdated-parquet-areas.py


### PR DESCRIPTION
(just for vivi-deployment https://github.com/ZeitOnline/vivi-deployment/pull/1096 changelog)

