### PR TITLE
WCM-456: Write toggle must not break checkin

### DIFF
--- a/core/docs/changelog/WCM-456.change
+++ b/core/docs/changelog/WCM-456.change
@@ -1,0 +1,1 @@
+WCM-456: Keep WebDAVProperties API consistent, operate with string values independent of connector toggles. Instead convert property values only, when metadata columns are origin or source.

--- a/core/src/zeit/cms/content/dav.py
+++ b/core/src/zeit/cms/content/dav.py
@@ -15,8 +15,6 @@ import zope.schema.interfaces
 import zope.xmlpickle
 
 from zeit.cms.content.interfaces import WRITEABLE_ON_CHECKIN
-from zeit.cms.content.sources import FEATURE_TOGGLES
-from zeit.connector.models import Content as ConnectorModel
 from zeit.connector.resource import PropertyKey
 import zeit.cms.content.caching
 import zeit.cms.content.interfaces
@@ -189,19 +187,7 @@ class UnicodeProperty:
 )
 @zope.interface.implementer(zeit.cms.content.interfaces.IDAVPropertyConverter)
 class IntProperty(UnicodeProperty):
-    def __init__(self, context, properties, propertykey):
-        super().__init__(context, properties, propertykey)
-        self.has_sql_type = ConnectorModel.column_by_name(*propertykey) is not None
-
-    def fromProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('read_metadata_columns'):
-            return value
-        return super().fromProperty(value)
-
-    def toProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('write_metadata_columns'):
-            return value
-        return super().toProperty(value)
+    pass
 
 
 @zope.component.adapter(
@@ -327,11 +313,8 @@ class ChoicePropertyWithIterableVocabulary:
 class BoolProperty:
     def __init__(self, context, properties, propertykey):
         self.context = context
-        self.has_sql_type = ConnectorModel.column_by_name(*propertykey) is not None
 
     def fromProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('read_metadata_columns'):
-            return value
         return self._fromProperty(value)
 
     @staticmethod
@@ -339,8 +322,6 @@ class BoolProperty:
         return value.lower() in ('yes', 'true')
 
     def toProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('write_metadata_columns'):
-            return value
         return self._toProperty(value)
 
     @staticmethod
@@ -355,13 +336,10 @@ class BoolProperty:
 class DatetimeProperty:
     def __init__(self, context, properties, propertykey):
         self.context = context
-        self.has_sql_type = ConnectorModel.column_by_name(*propertykey) is not None
 
     def fromProperty(self, value):
         if not value:
             return None
-        if self.has_sql_type and FEATURE_TOGGLES.find('read_metadata_columns'):
-            return value
         return self._fromProperty(value)
 
     @staticmethod
@@ -372,8 +350,6 @@ class DatetimeProperty:
         return date.in_tz('UTC')
 
     def toProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('write_metadata_columns'):
-            return value
         return self._toProperty(value)
 
     @staticmethod
@@ -407,7 +383,6 @@ class CollectionTextLineProperty:
     SPLIT_PATTERN = re.compile(r'(?!\\);')
 
     def __init__(self, context, value_type, properties, propertykey):
-        self.has_sql_type = ConnectorModel.column_by_name(*propertykey) is not None
         self.context = context
         self.value_type = value_type
         self.properties = properties
@@ -418,8 +393,6 @@ class CollectionTextLineProperty:
             self._type = self._type[0]
 
     def fromProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('read_metadata_columns'):
-            return value
         typ = zope.component.getMultiAdapter(
             (self.value_type, self.properties, self.propertykey),
             zeit.cms.content.interfaces.IDAVPropertyConverter,
@@ -444,8 +417,6 @@ class CollectionTextLineProperty:
         return self._type(result)
 
     def toProperty(self, value):
-        if self.has_sql_type and FEATURE_TOGGLES.find('write_metadata_columns'):
-            return value
         typ = zope.component.getMultiAdapter(
             (self.value_type, self.properties, self.propertykey),
             zeit.cms.content.interfaces.IDAVPropertyConverter,

--- a/core/src/zeit/connector/filesystem.py
+++ b/core/src/zeit/connector/filesystem.py
@@ -11,9 +11,7 @@ import lxml.etree
 import zope.app.file.image
 import zope.interface
 
-from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.connector.interfaces import ID_NAMESPACE, CannonicalId
-from zeit.connector.models import Content
 import zeit.cms.config
 import zeit.cms.content.dav
 import zeit.connector.converter
@@ -254,26 +252,12 @@ class Connector:
             return properties
 
         properties.update(parse_properties(xml))
-        self._convert_sql_types(properties)
 
         if zeit.connector.interfaces.RESOURCE_TYPE_PROPERTY not in properties:
             properties[zeit.connector.interfaces.RESOURCE_TYPE_PROPERTY] = self._guess_type(id)
 
         self.property_cache[id] = properties
         return properties
-
-    def _convert_sql_types(self, properties):
-        if not FEATURE_TOGGLES.find('read_metadata_columns'):
-            return
-        for key, value in properties.items():
-            properties[key] = self._convert_sql(key, value)
-
-    def _convert_sql(self, key, value):
-        column = Content.column_by_name(*key)
-        if column is None:
-            return value
-        converter = zeit.connector.interfaces.IConverter(column)
-        return converter.deserialize(value)
 
     def _guess_type(self, id):
         path = self._path(id)

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -12,7 +12,6 @@ from sqlalchemy.dialects import postgresql
 import pendulum
 import zope.event
 
-from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.connector.interfaces import (
     ID_NAMESPACE,
     UUID_PROPERTY,
@@ -362,16 +361,7 @@ class Connector(zeit.connector.filesystem.Connector):
             properties = super()._get_properties(id)
         else:
             properties = properties.copy()
-            self._convert_sql_types(properties)
         return properties
-
-    def _convert_sql(self, key, value):
-        if (
-            FEATURE_TOGGLES.find('write_metadata_columns')
-            or FEATURE_TOGGLES.find('write_metadata_columns_strict')
-        ) and not isinstance(value, str):
-            return value
-        return super()._convert_sql(key, value)
 
     def _set_properties(self, id, properties):
         stored_properties = self._get_properties(id)
@@ -386,10 +376,7 @@ class Connector(zeit.connector.filesystem.Connector):
                 stored_properties.pop((name, namespace), None)
                 continue
 
-            if not (
-                FEATURE_TOGGLES.find('write_metadata_columns')
-                or FEATURE_TOGGLES.find('write_metadata_columns_strict')
-            ) and not isinstance(value, str):
+            if not isinstance(value, str):
                 raise ValueError('Expected str, got %s: %r' % (type(value), value))
             stored_properties[(name, namespace)] = value
         self._properties[id] = stored_properties

--- a/core/src/zeit/connector/testing.py
+++ b/core/src/zeit/connector/testing.py
@@ -195,6 +195,7 @@ class SQLDatabaseLayer(plone.testing.Layer):
     def tearDown(self):
         self['sql_connection'].close()
         del self['sql_connection']
+        del os.environ['PGDATABASE']
 
     def testSetUp(self):
         """Sets up a transaction savepoint, which will be rolled back

--- a/core/src/zeit/connector/tests/test_mock.py
+++ b/core/src/zeit/connector/tests/test_mock.py
@@ -5,7 +5,6 @@ import logging
 import pendulum
 import transaction
 
-from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.connector.search import SearchVar as SV
 import zeit.connector.testing
 
@@ -66,40 +65,3 @@ Searching: (:and
         transaction.commit()
         res = self.get_resource('foo')
         self.connector['http://xml.zeit.de/testing/foo'] = res
-
-
-class MockTypeConversionTest(zeit.connector.testing.MockTest):
-    def test_converts_sql_properties_on_read(self):
-        params = [
-            [
-                ('workflow', 'published'),
-                True,
-                'yes',
-            ],
-            [
-                ('document', 'date_created'),
-                pendulum.datetime(1970, 1, 1),
-                '1970-01-01T00:00:00+00:00',
-            ],
-            [
-                ('document', 'channels'),
-                (
-                    ('International', 'Nahost'),
-                    ('Wissen', None),
-                ),
-                'International Nahost;Wissen',
-            ],
-            [
-                ('document', 'channels'),
-                (),
-                '',
-            ],
-        ]
-        for prop, val_py, val_str in params:
-            prop = (prop[1], f'http://namespaces.zeit.de/CMS/{prop[0]}')
-            FEATURE_TOGGLES.unset('read_metadata_columns')
-            res = self.add_resource('foo', properties={prop: val_str})
-            self.assertEqual(res.properties[prop], val_str)
-            FEATURE_TOGGLES.set('read_metadata_columns')
-            res = self.connector[res.id]
-            self.assertEqual(res.properties[prop], val_py)


### PR DESCRIPTION
Die API Änderung des DAVPropertyConverters ist das Problem, dass sich durch das Zurückdrehen des `write_metadata_columns` Toggles gezeigt hat. 

Der Toggle hat dafür gesorgt, dass nicht nur die Daten in die neuen Spalten geschrieben werden, sondern auch, dass in den Properties der Resource keine Strings, sondern Python Objekte drin stehen. Beispielsweise `PropertyKey(name='year', namespace='http://namespaces.zeit.de/CMS/document'): 2008` statt `PropertyKey(name='year', namespace='http://namespaces.zeit.de/CMS/document'): '2008'`. Oder `PropertyKey(name='date_created', namespace='http://namespaces.zeit.de/CMS/document'): DateTime(2024, 10, 16, 15, 5, 32, 67016, tzinfo=Timezone('Europe/Berlin'))` statt `PropertyKey(name='date_created', namespace='http://namespaces.zeit.de/CMS/document'): '2024-10-16T15:56:36.967542+02:00'`.

Damit kann aber weder die `unsorted` Spalte, noch der `IDAVPropertyConverter` umgehen.
siehe
```
  File "/Users/louisa.huelsen/Projects/vivi-deployment/work/source/vivi/core/src/zeit/cms/content/dav.py", line 85, in __fetch__
    value = converter.fromProperty(dav_value)
   - __traceback_info__: (<zeit.content.article.article.Article http://xml.zeit.de/08e96b04-bcff-4c54-9a3e-39c32237ecdf.tmp>, <zope.schema._field.Tuple object at 0x13ab3f350 zeit.cms.content.interfaces.ICommonMetadata.channels>, 'channels', (('Kultur', None),))
  File "/Users/louisa.huelsen/Projects/vivi-deployment/work/source/vivi/core/src/zeit/cms/content/dav.py", line 430, in fromProperty
    found = value.find(';', start)
  ``` 

Deshalb darf sich die API des `IDAVPropertyConverter`s erst ändern, wenn sich sowohl read, als auch write einig über den Datentyp sind, mit dem sie hantieren. 

Jetzt ist der Write-Toggle wirklich nur darauf beschränkt im Connector in die neuen Spalten zu schreiben. Das schien mir sinnvoller als ein Pflaster in `from_webdav` in Richtung:
```python
if not isinstance(v, str):
    # Support unsetting write_metadata_columns toggle. Must write json serializable
    # values to unsorted
    column = self.column_by_name(k, ns)
    if column is not None:
        converter = zeit.connector.interfaces.IConverter(column)
        unsorted[ns.replace(self.NS, '', 1)][k] = converter.serialize(v)
else:
    unsorted[ns.replace(self.NS, '', 1)][k] = v
```
### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![monday](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTV5em9xZTd5d3JvbWZobDVqY3R1NDRybHN5NXE3aDcxMmo0NW9pZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6fJbwYFe3SmVVQ4M/giphy.gif)