### PR TITLE
WCM-434: Apply TMS type conversion for datetime in both directions (belongs to 09bef55)

### DIFF
--- a/core/docs/changelog/tmscontent.fix
+++ b/core/docs/changelog/tmscontent.fix
@@ -1,0 +1,1 @@
+Apply TMS type conversion for datetime in both directions

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -279,6 +279,9 @@ class DateTime(JSONType):
         PropertyKey,
     )
 
+    def fromProperty(self, value):
+        return zeit.cms.content.dav.DatetimeProperty._fromProperty(value)
+
     def toProperty(self, value):
         return zeit.cms.content.dav.DatetimeProperty._toProperty(value)
 


### PR DESCRIPTION
Since we now need tms/json-specific conversion, ITMSContent [no longer falls back](https://github.com/ZeitOnline/zeit.web/actions/runs/11325782035/job/31493386599#step:13:2672) to the normal DAVPropertyConverter to deserialize datetimes, so we need to handle that in the specific one of course.