### PR TITLE
FIX: manual audio publish not working

### DIFF
--- a/core/docs/changelog/FIX_manual-audio-publish-not-working.change
+++ b/core/docs/changelog/FIX_manual-audio-publish-not-working.change
@@ -1,0 +1,1 @@
+FIX: manual audio publish was not working

--- a/core/src/zeit/content/audio/browser/configure.zcml
+++ b/core/src/zeit/content/audio/browser/configure.zcml
@@ -96,6 +96,7 @@
     for="zeit.content.audio.interfaces.IAudio"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     name="publish.html"
+    class="zeit.workflow.browser.publish.Publish"
     template="publish.pt"
     permission="zeit.content.audio.Publish"
     />


### PR DESCRIPTION
Das manuelle publishen von `Audio`s hat nicht funktioniert, da eine Klasse fehlte.