### PR TITLE
WCM-507: elastic search returns authors field

### DIFF
--- a/core/docs/changelog/WCM-507.change
+++ b/core/docs/changelog/WCM-507.change
@@ -1,0 +1,1 @@
+WCM-507: elastic search returns authors field

--- a/core/src/zeit/find/browser/find.py
+++ b/core/src/zeit/find/browser/find.py
@@ -261,7 +261,9 @@ class SearchResult(JSONView):
         return result.get('doc_type', '')
 
     def get_authors(self, result):
-        return result.get('author', '').split(',')
+        if authors := result.get('author'):
+            return authors.split(',')
+        return []
 
     def _get_unformatted_date(self, result):
         last_semantic_change = result.get('payload.document.last-semantic-change')

--- a/core/src/zeit/find/search.py
+++ b/core/src/zeit/find/search.py
@@ -12,6 +12,7 @@ DEFAULT_FIELDS = (
     'payload',
     'title',
     'teaser',
+    'author',
 )
 
 


### PR DESCRIPTION
Das Feld muss natürlich auch im `_source` des elastic Queries enthalten sein 🙄 