### PR TITLE
WCM-257: Improve news import handling

### DIFF
--- a/core/docs/changelog/WCM-257.change
+++ b/core/docs/changelog/WCM-257.change
@@ -1,0 +1,1 @@
+WCM-257: Improve news import handling

--- a/core/src/zeit/cms/checkout/helper.py
+++ b/core/src/zeit/cms/checkout/helper.py
@@ -28,6 +28,7 @@ def checked_out(
     ignore_conflicts=False,
     temporary=True,
     raise_if_error=False,
+    will_publish_soon=False,
 ):
     __traceback_info__ = (content.uniqueId,)
     manager = zeit.cms.checkout.interfaces.ICheckoutManager(content)
@@ -47,5 +48,8 @@ def checked_out(
         else:
             manager = zeit.cms.checkout.interfaces.ICheckinManager(checked_out)
             manager.checkin(
-                event=events, semantic_change=semantic_change, ignore_conflicts=ignore_conflicts
+                event=events,
+                semantic_change=semantic_change,
+                ignore_conflicts=ignore_conflicts,
+                will_publish_soon=will_publish_soon,
             )

--- a/core/src/zeit/cms/checkout/interfaces.py
+++ b/core/src/zeit/cms/checkout/interfaces.py
@@ -15,7 +15,7 @@ class ICheckoutManager(zope.interface.Interface):
         'True if the object can be checked out, False otherwise.'
     )
 
-    def checkout(event=True, temporary=False):
+    def checkout(event=True, temporary=False, publishing=False):
         """Checkout the managed object.
 
         returns the checked out object.
@@ -25,6 +25,7 @@ class ICheckoutManager(zope.interface.Interface):
         - If temporary is True the object will be added to a temporary
           workingcopy.
 
+        -  ``publishing``: True if this checkout happens during publishing.
         """
 
 
@@ -38,7 +39,13 @@ class ICheckinManager(zope.interface.Interface):
         """
     )
 
-    def checkin(event=True, semantic_change=None, ignore_conflicts=False):
+    def checkin(
+        event=True,
+        semantic_change=None,
+        ignore_conflicts=False,
+        publishing=False,
+        will_publish_soon=False,
+    ):
         """Check in the managed object and return the checked-in object.
 
         Checking in effectively removes the object from the working copy.
@@ -54,6 +61,14 @@ class ICheckinManager(zope.interface.Interface):
         - If ``ignore_conflicts`` is True, no conflict detection will take
           place.
 
+        -  ``publishing``: True if this checkin happens during publishing.
+
+        Event handlers can use this to prevent infinite loops (since another
+        checkout/checkin cycle happens during publishing to update XML
+        references etc.).
+
+        - ``will_publish_soon``: Flag to indicate a workflow where publish
+        will soon follow the checkin. (XXX kludgy workaround for concurrency issues)
         """
 
     def delete():

--- a/core/src/zeit/newsimport/news.py
+++ b/core/src/zeit/newsimport/news.py
@@ -342,7 +342,9 @@ class ImageEntry(Entry):
         self.apply_to_cms()
 
     def apply_to_cms(self):
-        with zeit.cms.checkout.helper.checked_out(self.article_context) as co:
+        with zeit.cms.checkout.helper.checked_out(
+            self.article_context, will_publish_soon=True
+        ) as co:
             news = zeit.newsimport.news.Image(self.entry, co)
             image = news.do_import()
             if image is not None:

--- a/core/src/zeit/newsimport/news.py
+++ b/core/src/zeit/newsimport/news.py
@@ -246,7 +246,7 @@ class ArticleEntry(Entry):
 
     def apply_to_cms(self, article):
         image = self.add_main_image(article)
-        with zeit.cms.checkout.helper.checked_out(article) as co:
+        with zeit.cms.checkout.helper.checked_out(article, will_publish_soon=True) as co:
             co.supertitle = self.supertitle
             co.title = self.entry['headline']
             co.channels = (('News', None),)

--- a/core/src/zeit/newsimport/tests/test_news.py
+++ b/core/src/zeit/newsimport/tests/test_news.py
@@ -523,7 +523,7 @@ class DPATOTMSTest(zeit.newsimport.testing.FunctionalTestCase):
         zeit.newsimport.news.process_task(entry)
         transaction.commit()
         zeit.workflow.testing.run_tasks()
-        content = tms.index.call_args_list[-1][0][0]
+        content = ICMSContent('http://xml.zeit.de/news/2021-12/15/beispielmeldung-ueberschrift')
         self.assertTrue(isinstance(content, zeit.content.article.article.Article))
         self.assertTrue(IPublishInfo(content).published)
         self.assertEqual(['one', 'two'], [x.label for x in content.keywords])

--- a/core/src/zeit/retresco/testhelper.py
+++ b/core/src/zeit/retresco/testhelper.py
@@ -36,6 +36,8 @@ class TMSMockLayer(plone.testing.Layer):
         self['tms'] = mock.Mock()
         self['tms'].get_topicpage_documents.return_value = zeit.cms.interfaces.Result()
         self['tms'].get_related_documents.return_value = zeit.cms.interfaces.Result()
+        self['tms'].generate_keyword_list.return_value = []
+        self['tms'].extract_keywords.return_value = []
         self['tms'].get_article_data.return_value = {}
         zope.interface.alsoProvides(self['tms'], zeit.retresco.interfaces.ITMS)
         zope.component.getSiteManager().registerUtility(self['tms'])


### PR DESCRIPTION
Auf den Verdacht hin, dass wir hier ein ähnliches Cache-Overwrite-Problem mit einem concurrent TMS-Job haben, wie wir mit #769 bei Publish umpflastert haben.