### PR TITLE
WCM-401

### DIFF
--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -17,6 +17,7 @@ import zeit.cms.repository.interfaces
 import zeit.cms.type
 import zeit.content.article.interfaces
 import zeit.content.audio.interfaces
+import zeit.content.image.imagereference
 import zeit.content.image.interfaces
 
 
@@ -72,10 +73,17 @@ class AudioType(zeit.cms.type.XMLContentTypeDeclaration):
     type = 'audio'  # Wert für {http://namespaces.zeit.de/CMS/meta}type
 
 
+@grok.adapter(IAudio)
 @grok.implementer(zeit.content.image.interfaces.IImages)
-class PodcastImage(grok.Adapter):
-    grok.context(IAudio)
+def audio_image(context):
+    if context.audio_type == 'podcast':
+        return PodcastImage(context)
+    elif context.audio_type == 'manual':
+        return zeit.content.image.imagereference.ImagesAdapter(context)
+    return None
 
+
+class PodcastImage:
     def _get_podcast(self):
         if self.context.audio_type == 'podcast':
             info = IPodcastEpisodeInfo(self.context)

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -37,6 +37,8 @@ class Form:
 
     _omit_tts_fields = ('article_uuid', 'preview_url', 'checksum')
 
+    _omit_teaser_fields = ('teaserTitle', 'teaserSupertitle', 'teaserText')
+
     form_fields = (
         Base.form_fields
         + zope.formlib.form.FormFields(zeit.content.audio.interfaces.IPodcastEpisodeInfo).select(
@@ -110,7 +112,12 @@ class Mixin(Form):
         super().__init__(context, request)
         if context.audio_type == 'tts':
             self.form_fields = self.form_fields.omit(*self._omit_podcast_fields)
+            self.form_fields = self.form_fields.omit(*self._omit_teaser_fields)
         elif context.audio_type == 'podcast':
+            self.form_fields = self.form_fields.omit(*self._omit_tts_fields)
+            self.form_fields = self.form_fields.omit(*self._omit_teaser_fields)
+        elif context.audio_type == 'manual':
+            self.form_fields = self.form_fields.omit(*self._omit_podcast_fields)
             self.form_fields = self.form_fields.omit(*self._omit_tts_fields)
 
 

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -3,6 +3,7 @@ import zope.formlib
 
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.browser.form
+import zeit.cms.content.interfaces
 import zeit.content.audio.audio
 import zeit.content.audio.interfaces
 import zeit.workflow.browser.form
@@ -49,6 +50,9 @@ class Form:
         + zope.formlib.form.FormFields(zeit.content.audio.interfaces.ISpeechInfo).select(
             'article_uuid', 'preview_url', 'checksum'
         )
+        + zope.formlib.form.FormFields(zeit.cms.content.interfaces.ICommonMetadata).select(
+            'teaserTitle', 'teaserSupertitle', 'teaserText'
+        )
     )
 
     podcast_fields = gocept.form.grouped.Fields(
@@ -81,6 +85,12 @@ class Form:
         css_class='wide-widgets column-left',
     )
 
+    teaser_fields = gocept.form.grouped.Fields(
+        _('Teaser'),
+        ('teaserTitle', 'teaserSupertitle', 'teaserText'),
+        css_class='wide-widgets column-left',
+    )
+
     field_groups = (
         gocept.form.grouped.Fields(
             _('Navigation'), ('__name__',), css_class='wide-widgets column-right'
@@ -91,6 +101,7 @@ class Form:
         podcast_host_fields,
         tts_fields,
         tts_file_fields,
+        teaser_fields,
     )
 
 

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -19,6 +19,7 @@ class AudioTypeSource(zeit.cms.content.sources.SimpleFixedValueSource):
         'podcast': _('Podcast'),
         'tts': _('Text to Speech'),
         'premium': _('Premium Audio'),
+        'intro': _('Intro'),
     }
 
 

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -19,7 +19,7 @@ class AudioTypeSource(zeit.cms.content.sources.SimpleFixedValueSource):
         'podcast': _('Podcast'),
         'tts': _('Text to Speech'),
         'premium': _('Premium Audio'),
-        'intro': _('Intro'),
+        'manual': _('Manual Audio'),
     }
 
 


### PR DESCRIPTION
Neuer Audio-Objekt-Typ `Intro` hinzugefügt und `teaser`-Attribute von `ICommonMetadata` in der Form genutzt.

Ticket: [WCM-401](https://zeit-online.atlassian.net/browse/WCM-401)

[WCM-401]: https://zeit-online.atlassian.net/browse/WCM-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