### PR TITLE
WCM-574: remove toggle add_content_permissions and use new content permissions for embeds

### DIFF
--- a/core/docs/changelog/WCM-574.change
+++ b/core/docs/changelog/WCM-574.change
@@ -1,0 +1,1 @@
+WCM-574: remove toggle add_content_permissions and use new content permissions for embeds

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -1,5 +1,4 @@
 <features>
-  <add_content_permissions>true</add_content_permissions>
   <content_caching>true</content_caching>
   <dpa_import_delete_image>true</dpa_import_delete_image>
   <reference_index>true</reference_index>

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -1,4 +1,5 @@
 <features>
+  <add_content_permissions>true</add_content_permissions>
   <content_caching>true</content_caching>
   <dpa_import_delete_image>true</dpa_import_delete_image>
   <reference_index>true</reference_index>

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -681,8 +681,6 @@ class AddableCMSContentTypeSource(CMSContentTypeSource):
 
         if value.queryTaggedValue('zeit.cms.addform') == zeit.cms.type.SKIP_ADD:
             return False
-        if not FEATURE_TOGGLES.find('add_content_permissions'):
-            return True
         permission = value.queryTaggedValue('zeit.cms.addpermission')
         if not permission:  # most content types need no special permission
             return True

--- a/core/src/zeit/cms/content/sources.py
+++ b/core/src/zeit/cms/content/sources.py
@@ -679,7 +679,14 @@ class AddableCMSContentTypeSource(CMSContentTypeSource):
     def filterValue(self, context, value):
         import zeit.cms.type  # break circular import
 
-        return value.queryTaggedValue('zeit.cms.addform') != zeit.cms.type.SKIP_ADD
+        if value.queryTaggedValue('zeit.cms.addform') == zeit.cms.type.SKIP_ADD:
+            return False
+        if not FEATURE_TOGGLES.find('add_content_permissions'):
+            return True
+        permission = value.queryTaggedValue('zeit.cms.addpermission')
+        if not permission:  # most content types need no special permission
+            return True
+        return zope.security.management.getInteraction().checkPermission(permission, context)
 
 
 class PrintRessortSource(XMLSource):

--- a/core/src/zeit/cms/ftesting-securitypolicy.zcml
+++ b/core/src/zeit/cms/ftesting-securitypolicy.zcml
@@ -178,6 +178,14 @@
     />
   <grant
     principal="zope.producer"
+    permission="zeit.content.text.AddEmbed"
+    />
+  <grant
+    principal="zope.producer"
+    permission="zeit.content.text.EditEmbed"
+    />
+  <grant
+    principal="zope.producer"
     permission="zeit.MaterializeContent"
     />
   <grant

--- a/core/src/zeit/cms/permissions.zcml
+++ b/core/src/zeit/cms/permissions.zcml
@@ -182,6 +182,16 @@
     />
 
   <permission
+    id="zeit.content.text.AddEmbed"
+    title="Add Embed objects"
+    />
+
+  <permission
+    id="zeit.content.text.EditEmbed"
+    title="Edit Embed objects"
+    />
+
+  <permission
    id="zeit.MaterializeContent"
    title="Materialize dynamic folder content"
    />

--- a/core/src/zeit/content/text/browser/configure.zcml
+++ b/core/src/zeit/content/text/browser/configure.zcml
@@ -129,22 +129,12 @@
     permission="zope.Public"
     />
 
-
-  <!-- XXX Fold back together once the feature toggle `add_content_permissions`
-       is fully in production -->
   <browser:page
     for="zeit.cms.repository.interfaces.IFolder"
     name="zeit.content.text.embed.Add"
-    permission="zeit.AddContent"
+    permission="zeit.content.text.AddEmbed"
     class=".embed.Add"
-    />
-  <browser:menuItem
-    for="zeit.cms.repository.interfaces.IFolder"
-    layer="zope.publisher.interfaces.browser.IDefaultBrowserLayer"
-    menu="zeit-add-menu"
-    title="Embed"
-    action="zeit.content.text.embed.Add"
-    item_class=".embed.AddMenuItem"
+    menu="zeit-add-menu" title="Embed"
     />
 
   <browser:viewlet

