### PR TITLE
WCM-563: if you already own the lock, take it

### DIFF
--- a/core/docs/changelog/WCM-563.change
+++ b/core/docs/changelog/WCM-563.change
@@ -1,0 +1,1 @@
+WCM-563: if you already own the lock, take it

--- a/core/src/zeit/connector/interfaces.py
+++ b/core/src/zeit/connector/interfaces.py
@@ -155,8 +155,6 @@ class IConnector(zope.interface.Interface):
     def lock(id, principal, until):
         """Lock resource for principal until a given datetime.
 
-        A client MUST NOT submit the same write lock request twice.
-
         A successful request for an write lock results in the generation of a unique lock token
         associated with the requesting principal.
 

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -274,7 +274,7 @@ class Connector(zeit.connector.filesystem.Connector):
         id = self._get_cannonical_id(id)
         (another_principal, _, my_lock) = self.locked(id)
         if another_principal and not my_lock:
-            raise LockedByOtherSystemError('Resource is already locked by another principal')
+            raise LockedByOtherSystemError(id, '')
         self._locked[id] = (principal, until, my_lock)
 
     def unlock(self, id):

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -18,7 +18,6 @@ from zeit.connector.interfaces import (
     CannonicalId,
     CopyError,
     LockedByOtherSystemError,
-    LockingError,
     MoveError,
 )
 from zeit.connector.lock import lock_is_foreign
@@ -274,8 +273,8 @@ class Connector(zeit.connector.filesystem.Connector):
 
         id = self._get_cannonical_id(id)
         (another_principal, _, my_lock) = self.locked(id)
-        if another_principal:
-            raise LockingError('Resource is already locked by another principal')
+        if another_principal and not my_lock:
+            raise LockedByOtherSystemError('Resource is already locked by another principal')
         self._locked[id] = (principal, until, my_lock)
 
     def unlock(self, id):

--- a/core/src/zeit/connector/mock.py
+++ b/core/src/zeit/connector/mock.py
@@ -18,6 +18,7 @@ from zeit.connector.interfaces import (
     CannonicalId,
     CopyError,
     LockedByOtherSystemError,
+    LockingError,
     MoveError,
 )
 from zeit.connector.lock import lock_is_foreign
@@ -273,8 +274,11 @@ class Connector(zeit.connector.filesystem.Connector):
 
         id = self._get_cannonical_id(id)
         (another_principal, _, my_lock) = self.locked(id)
-        if another_principal and not my_lock:
-            raise LockedByOtherSystemError(id, '')
+        if another_principal:
+            if not my_lock:
+                raise LockedByOtherSystemError(id, '')
+            elif another_principal != principal:
+                raise LockingError(id, '')
         self._locked[id] = (principal, until, my_lock)
 
     def unlock(self, id):

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -40,7 +40,6 @@ from zeit.connector.interfaces import (
     INTERNAL_PROPERTY,
     CopyError,
     LockedByOtherSystemError,
-    LockingError,
     LockStatus,
     MoveError,
 )
@@ -538,7 +537,7 @@ class Connector:
                 self._update_lock_cache(content.uniqueid, principal, until)
                 return lock.token
             case LockStatus.OWN:
-                raise LockingError(id, f'You already own the lock of {uniqueid}.')
+                self._update_lock_cache(content.uniqueid, principal, until)
             case LockStatus.FOREIGN:
                 raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -537,7 +537,9 @@ class Connector:
                 self._update_lock_cache(content.uniqueid, principal, until)
                 return lock.token
             case LockStatus.OWN:
+                content.lock.until = until
                 self._update_lock_cache(content.uniqueid, principal, until)
+                return content.lock.token
             case LockStatus.FOREIGN:
                 raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
 

--- a/core/src/zeit/connector/postgresql.py
+++ b/core/src/zeit/connector/postgresql.py
@@ -260,7 +260,9 @@ class Connector:
             self.session.add(content)
         else:
             if content.lock_status == LockStatus.FOREIGN:
-                raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
+                raise LockedByOtherSystemError(
+                    uniqueid, f'{uniqueid} is already locked by {content.lock.principal}'
+                )
 
         (content.parent_path, content.name) = self._pathkey(uniqueid)
         current = content.to_webdav()
@@ -311,7 +313,9 @@ class Connector:
         if content is None:
             raise KeyError(f'The resource {uniqueid} does not exist.')
         if content.lock_status == LockStatus.FOREIGN:
-            raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
+            raise LockedByOtherSystemError(
+                uniqueid, f'{uniqueid} is already locked by {content.lock.principal}'
+            )
         current = content.to_webdav()
         current.update(properties)
         content.from_webdav(current)
@@ -332,7 +336,9 @@ class Connector:
             for child in to_delete:
                 if child.lock and child.lock.status == LockStatus.FOREIGN:
                     raise LockedByOtherSystemError(
-                        child.uniqueid, f'Could not delete {child.uniqueid}, because it is locked.'
+                        child.uniqueid,
+                        f'Could not delete {child.uniqueid}, because it is locked'
+                        f' by {child.lock.principal}',
                     )
 
         for content in to_delete:
@@ -486,7 +492,9 @@ class Connector:
             )
         if content.lock:
             if content.lock.status == LockStatus.FOREIGN:
-                raise LockedByOtherSystemError(old_uniqueid, f'{old_uniqueid} is already locked.')
+                raise LockedByOtherSystemError(
+                    old_uniqueid, f'{old_uniqueid} is already locked by {content.lock.principal}'
+                )
             del content.lock
 
         sources = [content]
@@ -497,7 +505,8 @@ class Connector:
                 if child.lock and child.lock.status == LockStatus.FOREIGN:
                     raise LockedByOtherSystemError(
                         old_uniqueid,
-                        f'Could not move {child.uniqueid} to {new_uniqueid}, because it is locked.',
+                        f'Could not move {child.uniqueid} to {new_uniqueid}, because it is locked'
+                        f' by {child.lock.principal}',
                     )
 
         updates = []
@@ -541,7 +550,9 @@ class Connector:
                 self._update_lock_cache(content.uniqueid, principal, until)
                 return content.lock.token
             case LockStatus.FOREIGN:
-                raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
+                raise LockedByOtherSystemError(
+                    uniqueid, f'{uniqueid} is already locked by {content.lock.principal}'
+                )
 
     def unlock(self, uniqueid):
         uniqueid = self._normalize(uniqueid)
@@ -549,7 +560,9 @@ class Connector:
         if not lock:
             return
         if lock.status == LockStatus.FOREIGN:
-            raise LockedByOtherSystemError(uniqueid, f'{uniqueid} is already locked.')
+            raise LockedByOtherSystemError(
+                uniqueid, f'{uniqueid} is already locked by {lock.principal}'
+            )
         self.session.delete(lock)
         self._update_lock_cache(uniqueid, None)
 


### PR DESCRIPTION
Noch kann ich es mir nicht erklären, wieso der Lockcache falsche bzw. keine Lockinformationen enthält. Der Fehler tritt ja wiederholt innerhalb des TTS Workflows auf. Dieser Workflow triggered eine Cache invalidierung.

Meine Annahme, Lockcache ist leer und dann wird erneut lock versucht, aber dieses mal direkt mit den Informationen innerhalb der DB.

In staging konnte ich den Fehler nicht reproduzieren, auch mit dem TTS Workflow nicht.

Daher fühlt sich das grundsätzlich nach einen Patch des Symptoms an, aber grundsätzlich auch richtig, einen bestehenden Lock einfach weiter zu verwenden.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()