### PR TITLE
WCM-599: Replace delete by retract for images in newsimport

### DIFF
--- a/core/docs/changelog/newsimport_images.change
+++ b/core/docs/changelog/newsimport_images.change
@@ -1,0 +1,1 @@
+WCM-599: Retract news images instead of deleting them.

--- a/core/src/zeit/cms/content/feature-toggle.xml
+++ b/core/src/zeit/cms/content/feature-toggle.xml
@@ -1,6 +1,5 @@
 <features>
   <content_caching>true</content_caching>
-  <dpa_import_delete_image>true</dpa_import_delete_image>
   <reference_index>true</reference_index>
   <tms_enrich_on_checkin>true</tms_enrich_on_checkin>
   <normalize_quotes>false</normalize_quotes>

--- a/core/src/zeit/newsimport/news.py
+++ b/core/src/zeit/newsimport/news.py
@@ -290,15 +290,13 @@ class ArticleEntry(Entry):
         if not article:
             return None
         IPublish(article).retract(background=False)
-        if zeit.cms.content.sources.FEATURE_TOGGLES.find('dpa_import_delete_image'):
-            if article.main_image is not None:
-                Image(self.entry, article).delete()
+        if article.main_image:
+            Image(self.entry, article).retract()
         return article
 
     def update(self, article):
-        if zeit.cms.content.sources.FEATURE_TOGGLES.find('dpa_import_delete_image'):
-            if article.main_image.target and not self.entry.get('associations', None):
-                Image(self.entry, article).delete()
+        if article.main_image and not self.entry.get('associations'):
+            Image(self.entry, article).retract()
         if not self.has_changes(article):
             return None
         log.info('Update %s', article)
@@ -351,11 +349,10 @@ class ImageEntry(Entry):
                 co.main_image = co.main_image.create(image)
 
     def retract(self):
-        if not self.content:
+        image = self.content
+        if not image:
             return
-        if zeit.cms.content.sources.FEATURE_TOGGLES.find('dpa_import_delete_image'):
-            if self.article_context.main_image is not None:
-                Image(self.entry, self.article_context).delete()
+        IPublish(image).retract(background=False)
 
 
 class Image(Entry):
@@ -438,13 +435,14 @@ class Image(Entry):
         log.info('Update %s for article %s', image_group, self.entry['urn'])
         return self.construct_image_group(image_group)
 
+    def retract(self):
+        image_group = self.article.main_image.target
+        IPublish(image_group).retract(background=False)
+        return image_group
+
     def delete(self):
         try:
-            image_group = zeit.cms.interfaces.ICMSContent(self.article.main_image.target)
-            # NOTE: this line has no effect when testing against
-            # IPublishInfo(image_group).published. But we decide to keep
-            # it here:
-            IPublish(image_group).retract(background=False)
+            image_group = self.retract()
             del self.article.__parent__[image_group.__name__]
             log.info(
                 'Retracted and deleted article image %s for article %s',


### PR DESCRIPTION
Bilder können implizit zurückgezogen werden, indem ein Artikel Update ohne `main_image` Entry kommt, oder explizit indem ein reines Image Update kommt. Siehe [Kommentar](https://zeit-online.atlassian.net/browse/ZO-540?focusedCommentId=78012)

Der Code für Delete war in Production nicht aktiv, denn der Toggle wurde nie umgeschmissen. Trotzdem sollten Bilder von der dpa nicht einfach veröffentlicht bleiben, selbst wenn der entsprechende Artikel, der sie referenziert, zurückgezogen wurde. Das lässt befürchten, dass es in prod lauter veröffentlichte dpa-Bilder gibt, die nirgendwo mehr hingehören.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![zzz](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExamg2cnIxeXowMXJsaWVxZ2FuZ3ZxZmZrZHh3amllM2trOGU5dDN3NiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FZ47lYjLfQuqc/giphy.gif)