--- a/core/src/zeit/content/text/browser/configure.zcml
+++ b/core/src/zeit/content/text/browser/configure.zcml
@@ -129,21 +129,32 @@
     permission="zope.Public"
     />
 
+
+  <!-- XXX Fold back together once the feature toggle `add_content_permissions`
+       is fully in production -->
   <browser:page
     for="zeit.cms.repository.interfaces.IFolder"
     name="zeit.content.text.embed.Add"
     permission="zeit.AddContent"
     class=".embed.Add"
-    menu="zeit-add-menu" title="Embed"
+    />
+  <browser:menuItem
+    for="zeit.cms.repository.interfaces.IFolder"
+    layer="zope.publisher.interfaces.browser.IDefaultBrowserLayer"
+    menu="zeit-add-menu"
+    title="Embed"
+    action="zeit.content.text.embed.Add"
+    item_class=".embed.AddMenuItem"
     />
 
-  <browser:page
+  <browser:viewlet
+    name="Checkout"
     for="zeit.content.text.interfaces.IEmbed"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="edit.html"
-    class=".embed.Edit"
-    permission="zeit.EditContent"
-    menu="zeit-context-views" title="Edit"
+    class=".embed.CheckoutMenuItem"
+    manager="zeit.cms.browser.interfaces.IContextActions"
+    permission="zeit.Checkout"
+    icon="/@@/zeit.cms/icons/checkout.png"
     />
 
   <browser:page

--- a/core/src/zeit/content/text/browser/embed.py
+++ b/core/src/zeit/content/text/browser/embed.py
@@ -1,7 +1,6 @@
 import zope.browsermenu.menu
 import zope.formlib.form
 
-from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cmp.interfaces
 import zeit.cms.browser.form
@@ -21,36 +20,12 @@ class Add(FormBase, zeit.cms.browser.form.AddForm):
     factory = zeit.content.text.embed.Embed
 
 
-class AddMenuItem(zope.browsermenu.menu.BrowserMenuItem):
-    # zope.browsermenu wants to set the permission from the outside (as
-    # declared in zcml), but we want to set it ourselves (according to the
-    # toggle), so we allow setting it exactly once.
-    _permission = None
-
-    def __init__(self, context, request):
-        if FEATURE_TOGGLES.find('add_content_permissions'):
-            self._permission = 'zeit.content.text.AddEmbed'
-        else:
-            self._permission = 'zeit.AddContent'
-        return super().__init__(context, request)
-
-    @property
-    def permission(self):
-        return self._permission
-
-    @permission.setter
-    def permission(self, value):
-        if not self._permission:
-            self._permission = value
-
-
 class CheckoutMenuItem(zeit.cms.checkout.browser.manager.CheckoutMenuItem):
     def is_visible(self):
-        if FEATURE_TOGGLES.find('add_content_permissions'):
-            if not self.request.interaction.checkPermission(
-                'zeit.content.text.EditEmbed', self.context
-            ):
-                return False
+        if not self.request.interaction.checkPermission(
+            'zeit.content.text.EditEmbed', self.context
+        ):
+            return False
         return super().is_visible()
 
 

--- a/core/src/zeit/content/text/browser/embed.py
+++ b/core/src/zeit/content/text/browser/embed.py
@@ -1,6 +1,7 @@
 import zope.browsermenu.menu
 import zope.formlib.form
 
+from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.i18n import MessageFactory as _
 import zeit.cmp.interfaces
 import zeit.cms.browser.form
@@ -18,6 +19,39 @@ class FormBase:
 class Add(FormBase, zeit.cms.browser.form.AddForm):
     title = _('Add embed')
     factory = zeit.content.text.embed.Embed
