### PR TITLE
ZO-5819: add export to datascience implementer

### DIFF
--- a/core/docs/changelog/ZO-5819.change
+++ b/core/docs/changelog/ZO-5819.change
@@ -1,0 +1,1 @@
+ZO-5819: add export to datascience


### PR DESCRIPTION
Das ist ein Pull-Request für Ticket [ZO-5819](https://zeit-online.atlassian.net/browse/ZO-5891). Data-Science pflegt und nutzt einen `Google Cloud Storage Bucket`, um ihre Analysen zu machen. Bei jedem Publish werden die Dateien in diesen Bucket gelegt (einmal Metadaten, einmal Body).

In diesem Pull Request wird ein neuer Publish-Workflow angelegt. Dabei wird der `body` roh und `meta` als JSON mitgegeben.  

[ZO-5819]: https://zeit-online.atlassian.net/browse/ZO-5819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Checkliste
- [x] Tests
- [x] Dokumentation 

### Gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcHpqbXY1ZTNrZTgweGJ1bm9uYjlidTA4aGVlajljNzc4bDFxdDN3ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mC7VjtF9sYofs9DUa5/giphy.gif)