### PR TITLE
FIX: attach_span of opentelemetry fixed

### DIFF
--- a/core/docs/changelog/FIX_attach-span-celery.change
+++ b/core/docs/changelog/FIX_attach-span-celery.change
@@ -1,0 +1,1 @@
+FIX: replace deprecated attach_span with attach_context


### PR DESCRIPTION
`attach_span` wurde durch `attach_context` ersetzt, siehe Commit:
https://github.com/open-telemetry/opentelemetry-python-contrib/commit/c3e9f75fb9611d1e2842b4f3fe11b910d7d2ae0c#diff-ed0dafdf74eda90912242a368cd05845c26ce3178f34c4fea9816f3ff1e49307R202