### PR TITLE
WCM-568: Ignore brightcove change events that were triggered by our own checkin handler

### DIFF
--- a/core/docs/changelog/WCM-568.change
+++ b/core/docs/changelog/WCM-568.change
@@ -1,0 +1,1 @@
+WCM-568: Ignore brightcove change events that were triggered by our own checkin handler

--- a/core/src/zeit/brightcove/configure.zcml
+++ b/core/src/zeit/brightcove/configure.zcml
@@ -27,9 +27,4 @@
     factory=".connection.playback_from_product_config"
     />
 
-  <subscriber
-    for="zeit.content.video.interfaces.IVideo
-         zeit.cms.checkout.interfaces.IAfterCheckinEvent"
-    handler=".update.export_video" />
-
 </configure>

--- a/core/src/zeit/brightcove/json/tests/test_update.py
+++ b/core/src/zeit/brightcove/json/tests/test_update.py
@@ -19,12 +19,3 @@ class NotificationTest(zeit.brightcove.testing.BrowserTestCase):
             )
             self.assertEqual('myvid', import_video.call_args[0][0])
             self.assertEqual('zope.user', import_video.call_args[1]['_principal_id_'])
-
-    def create_video(self):
-        bc = zeit.brightcove.convert.Video()
-        bc.data = {
-            'id': 'myvid',
-            'created_at': '2017-05-15T08:24:55.916Z',
-            'state': 'INACTIVE',
-        }
-        return bc

--- a/core/src/zeit/brightcove/json/tests/test_update.py
+++ b/core/src/zeit/brightcove/json/tests/test_update.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import json
 
 import zeit.brightcove.convert
 import zeit.brightcove.testing
@@ -6,16 +7,36 @@ import zeit.cms.testing
 
 
 class NotificationTest(zeit.brightcove.testing.BrowserTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch = mock.patch.object(zeit.brightcove.update.import_video_async, '__call__')
+        self.import_video = self.patch.start()
+        # Webhook view is available without authentication
+        self.browser = zeit.cms.testing.Browser(self.layer['wsgi_app'])
+
+    def tearDown(self):
+        self.patch.stop()
+        super().tearDown()
+
     def test_runs_import_as_system_user(self):
-        # View is available without authentication
-        b = zeit.cms.testing.Browser(self.layer['wsgi_app'])
-        with mock.patch.object(
-            zeit.brightcove.update.import_video_async, '__call__'
-        ) as import_video:
-            b.post(
-                'http://localhost/@@update_video',
-                '{"event": "video-change", "video": "myvid"}',
-                'application/x-javascript',
-            )
-            self.assertEqual('myvid', import_video.call_args[0][0])
-            self.assertEqual('zope.user', import_video.call_args[1]['_principal_id_'])
+        self.browser.post(
+            'http://localhost/@@update_video',
+            json.dumps({'event': 'video-change', 'video': 'myvid'}),
+            'application/json',
+        )
+        self.assertEqual('myvid', self.import_video.call_args[0][0])
+        self.assertEqual('zope.user', self.import_video.call_args[1]['_principal_id_'])
+
+    def test_ignores_event_if_origin_is_ourselves(self):
+        self.browser.post(
+            'http://localhost/@@update_video',
+            json.dumps(
+                {
+                    'event': 'video-change',
+                    'video': 'myvid',
+                    'updated_by': {'type': 'api_key', 'email': 'vivi@example.com'},
+                }
+            ),
+            'application/json',
+        )
+        self.assertFalse(self.import_video.called)

--- a/core/src/zeit/brightcove/json/update.py
+++ b/core/src/zeit/brightcove/json/update.py
@@ -35,6 +35,13 @@ class Notification:
         if data.get('event') != 'video-change' or not data.get('video'):
             return
 
+        own_apikey = zeit.cms.config.required('zeit.brightcove', 'client-email')
+        origin = data.get('updated_by', {})
+        if origin.get('type') == 'api_key' and origin.get('email') == own_apikey:
+            # Nothing left to do if we ourselves originated this change
+            # (see zeit.brighcove.update.export_video).
+            return
+
         zeit.brightcove.update.import_video_async.delay(
             data.get('video'),
             _principal_id_=zeit.cms.config.required('zeit.brightcove', 'index-principal'),

--- a/core/src/zeit/brightcove/testing.py
+++ b/core/src/zeit/brightcove/testing.py
@@ -28,6 +28,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         'oauth-url': 'none',
         'client-id': 'none',
         'client-secret': 'none',
+        'client-email': 'vivi@example.com',
         'timeout': '300',
         'playback-url': 'none',
         'playback-policy-key': 'none',

--- a/core/src/zeit/brightcove/update.py
+++ b/core/src/zeit/brightcove/update.py
@@ -1,5 +1,6 @@
 import logging
 
+import grokcore.component as grok
 import z3c.celery.celery
 import zope.event
 import zope.lifecycleevent
@@ -171,6 +172,9 @@ def import_video_async(video_id):
     import_video(zeit.brightcove.convert.Video.find_by_id(video_id))
 
 
+@grok.subscribe(
+    zeit.content.video.interfaces.IVideo, zeit.cms.checkout.interfaces.IAfterCheckinEvent
+)
 def export_video(context, event):
     if event.publishing or FEATURE_TOGGLES.find('video_disable_export_on_checkin'):
         return


### PR DESCRIPTION
### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~
- [x] Konfiguration: ZeitOnline/vivi-deployment@d31b8635b