### PR TITLE
WCM-392: Remove toggle which overrides the access property

### DIFF
--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -55,14 +55,6 @@ ARTICLE_TEMPLATE = """\
 </article>"""
 
 
-class ToggleableAccess(zeit.cms.content.dav.DAVProperty):
-    def __get__(self, instance, class_, properties=None):
-        value = super().__get__(instance, class_, properties)
-        if FEATURE_TOGGLES.find('access_treat_free_as_dynamic') and value == 'free':
-            return 'dynamic'
-        return value
-
-
 @zope.interface.implementer(
     zeit.content.article.interfaces.IArticle, zeit.cms.interfaces.IEditorialContent
 )
@@ -97,7 +89,7 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
         ),
     )
 
-    access = ToggleableAccess(
+    access = zeit.cms.content.dav.DAVProperty(
         ICommonMetadata['access'],
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
         'access',

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -392,17 +392,6 @@ class ArticleSpeechbertTest(zeit.content.article.testing.FunctionalTestCase):
         assert not checksum.checksum
 
 
-class ArticleAccess(zeit.content.article.testing.FunctionalTestCase):
-    def test_free_is_treated_as_dynamic_according_to_toggle(self):
-        article = self.repository['article'] = self.get_article()
-        with zeit.cms.checkout.helper.checked_out(article) as co:
-            co.access = 'free'
-        article = self.repository['article']
-        self.assertEqual('free', article.access)
-        FEATURE_TOGGLES.set('access_treat_free_as_dynamic')
-        self.assertEqual('dynamic', article.access)
-
-
 class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
     def _add_audio_to_article(self):
         self.repository['article'] = self.article


### PR DESCRIPTION
Wir haben mal ein Feature eingeführt. Dass – je nach Toggle – die access-Property den Wert "dynamic" ausgeben soll, wenn sie eigentlich "free" ist.

- Ticket: https://zeit-online.atlassian.net/browse/ZO-3478
- PRs: https://github.com/ZeitOnline/vivi/pull/456 und https://github.com/ZeitOnline/vivi/pull/460

Es hat den Anschein, als wenn das nicht den Getter überschreibt, sondern das Verhalten der GUI (und ausgerechnet nicht die Property bzw den Getter). Siehe Beschreibungen und Screenshots am Ticket https://zeit-online.atlassian.net/browse/WCM-392 .

Dieser PR hier löscht den Code. Und einen dazugehörigen Test.
Aber weil ebenjener Test eigentlich das gewünschte Verhalten beweist (, und nicht das konfuse im Vivi UI),  ist dieser PR wohl eher ein Aufhänger fürs Debuggen und Diskutieren.

### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdTZkcXd2b29raWw1MDliNTNkYmxwaTVpa3Q4aW44b2t2MDh2MXF1diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/n5NtisNKVzXWg/giphy.gif)