### PR TITLE
WCM-268: Export to Interred during checkout or publish 

### DIFF
--- a/core/docs/changelog/WCM-268.change
+++ b/core/docs/changelog/WCM-268.change
@@ -1,0 +1,1 @@
+WCM-268: Notify webhook conditionally

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -23,14 +23,19 @@ WEBHOOK_LAYER = plone.testing.Layer(
 )
 
 
-class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
+class FunctionalTestCase(zeit.cms.testing.ZeitCmsTestCase):
     layer = WEBHOOK_LAYER
+
+    @property
+    def config(self):
+        port = self.layer['http_port']
+        return f"""<webhooks>
+          <webhook id="default" url="http://localhost:{port}"/>
+        </webhooks>
+        """
 
     def setUp(self):
         super().setUp()
-        self.config = (
-            '<webhooks><webhook url="http://localhost:%s"/></webhooks>' % self.layer['http_port']
-        )
         self.patch = mock.patch(
             'zeit.cms.checkout.webhook.HookSource._get_tree',
             side_effect=lambda: lxml.etree.fromstring(self.config),
@@ -44,6 +49,8 @@ class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
         self.patch.stop()
         super().tearDown()
 
+
+class WebhookTest(FunctionalTestCase):
     def test_calls_post_with_uniqueId_for_configured_urls(self):
         with checked_out(self.repository['testcontent']):
             pass
@@ -65,19 +72,6 @@ class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
             {'body': '["http://xml.zeit.de/testcontent2"]', 'path': '/', 'verb': 'POST'}, request
         )
 
-    def test_does_not_call_hook_when_exclude_matches(self):
-        self.config = """<webhooks>
-          <webhook url="http://localhost:%s">
-            <exclude>
-              <type>testcontenttype</type>
-            </exclude>
-          </webhook>
-        </webhooks>
-        """ % self.layer['http_port']
-        with checked_out(self.repository['testcontent']):
-            pass
-        self.assertEqual([], self.layer['request_handler'].requests)
-
     def test_retry_on_technical_error(self):
         self.layer['request_handler'].response_code = [503, 200]
         with self.assertRaises(celery.exceptions.Retry):
@@ -91,15 +85,34 @@ class WebhookTest(zeit.cms.testing.ZeitCmsTestCase):
                 pass
 
 
+class WebhookConfigTest(FunctionalTestCase):
+    @property
+    def config(self):
+        port = self.layer['http_port']
+        return f"""<webhooks>
+          <webhook id="default" url="http://localhost:{port}">
+            <exclude>
+              <type>testcontenttype</type>
+            </exclude>
+          </webhook>
+        </webhooks>
+        """
+
+    def test_does_not_call_hook_when_exclude_matches(self):
+        with checked_out(self.repository['testcontent']):
+            pass
+        self.assertEqual([], self.layer['request_handler'].requests)
+
+
 class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):
     def test_match_contenttype(self):
-        hook = zeit.cms.checkout.webhook.Hook(None)
+        hook = zeit.cms.checkout.webhook.Hook(None, None)
         hook.add_exclude('type', 'testcontenttype')
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
         self.assertFalse(hook.should_exclude(self.repository['online']['2007']['01']['Somalia']))
 
     def test_match_product(self):
-        hook = zeit.cms.checkout.webhook.Hook(None)
+        hook = zeit.cms.checkout.webhook.Hook(None, None)
         hook.add_exclude('product', 'ZEI')
         self.assertFalse(hook.should_exclude(self.repository['testcontent']))
         with checked_out(self.repository['testcontent']) as co:
@@ -107,14 +120,14 @@ class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
 
     def test_skip_auto_renameable(self):
-        hook = zeit.cms.checkout.webhook.Hook(None)
+        hook = zeit.cms.checkout.webhook.Hook(None, None)
         self.assertFalse(hook.should_exclude(self.repository['testcontent']))
         with checked_out(self.repository['testcontent']) as co:
             IAutomaticallyRenameable(co).renameable = True
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
 
     def test_match_path_prefix(self):
