### PR TITLE
FIX: publish script not working when info.date_last_published is None

### DIFF
--- a/core/docs/changelog/FIX_publish-script-not-working.change
+++ b/core/docs/changelog/FIX_publish-script-not-working.change
@@ -1,0 +1,1 @@
+FIX: publish script not working when info.date_last_published is None

--- a/core/src/zeit/cms/workflow/cli.py
+++ b/core/src/zeit/cms/workflow/cli.py
@@ -109,7 +109,11 @@ def publish():
             log.info('Skipping %s, not published and no --force-unpublished', id)
             continue
         semantic = zeit.cms.content.interfaces.ISemanticChange(content)
-        if semantic.last_semantic_change > info.date_last_published and not options.force_changed:
+        if (
+            info.date_last_published is not None
+            and semantic.last_semantic_change > info.date_last_published
+            and not options.force_changed
+        ):
             log.info('Skipping %s, has semantic change and no --force-changed', id)
             continue
 

--- a/core/src/zeit/cms/workflow/cli.py
+++ b/core/src/zeit/cms/workflow/cli.py
@@ -111,6 +111,7 @@ def publish():
         semantic = zeit.cms.content.interfaces.ISemanticChange(content)
         if (
             info.date_last_published is not None
+            and semantic.last_semantic_change is not None
             and semantic.last_semantic_change > info.date_last_published
             and not options.force_changed
         ):


### PR DESCRIPTION
Der Publish-Script hat nicht funktioniert, da `info.date_last_published` `None` sein kann.