### PR TITLE
WCM-559: add tts references to articles even if the checksum does not match

### DIFF
--- a/core/docs/changelog/WCM-559.change
+++ b/core/docs/changelog/WCM-559.change
@@ -1,0 +1,1 @@
+WCM-559: add tts references to articles even if the checksum does not match

--- a/core/src/zeit/speech/errors.py
+++ b/core/src/zeit/speech/errors.py
@@ -1,5 +1,0 @@
-class AudioReferenceError(Exception):
-    """
-    An exception raised if the article was updated after publish, to avoid publishing it with
-    unreviewed changes
-    """


### PR DESCRIPTION
Die Audioreferenz sollten wir so früh wie möglich an den Artikel hängen. Checkin Checkout Fehler werden einfach nochmal probiert durch Celery. Konsequenz ist natürlich das Artikel mit unveröffentlichten Änderungen händisch durch die Redakteure veröffentlicht werden müssen.

Aber so umgehen wir das ein Audio gar nicht mehr am Artikel ist, weil die erfolgten Änderungen keinen Einfluss auf die TTS Neuerstellung hatten.

Sollte dann auch bei [WCM-186](https://zeit-online.atlassian.net/browse/WCM-186) helfen

### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXVqY2YyNzhhdG5mbXkxbW1qM3d4NGE0b3dteXlocWczdDNndnc4MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3TCBh8i6H3bz2/giphy.gif)

[WCM-186]: https://zeit-online.atlassian.net/browse/WCM-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