-        hook = zeit.cms.checkout.webhook.Hook(None)
+        hook = zeit.cms.checkout.webhook.Hook(None, None)
         hook.add_exclude('path_prefix', '/online')
         self.assertFalse(hook.should_exclude(self.repository['testcontent']))
         self.assertTrue(hook.should_exclude(self.repository['online']['2007']['01']['Somalia']))

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -119,6 +119,14 @@ class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):
             co.product = Product('ZEI')
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
 
+    def test_match_product_attribute(self):
+        hook = zeit.cms.checkout.webhook.Hook('checkin', None)
+        hook.add_exclude('product_counter', 'online')
+        self.assertFalse(hook.should_exclude(self.repository['testcontent']))
+        with checked_out(self.repository['testcontent']) as co:
+            co.product = Product('ZEDE')
+        self.assertTrue(hook.should_exclude(self.repository['testcontent']))
+
     def test_skip_auto_renameable(self):
         hook = zeit.cms.checkout.webhook.Hook(None, None)
         self.assertFalse(hook.should_exclude(self.repository['testcontent']))

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -113,6 +113,13 @@ class Hook:
             return False
         return content.product and content.product.id == value
 
+    def _match_product_counter(self, content, value):
+        if not ICommonMetadata.providedBy(content):
+            return False
+        if not content.product:
+            return False
+        return content.product and content.product.counter == value
+
     def _match_path_prefix(self, content, value):
         path = content.uniqueId.replace(zeit.cms.interfaces.ID_NAMESPACE, '/')
         return path.startswith(value)

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -36,10 +36,6 @@ def create_webhook_job(id, context, **kwargs):
 def notify_after_checkin(context, event):
     # XXX Work around redis/ZODB race condition, see BUG-796.
     if event.publishing:
-        log.info(
-            'No async webhook job created for %s. This is a publishing event.',
-            context.uniqueId,
-        )
         return
     create_webhook_job('checkin', context, countdown=5)
 

--- a/core/src/zeit/cms/content/products.xml
+++ b/core/src/zeit/cms/content/products.xml
@@ -5,7 +5,8 @@
              volume="True"
              location="http://xml.zeit.de/{year}/{name}/ausgabe"
              centerpage="http://xml.zeit.de/{year}/{name}/index"
-             cp_template="http://xml.zeit.de/ausgabe-cp-template">
+             cp_template="http://xml.zeit.de/ausgabe-cp-template"
+             counter="print">
              Die Zeit</product>
     <product id="ZMLB"
              relates_to="ZEI">
@@ -29,5 +30,5 @@
     <product id="tbd">Zeit Oesterreich</product>
     <product id="Reuters">Reuters</product>
     <product id="KINZ" vgwortcode="1234abc">Kinderzeit Magazin</product>
-    <product id="ZEDE">Zeit Online</product>
+    <product id="ZEDE" counter="online">Zeit Online</product>
 </products>

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -582,6 +582,7 @@ class Product(AllowedBase):
         autochannel=True,
         relates_to=None,
         is_news=False,
+        counter=False,
     ):
         super().__init__(id, title, None)
         self.vgwortcode = vgwortcode
@@ -597,6 +598,7 @@ class Product(AllowedBase):
         self.relates_to = relates_to
         self.is_news = is_news
         self.dependent_products = []
+        self.counter = counter
 
 
 class ProductSource(ObjectSource, SimpleContextualXMLSource):
@@ -623,6 +625,7 @@ class ProductSource(ObjectSource, SimpleContextualXMLSource):
                 node.get('autochannel', '').lower() != 'false',
                 unicode_or_none(node.get('relates_to')),
                 node.get('is_news', '').lower() == 'true',
+                unicode_or_none(node.get('counter')),
             )
             result[product.id] = product
         self._add_dependent_products(result)

