### PR TITLE
WCM-316: fix alignment of volume and covers and make volume.teaser a large text area

### DIFF
--- a/core/src/zeit/content/volume/browser/form.py
+++ b/core/src/zeit/content/volume/browser/form.py
@@ -39,11 +39,6 @@ class Base:
             ('product', 'year', 'volume', 'date_digital_published', 'volume_note'),
             css_class='column-left',
         ),
-        gocept.form.grouped.Fields(
-            _('Teaser'),
-            ('title', 'teaser', 'background_color'),
-            css_class='wide-widgets column-left',
-        ),
     )
 
     def __init__(self, context, request):
@@ -83,6 +78,15 @@ class Base:
                 self.field_groups += (
                     gocept.form.grouped.Fields(product.title, fieldnames, css_class='column-right'),
                 )
+        # Append the teaser field to the teaser group at the end of the dom
+        # so it is aligned properly
+        self.field_groups += (
+            gocept.form.grouped.Fields(
+                _('Teaser'),
+                ('title', 'teaser', 'background_color'),
+                css_class='wide-widgets column-left',
+            ),
+        )
 
 
 class Add(Base, zeit.cms.browser.form.AddForm):

--- a/core/src/zeit/content/volume/browser/resources/volume-covers.js
+++ b/core/src/zeit/content/volume/browser/resources/volume-covers.js
@@ -15,10 +15,12 @@ $(document).bind('fragment-ready', function(event) {
     // substring match on "fieldname-cover*", so it might be complicated).
     $('fieldset.column-right').first().before(
         '<fieldset class="column-right choose">' +
-        '<b>COVERS:</b> <select id="choose-cover">' +
+        '<legend>COVERS</legend> <select id="choose-cover">' +
         '</select></fieldset>');
 
-    $('fieldset.column-right legend').each(function(i, element) {
+    // Iterate through all legends and add them to the select
+    // ignoring the first legend, because it is the legend for the selection
+    $('fieldset.column-right legend:not(:first)').each(function(i, element) {
         $('#choose-cover').append(
             '<option>' + $(element).text() + '</option>');
     });

--- a/core/src/zeit/content/volume/interfaces.py
+++ b/core/src/zeit/content/volume/interfaces.py
@@ -49,7 +49,7 @@ class IVolume(zeit.cms.content.interfaces.IXMLContent):
 
     title = zope.schema.TextLine(title=_('Title'), required=False)
 
-    teaser = zope.schema.TextLine(title=_('Teaser'), required=False)
+    teaser = zope.schema.Text(title=_('Teaser'), required=False)
 
     background_color = zope.schema.TextLine(
         title=_('Area background color (6 characters, no #)'),


### PR DESCRIPTION
Vorher:
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/ac7b2684-e168-490a-93ef-beb22222714b">

Nachher:
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/6aa59b5f-487b-4ea9-8011-c6ad6adc6b13">
