### PR TITLE
ZO-883: remove avif format due to incompabilities of greyscale with b…

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "pendulum>=3.0.0.dev0",
     "persistent",
     "pillow",
-    "pillow-avif-plugin",
     "prometheus-client",
     "pyjwt>=2.0.0",
     "pyramid_dogpile_cache2",

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -232,16 +232,6 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
             image.load()
         self.assertEqual('WEBP', image.format)
 
-    def test_create_variant_image_allows_overriding_output_format_avif(self):
-        image = self.group.create_variant_image(
-            zeit.content.image.interfaces.IVariants(self.group)['square'], format='AVIF'
-        )
-        self.assertEqual('image/avif', image.mimeType)
-        with image.open() as f:
-            image = PIL.Image.open(f)
-            image.load()
-        self.assertEqual('AVIF', image.format)
-
     def test_parse_url_variant(self):
         result = self.traverser.parse_url('cinema__300x160__scale_2.25__0000ff')
         assert result['variant'].name == 'cinema'

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -1,7 +1,6 @@
 import PIL.Image
 import PIL.ImageColor
 import PIL.ImageEnhance
-import pillow_avif  # noqa: F401
 import zope.component
 import zope.interface
 import zope.security.proxy


### PR DESCRIPTION
AVIF wird wieder als Bildformat rausgenommen, da es ein Issue mit Greyscale-Bildern in Firefox und Chrome gab.

Relevantes Issue:
https://github.com/AOMediaCodec/libavif/issues/1483

Firefox Issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1846055

### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcnNpdXh4a2ZoZm1uNmJ4MnpxY3J1cjVud3k3eTE1YTVvZWdqY3RiZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5bgS90uCmWoWp2hBvj/giphy-downsized.gif)