### PR TITLE
WCM-540: Extend IPodcast to provide attributes needed for Spotify RSS…

### DIFF
--- a/core/docs/changelog/WCM-540.change
+++ b/core/docs/changelog/WCM-540.change
@@ -1,0 +1,1 @@
+WCM-560: Extend attributes of IPodcast for Spotify RSS feed

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -40,6 +40,19 @@ class IAudio(
     audio_type = zope.schema.Choice(title=_('Type'), readonly=True, source=AudioTypeSource())
 
 
+class PodcastTypeSource(zeit.cms.content.sources.SimpleFixedValueSource):
+    """
+    Define podcast types. This is especially interesting for third party platforms
+    or podcatchers.
+    """
+
+    values = {
+        'serial': _('Serial'),
+        'episodic': _('Episodic'),
+        'episodic_seasons': _('Episodic seasons'),
+    }
+
+
 class IPodcast(zope.interface.Interface):
     id = zope.interface.Attribute('id')
     title = zope.interface.Attribute('title')
@@ -49,6 +62,10 @@ class IPodcast(zope.interface.Interface):
     image = zope.schema.URI(title=_('show art'))
     distribution_channels = zope.interface.Attribute('distribution_channels')
     feed = zope.schema.URI(title=_('feed'))
+    explicit = zope.schema.Bool(title=_('Explicit'), readonly=True, default=False)
+    author = zope.interface.Attribute('author')
+    category = zope.interface.Attribute('category')
+    podcast_type = zope.schema.Choice(title=_('Type'), readonly=True, source=PodcastTypeSource())
 
 
 class Podcast(zeit.cms.content.sources.AllowedBase):
@@ -62,6 +79,10 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         image=None,
         distribution_channels=None,
         feed=None,
+        explicit=None,
+        author=None,
+        category=None,
+        podcast_type=None,
     ):
         super().__init__(id, title, available=None)
         self.external_id = external_id
@@ -72,6 +93,10 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         self.distribution_channels = distribution_channels
         # For parallel use of podcast hosts
         self.feed = feed
+        self.explicit = explicit
+        self.author = author
+        self.category = category
+        self.podcast_type = podcast_type
 
     def __eq__(self, other):
         return (
@@ -84,6 +109,10 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
             and self.image == other.image
             and self.distribution_channels == other.distribution_channels
             and self.feed == other.feed
+            and self.explicit == other.explicit
+            and self.author == other.author
+            and self.category == other.category
+            and self.podcast_type == other.podcast_type
         )
 
 
@@ -114,6 +143,10 @@ class PodcastSource(zeit.cms.content.sources.ObjectSource, zeit.cms.content.sour
             node.get('image'),
             distribution_channels,
             node.get('feed'),
+            bool(node.get('explicit')),
+            node.get('author'),
+            node.get('category'),
+            node.get('podcast_type'),
         )
         return podcast
 

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -66,6 +66,7 @@ class IPodcast(zope.interface.Interface):
     author = zope.interface.Attribute('author')
     category = zope.interface.Attribute('category')
     podcast_type = zope.schema.Choice(title=_('Type'), readonly=True, source=PodcastTypeSource())
+    rss_image = zope.schema.URI(title=_('rss_image'))
 
 
 class Podcast(zeit.cms.content.sources.AllowedBase):
@@ -83,6 +84,7 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         author=None,
         category=None,
         podcast_type=None,
+        rss_image=None,
     ):
         super().__init__(id, title, available=None)
         self.external_id = external_id
@@ -97,6 +99,7 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         self.author = author
         self.category = category
         self.podcast_type = podcast_type
+        self.rss_image = rss_image
 
     def __eq__(self, other):
         return (
@@ -113,6 +116,7 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
             and self.author == other.author
             and self.category == other.category
             and self.podcast_type == other.podcast_type
+            and self.rss_image == other.rss_image
         )
 
 
@@ -147,6 +151,7 @@ class PodcastSource(zeit.cms.content.sources.ObjectSource, zeit.cms.content.sour
             node.get('author'),
             node.get('category'),
             node.get('podcast_type'),
+            node.get('rss_image'),
         )
         return podcast
 

--- a/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
+++ b/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <podcasts>
-    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_' explicit='True' category='News' author='Author Mc Cat Face' podcast_type='serial'>
+    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_' explicit='True' category='News' author='Author Mc Cat Face' podcast_type='serial' rss_image="https://rss_image">
         <distribution_channel id="itunes" href="http://example.com/itunes">Apple Podcasts</distribution_channel>
         <distribution_channel id="google" href="http://example.com/google">Google Podcasts</distribution_channel>
     </podcast>

--- a/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
+++ b/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <podcasts>
-    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_'>
+    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_' explicit='True' category='News' author='Author Mc Cat Face' podcast_type='serial'>
         <distribution_channel id="itunes" href="http://example.com/itunes">Apple Podcasts</distribution_channel>
         <distribution_channel id="google" href="http://example.com/google">Google Podcasts</distribution_channel>
     </podcast>

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -34,6 +34,10 @@ class PodcastSourceTest(FunctionalTestCase):
             'http://xml.zeit.de/2006/DSC00109_2.JPG',
             distribution_channels,
             'https://feeds.example.com/aRDC72E_',
+            True,
+            'Author Mc Cat Face',
+            'News',
+            'serial',
         )
         assert values[0] == podcast
 

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -38,6 +38,7 @@ class PodcastSourceTest(FunctionalTestCase):
             'Author Mc Cat Face',
             'News',
             'serial',
+            'https://rss_image',
         )
         assert values[0] == podcast
 


### PR DESCRIPTION
… feed

Die Notwendigkeit für die Erweiterung ergibt sich aus [diesem PR](https://github.com/ZeitOnline/zeit.web/pull/8384). In der Podcast.xml sollen die weiteren Attribute pro Podcast gesetzt werden.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![Feed](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTI1bWJ4b3MxZGlsNDk1dzJyMm9hbnRsZDQyYnRjZzFzMWs1aTE1ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l41lRTRi4lYbaTTcQ/giphy.gif)