+
+
+class AddMenuItem(zope.browsermenu.menu.BrowserMenuItem):
+    # zope.browsermenu wants to set the permission from the outside (as
+    # declared in zcml), but we want to set it ourselves (according to the
+    # toggle), so we allow setting it exactly once.
+    _permission = None
+
+    def __init__(self, context, request):
+        if FEATURE_TOGGLES.find('add_content_permissions'):
+            self._permission = 'zeit.content.text.AddEmbed'
+        else:
+            self._permission = 'zeit.AddContent'
+        return super().__init__(context, request)
+
+    @property
+    def permission(self):
+        return self._permission
+
+    @permission.setter
+    def permission(self, value):
+        if not self._permission:
+            self._permission = value
+
+
+class CheckoutMenuItem(zeit.cms.checkout.browser.manager.CheckoutMenuItem):
+    def is_visible(self):
+        if FEATURE_TOGGLES.find('add_content_permissions'):
+            if not self.request.interaction.checkPermission(
+                'zeit.content.text.EditEmbed', self.context
+            ):
+                return False
+        return super().is_visible()
 
 
 class Edit(FormBase, zeit.cms.browser.form.EditForm):

--- a/core/src/zeit/content/text/browser/tests/test_embed.py
+++ b/core/src/zeit/content/text/browser/tests/test_embed.py
@@ -1,3 +1,5 @@
+from zope.testbrowser.browser import LinkNotFoundError
+
 import zeit.cms.testing
 import zeit.content.text.embed
 import zeit.content.text.testing
@@ -25,12 +27,38 @@ class EmbedBrowserTest(zeit.content.text.testing.BrowserTestCase):
         b.getLink('Checkin').click()
         self.assertEllipsis('...<pre>changed</pre>...', b.contents)
 
+    def test_special_permission_is_required_to_add_embed_via_addcentral(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/@@addcentral')
+        self.assertIn('Embed', b.getControl('Type').displayOptions)
+
+        b = zeit.cms.testing.Browser(self.layer['wsgi_app'])
+        b.login('user', 'userpw')
+        b.open('http://localhost/++skin++vivi/@@addcentral')
+        self.assertNotIn('Embed', b.getControl('Type').displayOptions)
+
+    def test_special_permission_is_required_to_edit_embed(self):
+        embed = zeit.content.text.embed.Embed()
+        embed.text = ''
+        self.repository['embed'] = embed
+        b = self.browser
+        b.open('http://localhost/++skin++vivi/repository/embed')
+        with self.assertNothingRaised():
+            b.getLink('Checkout')
+
+        b = zeit.cms.testing.Browser(self.layer['wsgi_app'])
+        b.login('user', 'userpw')
+        b.open('http://localhost/++skin++vivi/repository/embed')
+        with self.assertRaises(LinkNotFoundError):
+            b.getLink('Checkout')
+
     def test_edit_cmp_fields(self):
         embed = zeit.content.text.embed.Embed()
         embed.text = ''
         self.repository['embed'] = embed
         b = self.browser
-        b.open('http://localhost/++skin++vivi/repository/embed/@@checkout')
+        b.open('http://localhost/++skin++vivi/repository/embed')
+        b.getLink('Checkout').click()
         b.getLink('Edit embed parameters').click()
         b.getControl('Contains thirdparty code').displayValue = ['yes']
         b.getControl('Add Vendors').click()

--- a/core/src/zeit/content/text/embed.py
+++ b/core/src/zeit/content/text/embed.py
@@ -76,3 +76,4 @@ class EmbedType(zeit.content.text.text.TextType):
     title = _('Embed')
     factory = Embed
     addform = 'zeit.content.text.embed.Add'
+    addpermission = 'zeit.content.text.AddEmbed'

--- a/core/src/zeit/securitypolicy/security.zcml
+++ b/core/src/zeit/securitypolicy/security.zcml
@@ -203,6 +203,14 @@
     role="zeit.Producer"
     permission="zeit.content.author.Delete"
     />
+  <grant
+    role="zeit.Producer"
+    permission="zeit.content.text.AddEmbed"
+    />
+  <grant
+    role="zeit.Producer"
+    permission="zeit.content.text.EditEmbed"
+    />
 
   <grant
     role="zeit.Producer"


### PR DESCRIPTION
Die Rechteanforderung für embeds ist erwünscht

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()