### PR TITLE
WCM-551: Cache analyzed toggles, not just their XML nodes

### DIFF
--- a/core/docs/changelog/WCM-551.change
+++ b/core/docs/changelog/WCM-551.change
@@ -1,0 +1,1 @@
+WCM-551: Cache analyzed toggles, not just their XML nodes (5% performance gain)

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -462,14 +462,7 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
         if key in os.environ:
             return bool(os.environ[key])
 
-        node = self._get_tree().xpath(f'//*[name() = "{name}"]')
-        if not node:
-            return False
-        node = node[0]
-        try:
-            return bool(node)
-        except TypeError:
-            return False
+        return self._values().get(name)
 
     def override(self, value, *names):
         for name in names:

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -476,6 +476,7 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
     def getValues(self, context):
         return [k for k, v in self._values().items() if v]
 
+    @FEATURE_CACHE.cache_on_arguments()
     def _values(self):
         tree = self._get_tree()
         result = {node.tag: bool(node) for node in tree.xpath('//*') if not node.getchildren()}

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -452,11 +452,6 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
             self.factory.override(False, *names)
 
     def find(self, name):
-        # Allow tests to set overrides
-        overrides = self._overrides()
-        if name in overrides:
-            return overrides[name]
-
         # Allow to override toggles via environment, for local development.
         key = 'toggle_{}'.format(name)
         if key in os.environ:
@@ -466,12 +461,8 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
 
     def override(self, value, *names):
         for name in names:
-            self._overrides()[name] = value
-
-    # Changes are discarded between tests, as they call dogpile clear()
-    @FEATURE_CACHE.cache_on_arguments()
-    def _overrides(self):
-        return {}
+            # Changes are discarded between tests, as they call dogpile clear()
+            self._values()[name] = value
 
     def getValues(self, context):
         return [k for k, v in self._values().items() if v]
@@ -480,7 +471,6 @@ class FeatureToggleSource(ShortCachedXMLBase, XMLSource):
     def _values(self):
         tree = self._get_tree()
         result = {node.tag: bool(node) for node in tree.xpath('//*') if not node.getchildren()}
-        result.update(self._overrides())
         return result
 
 


### PR DESCRIPTION
Especially with WCM-462 where each column looks for toggles, this yields a 5% performance improvement (local measurement 7.7s instead of 8.1 for a CP)

### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests (implizit, z.B. AutomaticAreaSQLCustomTest)
- [x] ~Translations~