### PR TITLE
FIX: Bring back variable resolution for error messages in log

### DIFF
--- a/core/docs/changelog/log.fix
+++ b/core/docs/changelog/log.fix
@@ -1,0 +1,1 @@
+Bring back variable resolution for error messages in log

--- a/core/src/zeit/cms/checkout/manager.py
+++ b/core/src/zeit/cms/checkout/manager.py
@@ -61,7 +61,7 @@ class CheckoutManager:
             ):
                 raise zeit.cms.checkout.interfaces.CheckinCheckoutError(
                     self.context.uniqueId,
-                    _('The content you tried to check out is already in your ' 'working copy.'),
+                    _('The content you tried to check out is already in your working copy.'),
                 )
         return True
 

--- a/core/src/zeit/workflow/publish.py
+++ b/core/src/zeit/workflow/publish.py
@@ -203,7 +203,7 @@ class PublishRetractTask:
                     # Like zeit.cms.browser.error.ErrorView.message
                     args = getattr(error, 'args', None)
                     if args:
-                        errormessage = zope.i18n.translate(_(args[0]), target_language='de')
+                        errormessage = zope.i18n.translate(args[0], target_language='de')
                     else:
                         errormessage = str(error)
 


### PR DESCRIPTION
### Checklist

- [ ] Documentation
- [ ] Changelog
- [ ] Tests
- [ ] Translations

![grafik](https://github.com/user-attachments/assets/37c80112-aa62-4922-83eb-eb8e553332e5)

statt

![grafik](https://github.com/user-attachments/assets/cb0e6fe3-be35-44f7-88e5-74b66edfa4bf)


### gif
![]()