### PR TITLE
WCM-544: read centerpage type from properties and not from xml body

### DIFF
--- a/core/docs/changelog/WCM-544.change
+++ b/core/docs/changelog/WCM-544.change
@@ -1,0 +1,1 @@
+WCM-544: read centerpage type from properties and not from xml body

--- a/core/src/zeit/content/cp/README.txt
+++ b/core/src/zeit/content/cp/README.txt
@@ -16,7 +16,7 @@ Centerpage
 The ancient XML representation looked as follows:
 
 >>> print(zeit.cms.testing.xmltotext(cp.xml))
-<centerpage... type="homepage"...>
+<centerpage...>
   <head/>
   <body>
     <cluster area="feature" kind="duo">

--- a/core/src/zeit/content/cp/centerpage.py
+++ b/core/src/zeit/content/cp/centerpage.py
@@ -46,10 +46,7 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
     def body(self):
         return zeit.content.cp.interfaces.IBody(self)
 
-    _type_xml = zeit.cms.content.property.ObjectPathAttributeProperty(
-        None, 'type', zeit.content.cp.interfaces.ICenterPage['type']
-    )
-    _type_dav = zeit.cms.content.dav.DAVProperty(
+    type = zeit.cms.content.dav.DAVProperty(
         zeit.content.cp.interfaces.ICenterPage['type'],
         zeit.content.cp.interfaces.DAV_NAMESPACE,
         'type',
@@ -148,15 +145,6 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
     og_image = zeit.cms.content.property.ObjectPathProperty(
         '.head.og_meta.og_image', zeit.content.cp.interfaces.ICenterPage['og_image']
     )
-
-    @property
-    def type(self):
-        return self._type_xml
-
-    @type.setter
-    def type(self, value):
-        self._type_xml = value
-        self._type_dav = value
 
     cache = gocept.cache.property.TransactionBoundCache('_v_cache', writeabledict)
 


### PR DESCRIPTION
### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()