### PR TITLE
WCM-462: toggle single columns on and off

### DIFF
--- a/core/docs/changelog/WCM-462.change
+++ b/core/docs/changelog/WCM-462.change
@@ -1,0 +1,1 @@
+WCM-462: toggle single columns on and off

--- a/core/src/zeit/connector/tests/test_mock.py
+++ b/core/src/zeit/connector/tests/test_mock.py
@@ -74,9 +74,9 @@ class MockTypeConversionTest(zeit.connector.testing.MockTest):
     def test_converts_sql_properties_on_read(self):
         params = [
             [
-                ('workflow', 'published'),
-                True,
-                'yes',
+                ('document', 'year'),
+                2024,
+                '2024',
             ],
             [
                 ('document', 'date_created'),


### PR DESCRIPTION
Wie wäre der Ablauf? Wir fügen ein neue Spalte hinzu mit der Info `toggled`, um diese explizit von den bestehenden zu unterscheiden bzw. später nach der Migration den Toggle zu "entfernen". 

Ab diesem Zeitpunkt können wir nach dem Schema `namespace_name_write` und `namespace_name_read` die Toggle für die einzelnen Spalten aktivieren.

Diese Toggle sind weiterhin abhängig von unseren übergeordneten Toggle `read_metadata_columns` und `write_metadata_columns`.

### Checklist

- [ ] Was passiert im DAVPropertyConverter ?
- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()