### PR TITLE
MAINT: add copy button to properties table

### DIFF
--- a/core/src/zeit/cms/repository/browser/property.py
+++ b/core/src/zeit/cms/repository/browser/property.py
@@ -1,3 +1,5 @@
+import html
+
 import zc.table.column
 import zc.table.interfaces
 import zope.interface
@@ -9,6 +11,23 @@ import zeit.cms.browser.listing
 @zope.interface.implementer(zc.table.interfaces.ISortableColumn)
 class GetterColumn(zc.table.column.GetterColumn):
     pass
+
+
+class ActionsColumn(zc.table.column.Column):
+    def renderCell(self, item, formatter):
+        selector = f'copy_{item[0][0]}'
+        copy_translation = _('Copy')
+        return (
+            f'<pre style="display: none" id="{selector}">'
+            f'{html.escape(str(item[1]))}'
+            f'</pre>'
+            f'<button style="display: flex" onclick="'
+            f"try{{navigator.clipboard.writeText(document.getElementById('{selector}').textContent);}}"
+            f'catch(e){{console.error(e);}}">'
+            f'<img src="/fanstatic/zeit.cms/icons/insert.png"/>'
+            f'{copy_translation}'
+            f'</button>'
+        )
 
 
 class MetadataColumn(GetterColumn):
@@ -30,6 +49,7 @@ class Listing(zeit.cms.browser.listing.Listing):
         GetterColumn(title=_('Namespace'), getter=lambda t, c: t[0][1]),
         GetterColumn(title=_('Name'), getter=lambda t, c: t[0][0]),
         GetterColumn(title=_('Value'), getter=lambda t, c: str(t[1])),
+        ActionsColumn(title=_('Actions')),
         MetadataColumn(),
     )
 


### PR DESCRIPTION
Dieser PR fügt einen Button in den Properties hinzu, der den jeweiligen Inhalt kopiert.

![grafik](https://github.com/user-attachments/assets/7287270e-5d08-4f48-8729-51130171cb94)
### Checklist

- [ ] Documentation
- [ ] Changelog
- [ ] Tests
- [ ] Translations

# GIF
![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWd6MjRwZ200eTlhNWZuYnF3anBjMHlhYmxuNW1kbTNqcHVjeWw5OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XJILJrdHp7QZVUP1OD/giphy.gif)