### PR TITLE
WCM-271: Use entirely separate model classes for developing columns

### DIFF
--- a/core/docs/changelog/WCM-271.change
+++ b/core/docs/changelog/WCM-271.change
@@ -1,0 +1,1 @@
+WCM-271: Use entirely separate model classes for developing columns

--- a/core/src/zeit/cms/content/dav.py
+++ b/core/src/zeit/cms/content/dav.py
@@ -16,7 +16,7 @@ import zope.xmlpickle
 
 from zeit.cms.content.interfaces import WRITEABLE_ON_CHECKIN
 from zeit.connector.interfaces import feature_toggle as connector_toggle
-from zeit.connector.models import Content as ConnectorModel
+from zeit.connector.models import ContentWithMetadataColumns as ConnectorModel
 from zeit.connector.resource import PropertyKey
 import zeit.cms.content.caching
 import zeit.cms.content.interfaces

--- a/core/src/zeit/connector/filesystem.py
+++ b/core/src/zeit/connector/filesystem.py
@@ -15,7 +15,7 @@ import zope.interface
 
 from zeit.connector.connector import CannonicalId
 from zeit.connector.interfaces import ID_NAMESPACE, feature_toggle
-from zeit.connector.models import Content
+from zeit.connector.models import ContentWithMetadataColumns as Content
 import zeit.cms.config
 import zeit.cms.content.dav
 import zeit.connector.dav.interfaces

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -24,7 +24,7 @@ from zeit.connector.interfaces import (
     feature_toggle,
 )
 from zeit.connector.lock import lock_is_foreign
-from zeit.connector.models import Content
+from zeit.connector.models import ContentWithMetadataColumns as Content
 import zeit.cms.config
 import zeit.connector.cache
 import zeit.connector.dav.interfaces

--- a/core/src/zeit/connector/tests/test_contract.py
+++ b/core/src/zeit/connector/tests/test_contract.py
@@ -868,10 +868,8 @@ class SQLProtocol:
         self.connector.session.delete(content)
 
     def add_in_storage(self, name):
-        from zeit.connector.postgresql import Content
-
         resource = self.get_resource(name)
-        content = Content()
+        content = self.connector.Content()
         content.from_webdav(resource.properties)
         content.type = resource.type
         content.is_collection = resource.is_collection

--- a/core/src/zeit/connector/tests/test_migrations.py
+++ b/core/src/zeit/connector/tests/test_migrations.py
@@ -94,7 +94,6 @@ class MigrationsTest(DBTestCase):
         c = self.engine.connect()
         zeit.connector.models.Base.metadata.create_all(c)
         scratch = self.dump_schema(c)
-        scratch = self._ignore_deferred_columns(scratch)
         c.close()
         self.dropdb()
 
@@ -110,25 +109,6 @@ class MigrationsTest(DBTestCase):
 
         diff = unified_diff(scratch, migrations, n=5)
         self.assertEqual(scratch, migrations, '\n'.join(diff))
-
-    def _ignore_deferred_columns(self, statements):
-        mapper = sqlalchemy.orm.class_mapper(zeit.connector.models.Content)
-        deferred = []
-        for column in mapper.columns:
-            prop = mapper.get_property_by_column(column)
-            if prop.deferred:
-                deferred.append(column.name)
-
-        result = []
-        for old in statements:
-            new = []
-            for line in old.split('\n'):
-                if any(x in line for x in deferred):
-                    continue
-                new.append(line)
-            if new:
-                result.append('\n'.join(new))
-        return result
 
 
 class MigrationsLint(unittest.TestCase):

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -301,6 +301,8 @@ class ContractChecksum(zeit.connector.testing.SQLTest):
 
 
 class PropertiesColumnTest(zeit.connector.testing.SQLTest):
+    layer = zeit.connector.testing.SQL_CONTENT_LAYER
+
     def tearDown(self):
         zeit.cms.config.set('zeit.connector', 'read_metadata_columns', 'False')
         zeit.cms.config.set('zeit.connector', 'write_metadata_columns', 'False')


### PR DESCRIPTION
Wenn das released ist, vivi-Version in https://github.com/ZeitOnline/content-storage-api/pull/284 hochziehen, dann ist der entblockiert.