### PR TITLE
WCM-520: Fix sqlalchemy API usage error that generated queries like `select count(*) where` without a `from` clause

### DIFF
--- a/core/docs/changelog/WCM-520.change
+++ b/core/docs/changelog/WCM-520.change
@@ -1,0 +1,1 @@
+WCM-520: Fix total_hits sqlalchemy error in SQL queries

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -618,7 +618,12 @@ class Connector:
         return result
 
     def search_sql_count(self, query):
-        rows = self._execute_suppress_errors(query.with_only_columns(sqlalchemy.func.count()))
+        rows = self._execute_suppress_errors(
+            query.with_only_columns(
+                sqlalchemy.func.count(),
+                maintain_column_froms=True,
+            )
+        )
         if rows is None:
             return 0
         return rows.one()

--- a/core/src/zeit/connector/tests/test_postgresql.py
+++ b/core/src/zeit/connector/tests/test_postgresql.py
@@ -167,7 +167,7 @@ class SQLConnectorTest(zeit.connector.testing.SQLTest):
         self.add_resource('one', type='article')
         self.add_resource('two', type='centerpage')
         self.add_resource('three', type='article')
-        query = select(Content).filter_by(type='article')
+        query = select(Content).where(sql("type='article'"))
         self.assertEqual(self.connector.search_sql_count(query), 2)
 
     def test_search_sql_suppresses_errors(self):


### PR DESCRIPTION
This is somewhat insiduous, because the API *sometimes* does what we want even without the explicit parameter.


### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~