### PR TITLE
MAINT: Let TMSGallery not implement Gallery

### DIFF
--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -125,7 +125,7 @@ class TMSLink(Content, zeit.content.link.link.Link):
     pass
 
 
-class TMSGallery(Content, zeit.content.gallery.gallery.Gallery):
+class TMSGallery(Content, zeit.cms.content.metadata.CommonMetadata):
     pass
 
 


### PR DESCRIPTION
Dieser PR ist erstmal nur ein Diskussionsbeitrag :) `TMSGallery` gibt gar keine Bilder zurück, was ich recht irreführend finde. Am liebsten wäre mir, wenn das Objekt mit dem wir es in Teasern für Galerien zu tun haben in beiden Fällen nur unterstützen würde was `TMSGallery` kann, aber das geht vermutlich nicht.

### Checklist

- [ ] Documentation
- [ ] Changelog
- [ ] Tests
- [ ] Translations

### gif
![Wheel Of Fortune Idk - Sm6I4hAtuREavkhxJy](https://github.com/user-attachments/assets/b181de83-b48e-4bdd-9e17-95e17d43a75a)