### PR TITLE
WCM-408: remove fallback logic of teaserText

### DIFF
--- a/core/docs/changelog/WCM-408.change
+++ b/core/docs/changelog/WCM-408.change
@@ -1,0 +1,1 @@
+WCM-408: remove fallback logic of teaserText

--- a/core/src/zeit/content/volume/volume.py
+++ b/core/src/zeit/content/volume/volume.py
@@ -78,15 +78,9 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
         'volume_note',
     )
 
-    _old_volume_note = zeit.cms.content.dav.DAVProperty(
-        zeit.content.volume.interfaces.IVolume['volume_note'],
-        zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        'teaserText',
-    )
-
     @property
     def volume_note(self):
-        text = self._volume_note or self._old_volume_note
+        text = self._volume_note
         if text is None:
             text = zeit.cms.config.required('zeit.content.volume', 'default-teaser-text')
         return self.fill_template(text)


### PR DESCRIPTION
Fallback-Logik von `volume_note` zu `teaserText` wurde entfernt, da wir alle `teaserText` in der Datenbank bereits zu `volume_note` umbenannt haben (siehe [WCM-408](https://zeit-online.atlassian.net/browse/WCM-408))

[WCM-408]: https://zeit-online.atlassian.net/browse/WCM-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