### PR TITLE
FIX: adjust maintenance hours for vg wort and timezone

### DIFF
--- a/core/docs/changelog/FIX_adjust-maintenance-hours-for-vg-wort
+++ b/core/docs/changelog/FIX_adjust-maintenance-hours-for-vg-wort
@@ -1,0 +1,1 @@
+FIX: adjust maintenance hours for vg wort

--- a/core/src/zeit/vgwort/cli.py
+++ b/core/src/zeit/vgwort/cli.py
@@ -21,11 +21,11 @@ log = logging.getLogger(__name__)
 
 
 def in_maintenance_hours():
-    now = pendulum.now('UTC')
+    now = pendulum.now('Europe/Berlin')
     today = pendulum.datetime(now.year, now.month, now.day)
-    four = today.replace(hour=3, minute=50)
+    three = today.replace(hour=2, minute=50)
     six = today.replace(hour=6, minute=10)
-    return four <= now <= six
+    return three <= now <= six
 
 
 # No transaction commit, as we don't care about the cache.


### PR DESCRIPTION
Die Timezone `UTC` hat Probleme gemacht. Der Wartungszeitraum von VGWort ist zwischen 03:00 und 06:00 morgens. Wir haben noch 10 Minuten Puffer reingemacht.