### PR TITLE
WCM-401: add new audio object type 'custom'

### DIFF
--- a/core/docs/changelog/WCM-401.change
+++ b/core/docs/changelog/WCM-401.change
@@ -1,0 +1,1 @@
+WCM-401: add new audio object type 'custom'

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -17,6 +17,7 @@ import zeit.cms.repository.interfaces
 import zeit.cms.type
 import zeit.content.article.interfaces
 import zeit.content.audio.interfaces
+import zeit.content.image.imagereference
 import zeit.content.image.interfaces
 
 
@@ -72,9 +73,18 @@ class AudioType(zeit.cms.type.XMLContentTypeDeclaration):
     type = 'audio'  # Wert für {http://namespaces.zeit.de/CMS/meta}type
 
 
+@grok.adapter(IAudio)
 @grok.implementer(zeit.content.image.interfaces.IImages)
-class PodcastImage(grok.Adapter):
-    grok.context(IAudio)
+def audio_image(context):
+    if context.audio_type == 'podcast':
+        return PodcastImage(context)
+    return zeit.content.image.imagereference.ImagesAdapter(context)
+
+
+@zope.interface.implementer(zeit.content.image.interfaces.IImages)
+class PodcastImage:
+    def __init__(self, context):
+        self.context = context
 
     def _get_podcast(self):
         if self.context.audio_type == 'podcast':

--- a/core/src/zeit/content/audio/browser/form.py
+++ b/core/src/zeit/content/audio/browser/form.py
@@ -3,6 +3,7 @@ import zope.formlib
 
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cms.browser.form
+import zeit.cms.content.interfaces
 import zeit.content.audio.audio
 import zeit.content.audio.interfaces
 import zeit.workflow.browser.form
@@ -30,7 +31,6 @@ class Form:
         'summary',
         'notes',
         'dashboard_link',
-        'image',
         'url_ad_free',
     )
 
@@ -49,11 +49,15 @@ class Form:
         + zope.formlib.form.FormFields(zeit.content.audio.interfaces.ISpeechInfo).select(
             'article_uuid', 'preview_url', 'checksum'
         )
+        + zope.formlib.form.FormFields(zeit.cms.content.interfaces.ICommonMetadata).select(
+            'teaserTitle', 'teaserSupertitle', 'teaserText'
+        )
+        + zope.formlib.form.FormFields(zeit.content.image.interfaces.IImages).select('image')
     )
 
     podcast_fields = gocept.form.grouped.Fields(
         _('Podcast Episode Info'),
-        ('podcast', 'image', 'episode_nr', 'summary', 'notes'),
+        ('podcast', 'episode_nr', 'summary', 'notes'),
         'wide-widgets column-left',
     )
 
@@ -81,6 +85,12 @@ class Form:
         css_class='wide-widgets column-left',
     )
 
