### PR TITLE
WCM-452: Handle empty channels in type conversion

### DIFF
--- a/core/docs/changelog/WCM-452.change
+++ b/core/docs/changelog/WCM-452.change
@@ -1,0 +1,1 @@
+WCM-452: Handle empty channels in type conversion

--- a/core/src/zeit/connector/converter.py
+++ b/core/src/zeit/connector/converter.py
@@ -5,6 +5,7 @@ exist.
 
 See ADR 009
 """
+
 from collections.abc import Iterable
 
 import grokcore.component as grok
@@ -74,6 +75,8 @@ class ChannelsConverter(DefaultConverter):
         return ';'.join(' '.join(x for x in item if x) for item in value)
 
     def deserialize(self, value: str) -> tuple:
+        if not value:
+            return ()
         result = []
         for channel in value.split(';'):
             subchannels = channel.split()

--- a/core/src/zeit/connector/tests/test_mock.py
+++ b/core/src/zeit/connector/tests/test_mock.py
@@ -91,6 +91,11 @@ class MockTypeConversionTest(zeit.connector.testing.MockTest):
                 ),
                 'International Nahost;Wissen',
             ],
+            [
+                ('document', 'channels'),
+                (),
+                '',
+            ],
         ]
         for prop, val_py, val_str in params:
             prop = (prop[1], f'http://namespaces.zeit.de/CMS/{prop[0]}')


### PR DESCRIPTION
Also, das auf Mock-Connector Ebene zu testen produziert exakt den Fehler. So weit, so gut. Allerdings ist es in echt ja mit dem SQL-Connector aufgetreten. Fehlt uns also doch noch irgendwie eine Test/Toggle/irgendwas-Ebene?