### PR TITLE
ZO-5697: Revert explicit paths table joining, it does not actually give us more information

### DIFF
--- a/core/docs/changelog/ZO-5697.change
+++ b/core/docs/changelog/ZO-5697.change
@@ -1,0 +1,1 @@
+ZO-5697: Revert explicit paths table joining, it does not actually give us more information

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -699,13 +699,14 @@ class Path(DBObject):
     __tablename__ = 'paths'
     __table_args__ = (UniqueConstraint('parent_path', 'name', 'id'),)
 
-    parent_path = Column(Unicode, index=True)
-    name = Column(Unicode, index=True)
+    parent_path = Column(Unicode, primary_key=True, index=True)
+    name = Column(Unicode, primary_key=True)
 
     id = Column(
         Uuid(as_uuid=False),
         ForeignKey('properties.id', ondelete='cascade'),
-        primary_key=True,
+        nullable=False,
+        index=True,
     )
     content = relationship('Content', uselist=False, lazy='raise_on_sql', back_populates='path')
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -384,7 +384,6 @@ class Connector:
                 .where(Path.parent_path.startswith(parent))
                 .order_by(Path.parent_path)
             )
-            query = query.options(joinedload(Content.path))
         query = query.options(joinedload(Content.lock))
         return self.session.execute(query).scalars()
 
@@ -419,9 +418,6 @@ class Connector:
             query = select(Path).filter_by(parent_path=parent, name=name)
             if getlock and self.support_locking:
                 query = query.options(joinedload(Path.content).joinedload(Content.lock))
-            else:
-                query = query.options(joinedload(Path.content))
-            query = query.options(joinedload(Path.content).joinedload(Content.path))
             path = self.session.execute(query).scalars().one_or_none()
             return path.content if path is not None else None
 
@@ -652,8 +648,6 @@ class Connector:
                 yield (content.uniqueid, '{urn:uuid:%s}' % content.id)
         else:
             query = select(Content).where(self._build_filter(expr))
-            if not feature_toggle('read-from-new-columns-name-parent-path'):
-                query = query.options(joinedload(Content.path))
             result = self.session.execute(query)
             for item in result.scalars():
                 data = [item.uniqueid]
@@ -708,7 +702,7 @@ class Path(DBObject):
         nullable=False,
         index=True,
     )
-    content = relationship('Content', uselist=False, lazy='raise_on_sql', back_populates='path')
+    content = relationship('Content', uselist=False, lazy='joined', back_populates='path')
 
     @property
     def uniqueid(self):
@@ -747,7 +741,7 @@ class Content(DBObject):
     path = relationship(
         'Path',
         uselist=False,
-        lazy='raise_on_sql',
+        lazy='joined',
         back_populates='content',
         cascade='all, delete-orphan',
         passive_deletes=True,  # Handled in DB, Path.id has ondelete=cascade

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -332,7 +332,7 @@ class SQLDatabaseLayer(plone.testing.Layer):
         del self['sql_nested']
 
 
-class SQLDatabaseTogglesLayer(plone.testing.Layer):
+class SQLDatabaseTogglesLayer(SQLDatabaseLayer):
     def __init__(self, name='SQLDatabaseTogglesLayer', module=None, bases=()):
         super().__init__(name=name, module=module, bases=bases)
 

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -336,10 +336,19 @@ class SQLDatabaseTogglesLayer(SQLDatabaseLayer):
     def __init__(self, name='SQLDatabaseTogglesLayer', module=None, bases=()):
         super().__init__(name=name, module=module, bases=bases)
 
-    def setUp(self):
+    def enable_toggles(self):
         zeit.cms.config.set('zeit.connector', 'write-to-new-columns-name-parent-path', True)
         zeit.cms.config.set('zeit.connector', 'read-from-new-columns-name-parent-path', True)
+
+    def setUp(self):
+        self.enable_toggles()
         super().setUp()
+
+    def testSetUp(self):
+        # Have to repeat this here, because SQL_CONFIG_LAYER/ProductConfigLayer
+        # restores *its* setUp-state during its testSetUp. Sigh.
+        self.enable_toggles()
+        super().testSetUp()
 
 
 SQL_ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
@@ -355,7 +364,7 @@ ZOPE_SQL_ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
 ZOPE_SQL_ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZOPE_SQL_ZCML_LAYER,))
 ZOPE_SQL_CONNECTOR_LAYER = SQLDatabaseLayer(bases=(ZOPE_SQL_ZOPE_LAYER,))
 
-ZOPE_SQL_CONNECTOR_LAYER_TOGGLES = SQLDatabaseTogglesLayer(bases=(ZOPE_SQL_CONNECTOR_LAYER,))
+ZOPE_SQL_CONNECTOR_LAYER_TOGGLES = SQLDatabaseTogglesLayer(bases=(ZOPE_SQL_ZOPE_LAYER,))
 
 
 class TestCase(zeit.cms.testing.FunctionalTestCase):

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -88,9 +88,6 @@ def alembic_upgrade(connection, name, **kw):
 
 
 class MigrationsTest(DBTestCase):
-    @unittest.skip(
-        'primary key definition in code of to-be-deleted paths table does not match production'
-    )
     def test_migrations_create_same_schema_as_from_scratch(self):
         self.createdb()
         c = self.engine.connect()

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -152,7 +152,7 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         uuid = props.id
         del self.connector[res.id]
         transaction.commit()
-        self.assertEqual(None, self.connector.session.get(Path, uuid))
+        self.assertEqual(None, self.connector.session.get(Path, self.connector._pathkey(res.id)))
         self.assertEqual(None, self.connector.session.get(Content, uuid))
 
     def test_search_for_uuid_uses_indexed_column(self):


### PR DESCRIPTION
Da wir _immer_ parallel noch nach `paths` schreiben, ist die Frage "verwenden wir die `paths` Tabelle auch wirklich nicht mehr, wenn wir den `read` Toggle setzen" nicht sinnvoll.

Insofern ersparen wir und lieber das ganze Gebastel (inkl verbogener sqlalchemy primary key definition), weil wir ja eh im nächsten Schritt die ganze `paths` Tabelle aus Code+DB entfernen.