### PR TITLE
FIX: make resource_class for mock connector configurable

### DIFF
--- a/core/docs/changelog/connector.fix
+++ b/core/docs/changelog/connector.fix
@@ -1,0 +1,1 @@
+make resource_class for mock connector configurable

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -65,6 +65,8 @@ class Connector(zeit.connector.filesystem.Connector):
         connector = super().factory()
         connector.detect_mime_type = config.get('detect-mime-type', True)
         connector.ignore_locking = config.get('ignore-locking', False)
+        if config.get('use-readonly-resource'):
+            connector.resource_class = zeit.connector.resource.CachedResource
 
         return connector
 


### PR DESCRIPTION
Da wir häufiger den MockConnector mit einer anderen Resource ausstatten, ist ein Setting mal angebracht um genau dies zu machen.

https://github.com/ZeitOnline/content-storage-api/pull/295#discussion_r1735917505