### PR TITLE
WCM-533: hide legend for access entitlements if field is not available

### DIFF
--- a/core/docs/changelog/WCM-533.change
+++ b/core/docs/changelog/WCM-533.change
@@ -1,0 +1,1 @@
+WCM-533: hide legend for access entitlements if field is not available

--- a/core/src/zeit/content/article/edit/browser/form.py
+++ b/core/src/zeit/content/article/edit/browser/form.py
@@ -416,14 +416,16 @@ class OptionsInteractive(zeit.edit.browser.form.InlineForm):
 
 
 class OptionsAccessControl(zeit.edit.browser.form.InlineForm):
-    legend = _('Access control')
+    _legend = _('Access control')
     prefix = 'options-access-control'
 
     @property
     def form_fields(self):
         form_fields = []
+        self.legend = ''
         if self.context.access == 'abo':
             form_fields = FormFields(ICommonMetadata).select('accepted_entitlements')
+            self.legend = self._legend
         return form_fields
 
 


### PR DESCRIPTION
### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [ ] ~~Tests~~
- [ ] ~~Translations~~

### gif
![]()