### PR TITLE
WCM-311: Revert Remove delay from inline form save, to avoid overlapping with other actions (that were triggered immediately)

### DIFF
--- a/core/docs/changelog/formsave.fix
+++ b/core/docs/changelog/formsave.fix
@@ -1,0 +1,1 @@
+Revert Remove delay from inline form save, to avoid overlapping with other actions (that were triggered immediately)


### PR DESCRIPTION
Revert #831
### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

### gif
![]()