--- a/core/src/zeit/cms/content/tests/test_sources.py
+++ b/core/src/zeit/cms/content/tests/test_sources.py
@@ -147,6 +147,10 @@ class ProductSourceTest(zeit.cms.testing.ZeitCmsTestCase):
             if value.id == 'ZEI':
                 self.assertEqual('Zeit Magazin', value.dependent_products[0].title)
 
+    def test_zeit_has_print_counter(self):
+        self.assertEqual('ZEI', self.values[0].id)
+        self.assertEqual('print', self.values[0].counter)
+
     def test_source_without_dependencies_has_empty_list_as_dependent_products(self):
         self.assertEqual([], self.values[1].dependent_products)
 

--- a/core/src/zeit/cms/workflow/cli.py
+++ b/core/src/zeit/cms/workflow/cli.py
@@ -26,6 +26,13 @@ def publish():
         action='store_true',
         help='Notify webhooks after checkin, like contenthub',
     )
+
+    parser.add_argument(
+        '--use-publish-hooks',
+        action='store_true',
+        help='Notify webhooks after publish, like contenthub',
+    )
+
     parser.add_argument(
         '--ignore-services',
         default=IGNORE_SERVICES,
@@ -75,6 +82,10 @@ def publish():
     if not options.use_checkin_hooks:
         log.info('Deactivating checkin hooks')
         assert registry.unregisterHandler(zeit.cms.checkout.webhook.notify_after_checkin)
+
+    if not options.use_publish_hooks:
+        log.info('Deactivating publish hooks')
+        assert registry.unregisterHandler(zeit.cms.checkout.webhook.notify_after_publish)
 
     if not options.wait_tms:
         mock.patch(

--- a/core/src/zeit/workflow/tests/test_publish.py
+++ b/core/src/zeit/workflow/tests/test_publish.py
@@ -283,7 +283,7 @@ class PublishEndToEndTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEllipsis(
             """\
 ...
-Publishing http://xml.zeit.de/online/2007/01/Somalia
+Publishing http://xml.zeit.de/online/2007/01/Somalia...
 Task zeit.workflow.publish.PUBLISH_TASK...succeeded...""",
             self.log.getvalue(),
         )
@@ -309,10 +309,10 @@ Task zeit.workflow.publish.PUBLISH_TASK...succeeded...""",
             """\
 ...
 Running job...for http://xml.zeit.de/online/2007/01/Flugsicherheit
-Publishing http://xml.zeit.de/online/2007/01/Flugsicherheit
+Publishing http://xml.zeit.de/online/2007/01/Flugsicherheit...
 Task zeit.workflow.publish.PUBLISH_TASK...succeeded...
 Running job...for http://xml.zeit.de/online/2007/01/Saarland
-Publishing http://xml.zeit.de/online/2007/01/Saarland
+Publishing http://xml.zeit.de/online/2007/01/Saarland...
 Task zeit.workflow.publish.PUBLISH_TASK...succeeded...""",
             self.log.getvalue(),
         )


### PR DESCRIPTION
Um den Interred Webhook entweder während des Checkins oder während des Veröffentlichens Bescheid zu sagen, kann man nun mehrere `<webhook>` Tags in der `checkin-webhooks.xml` anlegen. Damit das funktioniert gibts nun für jeden eine `id` und nicht nur eine `url` um den Webhook zu identifizieren. 

Zusätzlich kann man nun den das Attribute `counter` aus der `products.xml` als `exclude` nutzen, sodass man z.B. `<product_counter>online</product_counter>` oder `print` in die `checkin-webhooks.xml` eintragen kann. 

Warum so? Warum nicht eine extra XML-Resource? Damit die Informationen, wann welche Inhalte an Interred geschickt werden, nicht über mehrere Source-Files verstreut sind.

### Checklist

- [x] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![flop](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGt5cnBpNWpuejVzZG55eHM2a2JkOGdrOHlveXVtbjI0dWFvazBrcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6fJbwYFe3SmVVQ4M/giphy.gif)