### PR TITLE
WCM-445: Add gallery_type column and alembic migration

### DIFF
--- a/core/docs/changelog/WCM-445.change
+++ b/core/docs/changelog/WCM-445.change
@@ -1,0 +1,1 @@
+WCM-445: Add galery_type column

--- a/core/src/zeit/connector/migrations/predeploy/20241015_1128-b03c427b88de_wcm_445_gallery_type_column.py
+++ b/core/src/zeit/connector/migrations/predeploy/20241015_1128-b03c427b88de_wcm_445_gallery_type_column.py
@@ -1,0 +1,26 @@
+"""WCM-445_gallery_type_column
+
+Revision ID: b03c427b88de
+Revises: 10c0b7d30778
+Create Date: 2024-10-15 11:28:23.231396
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b03c427b88de'
+down_revision: Union[str, None] = '10c0b7d30778'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('properties', sa.Column('gallery_type', sa.Unicode(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('properties', 'gallery_type')

--- a/core/src/zeit/connector/models.py
+++ b/core/src/zeit/connector/models.py
@@ -77,6 +77,12 @@ class Article:
     )
 
 
+class Gallery:
+    gallery_type = mapped_column(
+        Unicode, info={'namespace': 'zeit.content.gallery', 'name': 'type', 'migration': 'wcm_471'}
+    )
+
+
 class SemanticChange:
     date_last_modified_semantic = mapped_column(
         TIMESTAMP,
@@ -128,7 +134,7 @@ class PublishInfo:
     )
 
 
-class Content(Base, CommonMetadata, Modified, PublishInfo, SemanticChange, Article):
+class Content(Base, CommonMetadata, Modified, PublishInfo, SemanticChange, Article, Gallery):
     __tablename__ = 'properties'
 
     @declared_attr


### PR DESCRIPTION
Neue Spalte `gallery_type`, aber kein Index, weil dieser keine Auswirkung auf die Query Performance hätte. Die Spalten sind nun immer in Paketen getoggelt. Die Datenmigration der `gallery_type` Spalte soll zusammen mit den Spalten für Rawqueries erfolgen, siehe [Ticket](https://zeit-online.atlassian.net/browse/WCM-471).

### Checklist

- [x] [Documentation](https://github.com/ZeitOnline/content-storage-api/pull/361)
- [x] Changelog
- [x] Tests
- [x] ~~Translations~~
- [x] Migrate [Skript](https://github.com/ZeitOnline/vivi-deployment/pull/1168)

### gif
![gallery](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWc2dzEydWRveWdpdGp3d2R2YWVkdmdhajI5aHlreWZoZ2Q0dG9paiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/c3PWmJWHxXgoo/giphy.gif)