### PR TITLE
WCM-471: Columns for raw queries

### DIFF
--- a/core/docs/changelog/WCM-471.change
+++ b/core/docs/changelog/WCM-471.change
@@ -1,0 +1,1 @@
+ZO-471: Add columns required for raw queries

--- a/core/src/zeit/connector/migrations/postdeploy/20241111_1359-b6c4f9badee3_wcm_471_raw_query_columns.py
+++ b/core/src/zeit/connector/migrations/postdeploy/20241111_1359-b6c4f9badee3_wcm_471_raw_query_columns.py
@@ -1,0 +1,39 @@
+"""WCM-471: raw query columns
+
+Revision ID: b6c4f9badee3
+Revises: cbac9954ed68
+Create Date: 2024-11-11 13:59:09.102738
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text as sql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6c4f9badee3'
+down_revision: Union[str, None] = 'cbac9954ed68'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            'ix_properties_article_audio_premium_enabled',
+            'properties',
+            [sql('article_audio_premium_enabled')],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            'ix_properties_article_audio_premium_enabled',
+            table_name='properties',
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/core/src/zeit/connector/migrations/predeploy/20241015_1128-b03c427b88de_wcm_445_gallery_type_column.py
+++ b/core/src/zeit/connector/migrations/predeploy/20241015_1128-b03c427b88de_wcm_445_gallery_type_column.py
@@ -1,4 +1,4 @@
-"""WCM-445_gallery_type_column
+"""WCM-445_gallery_type_column_WCM-471_raw_query_columns
 
 Revision ID: b03c427b88de
 Revises: 10c0b7d30778

--- a/core/src/zeit/connector/migrations/predeploy/20241105_1528-fb15e09b44f8_wcm_471_raw_query_columns.py
+++ b/core/src/zeit/connector/migrations/predeploy/20241105_1528-fb15e09b44f8_wcm_471_raw_query_columns.py
@@ -1,0 +1,40 @@
+"""WCM-471: raw query columns
+
+Revision ID: fb15e09b44f8
+Revises: b03c427b88de
+Create Date: 2024-11-05 15:28:03.522675
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'fb15e09b44f8'
+down_revision: Union[str, None] = 'b03c427b88de'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('properties', sa.Column('print_page', sa.Integer(), nullable=True))
+    op.add_column(
+        'properties', sa.Column('article_audio_premium_enabled', sa.Boolean(), nullable=True)
+    )
+    op.add_column(
+        'properties', sa.Column('article_audio_speech_enabled', sa.Boolean(), nullable=True)
+    )
+    op.add_column('properties', sa.Column('article_header', sa.Unicode(), nullable=True))
+    op.add_column('properties', sa.Column('centerpage_type', sa.Unicode(), nullable=True))
+    op.add_column('properties', sa.Column('seo_meta_robots', sa.Unicode(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('properties', 'seo_meta_robots')
+    op.drop_column('properties', 'centerpage_type')
+    op.drop_column('properties', 'article_header')
+    op.drop_column('properties', 'article_audio_speech_enabled')
+    op.drop_column('properties', 'article_audio_premium_enabled')
+    op.drop_column('properties', 'print_page')

--- a/core/src/zeit/connector/models.py
+++ b/core/src/zeit/connector/models.py
@@ -69,11 +69,29 @@ class CommonMetadata:
     volume_number = mapped_column(
         Integer, info={'namespace': 'document', 'name': 'volume', 'migration': 'wcm_430'}
     )
+    print_page = mapped_column(
+        Integer, info={'namespace': 'document', 'name': 'page', 'migration': 'wcm_471'}
+    )
 
 
 class Article:
+    article_audio_premium_enabled = mapped_column(
+        Boolean, info={'namespace': 'print', 'name': 'has_audio', 'migration': 'wcm_471'}
+    )
+    article_audio_speech_enabled = mapped_column(
+        Boolean, info={'namespace': 'document', 'name': 'audio_speechbert', 'migration': 'wcm_471'}
+    )
     article_genre = mapped_column(
         Unicode, info={'namespace': 'document', 'name': 'genre', 'migration': 'wcm_430'}
+    )
+    article_header = mapped_column(
+        Unicode, info={'namespace': 'document', 'name': 'header_layout', 'migration': 'wcm_471'}
+    )
+
+
+class Centerpage:
+    centerpage_type = mapped_column(
+        Unicode, info={'namespace': 'zeit.content.cp', 'name': 'type', 'migration': 'wcm_471'}
     )
 
 
@@ -134,7 +152,16 @@ class PublishInfo:
     )
 
 
-class Content(Base, CommonMetadata, Modified, PublishInfo, SemanticChange, Article, Gallery):
+class SEO:
+    seo_meta_robots = mapped_column(
+        Unicode,
+        info={'namespace': 'document', 'name': 'html-meta-robots', 'migration': 'wcm_471'},
+    )
+
+
+class Content(
+    Base, CommonMetadata, Modified, PublishInfo, SemanticChange, Article, Gallery, Centerpage, SEO
+):
     __tablename__ = 'properties'
 
     @declared_attr
@@ -170,6 +197,7 @@ class Content(Base, CommonMetadata, Modified, PublishInfo, SemanticChange, Artic
                 cls.Index(getattr(cls, column))
                 for column in [
                     'access',
+                    'article_audio_premium_enabled',
                     'article_genre',
                     'print_ressort',
                     'product',


### PR DESCRIPTION
Warum ein Index für `article_audio_premium_enabled`? Weil sich die execution time der Query von ca 40 ms auf 10ms verringert hat siehe https://zeit-online.atlassian.net/browse/WCM-471?focusedCommentId=105019 . Bzw mit der herausgesuchten Query https://zeit-online.atlassian.net/browse/WCM-471?focusedCommentId=105018
Warum ist `seo_meta_robots` plötzlich ein Array? Weil die Query meist unter 10ms dauert statt mit `Varchar` Type und `varchar_pattern_ops`-Index 40ms. Und die Zeiten stabiler sind, als bei Varchar.
oder auch, wir sollten das nochmal diskutieren, siehe https://zeit-online.atlassian.net/browse/WCM-471?focusedCommentId=105017

### Notes
Sowohl für `seo_meta_robots` als Array, als auch als Varchar: wenn man versucht die Ergebnisse nach `date_last_published_semantic` zu ordnen, sind wir für Varchar bei 7500ms und fürs Array ist es quasi nicht mehr ausführbar.

### Checklist

- [ ] Documentation-> kommt
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

![gallery](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWc2dzEydWRveWdpdGp3d2R2YWVkdmdhajI5aHlreWZoZ2Q0dG9paiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/c3PWmJWHxXgoo/giphy.gif)