+    teaser_fields = gocept.form.grouped.Fields(
+        _('Teaser'),
+        ('teaserTitle', 'teaserSupertitle', 'teaserText', 'image'),
+        css_class='wide-widgets column-left',
+    )
+
     field_groups = (
         gocept.form.grouped.Fields(
             _('Navigation'), ('__name__',), css_class='wide-widgets column-right'
@@ -91,6 +101,7 @@ class Form:
         podcast_host_fields,
         tts_fields,
         tts_file_fields,
+        teaser_fields,
     )
 
 
@@ -101,6 +112,10 @@ class Mixin(Form):
             self.form_fields = self.form_fields.omit(*self._omit_podcast_fields)
         elif context.audio_type == 'podcast':
             self.form_fields = self.form_fields.omit(*self._omit_tts_fields)
+        elif context.audio_type == 'custom':
+            self.form_fields = self.form_fields.omit(
+                *self._omit_podcast_fields, *self._omit_tts_fields
+            )
 
 
 class Add(Form, zeit.cms.browser.form.AddForm):

--- a/core/src/zeit/content/audio/browser/tests/test_form.py
+++ b/core/src/zeit/content/audio/browser/tests/test_form.py
@@ -1,8 +1,9 @@
 import zeit.content.audio.testing
+import zeit.content.image.testing
 
 
 class TestAudioForm(zeit.content.audio.testing.BrowserTestCase):
-    def add_audio(self):
+    def add_podcast_audio(self):
         self.browser.open('/repository/online/2007/01')
         menu = self.browser.getControl(name='add_menu')
         menu.displayValue = ['Audio']
@@ -22,8 +23,8 @@ class TestAudioForm(zeit.content.audio.testing.BrowserTestCase):
         self.browser.getControl('Add').click()
         assert 'There were errors' not in self.browser.contents
 
-    def test_add_form(self):
-        self.add_audio()
+    def test_add_podcast_form(self):
+        self.add_podcast_audio()
         self.browser.getLink('Checkin').click()
         self.assertEllipsis(
             """...
@@ -69,3 +70,37 @@ class TestAudioForm(zeit.content.audio.testing.BrowserTestCase):
         self.browser.getControl('Checksum').value = '123foo'
         self.browser.getControl('Add').click()
         assert 'There were errors' not in self.browser.contents
+
+    def test_add_custom_audio(self):
+        self.browser.open('/repository/online/2007/01')
+        menu = self.browser.getControl(name='add_menu')
+        menu.displayValue = ['Audio']
+        self.browser.open(menu.value[0])
+        self.browser.getControl('File name').value = 'count-olaf-audio'
+        self.browser.getControl('Type').displayValue = 'Custom Audio'
+        group = zeit.content.image.testing.create_image_group()
+        self.browser.getControl('Image').value = group.uniqueId
+        self.browser.getControl('Title').value = 'Count Olaf takes the Baudelaire children'
+        self.browser.getControl(
+            'Teaser kicker'
+        ).value = 'Count Olaf is back to steal the Pugs fortune'
+        self.browser.getControl(
+            'Teaser text'
+        ).value = 'The Baudelaire orphans are in for a surprise'
+        self.browser.getControl('Add').click()
+        assert 'There were errors' not in self.browser.contents
+        self.browser.getLink('Checkin').click()
+        self.assertEllipsis(
+            """...
+            <label for="form.teaserTitle">...
+            <div class="widget">Count Olaf takes the Baudelaire children</div>...
+            <label for="form.teaserSupertitle">...
+            <div class="widget">Count Olaf is back to steal the Pugs fortune</div>...
+            <label for="form.teaserText">...
+            <div class="widget">The Baudelaire orphans are in for a surprise</div>...
+            <label for="form.image">...
+            <div class="widget">...
+            <span class="uniqueId">http://xml.zeit.de/image-group/</span>...
+            """,
+            self.browser.contents,
+        )

--- a/core/src/zeit/content/audio/ftesting.zcml
+++ b/core/src/zeit/content/audio/ftesting.zcml
@@ -1,6 +1,8 @@
 <configure
    xmlns="http://namespaces.zope.org/zope"
-   i18n_domain="zope">
+   xmlns:meta="http://namespaces.zope.org/meta"
+   i18n_domain="zope"
+   >
 
   <include package="zeit.cms" file="ftesting.zcml" />
 
@@ -8,5 +10,5 @@
   <include package="zeit.content.audio.browser" />
 
   <include package="zeit.simplecast" />
-
+  <include package="zeit.content.image" />
 </configure>

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -19,6 +19,7 @@ class AudioTypeSource(zeit.cms.content.sources.SimpleFixedValueSource):
         'podcast': _('Podcast'),
         'tts': _('Text to Speech'),
         'premium': _('Premium Audio'),
+        'custom': _('Custom Audio'),
     }
 
 

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -6,6 +6,7 @@ from zeit.cms.repository.interfaces import IRepository
 from zeit.content.audio.audio import Audio
 from zeit.content.audio.interfaces import IPodcastEpisodeInfo, ISpeechInfo, Podcast
 import zeit.cms.testing
+import zeit.content.image.testing
 
 
 T = TypeVar('T')  # Can be anything
@@ -15,7 +16,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     {
         'podcast-source': f'file://{HERE}/tests/fixtures/podcasts.xml',
     },
-    bases=(zeit.cms.testing.CONFIG_LAYER,),
+    bases=(zeit.content.image.testing.CONFIG_LAYER,),
 )
 
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer('ftesting.zcml', bases=(CONFIG_LAYER,))

--- a/core/src/zeit/find/testing.py
+++ b/core/src/zeit/find/testing.py
@@ -17,7 +17,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         'elasticsearch-url': 'http://tms-backend.staging.zeit.de:80/elasticsearch',
         'elasticsearch-index': 'foo_pool',
     },
-    bases=(zeit.content.image.testing.CONFIG_LAYER, zeit.content.audio.testing.CONFIG_LAYER),
+    bases=(zeit.content.audio.testing.CONFIG_LAYER,),
 )
 ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=(CONFIG_LAYER,))
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(bases=(ZCML_LAYER,))


### PR DESCRIPTION
Neuer Audio-Objekt-Typ `manual` hinzugefügt und `teaser`-Attribute von `ICommonMetadata` in der Form genutzt.

Ticket: [WCM-401](https://zeit-online.atlassian.net/browse/WCM-401)

[WCM-401]: https://zeit-online.atlassian.net/browse/WCM-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

- [x] Documentation
- [x] Changelog
- [x] Tests
- [x] Translations

Docs: https://github.com/ZeitOnline/vivi-deployment/pull/1166

# GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTRqaXVvdWliYW1zM3VzaGQ1YW51djM2YmVrbzV0bWRteW9vM21jcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3lxD1O74siiz5FvrJs/giphy-downsized.gif)
