### PR TITLE
WCM-489: add functionality to ignore uniqueid on publish

### DIFF
--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -252,7 +252,7 @@ class IgnoreMixin:
         'genre': 'genres',
         'template': 'templates',
         'ressort': 'ressorts',
-        'uniqueId': 'uniqueid',
+        'uniqueId': 'uniqueids',
     }
 
     @property

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -252,6 +252,7 @@ class IgnoreMixin:
         'genre': 'genres',
         'template': 'templates',
         'ressort': 'ressorts',
+        'uniqueId': 'uniqueid',
     }
 
     @property
@@ -438,7 +439,7 @@ class CenterPageIndexNow(grok.Adapter, IndexNowMixin):
 
 
 class DataScienceMixin(PropertiesMixin):
-    def publish_json(self):
+    def _json(self):
         if self.properties is None:
             return None
         return {
@@ -446,12 +447,15 @@ class DataScienceMixin(PropertiesMixin):
             'body': lxml.etree.tostring(self.context.xml, encoding='unicode'),
         }
 
+    def publish_json(self):
+        return self._json()
+
     def retract_json(self):
         return {}
 
 
 @grok.implementer(zeit.workflow.interfaces.IPublisherData)
-class ArticleDataScience(grok.Adapter, DataScienceMixin):
+class ArticleDataScience(grok.Adapter, IgnoreMixin, DataScienceMixin):
     grok.context(zeit.content.article.interfaces.IArticle)
     grok.name('datascience')
 

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -583,7 +583,9 @@ class DatasciencePayloadTest(zeit.workflow.testing.FunctionalTestCase):
     def test_datascience_payload_ignore_article(self):
         article = zeit.content.article.testing.create_article()
         zeit.cms.config.set(
-            'zeit.workflow', 'datascience-ignore-uniqueid', 'http://xml.zeit.de/article'
+            'zeit.workflow',
+            'datascience-ignore-uniqueids',
+            'http://xml.zeit.de/article http://xml.zeit.de/article-two',
         )
         p = article.body.create_item('p')
         p.text = 'foo'

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -580,6 +580,17 @@ class DatasciencePayloadTest(zeit.workflow.testing.FunctionalTestCase):
         payload = zeit.workflow.testing.publish_json(article, 'datascience')
         self.assertEqual(payload['body'], lxml.etree.tostring(article.xml, encoding=str))
 
+    def test_datascience_payload_ignore_article(self):
+        article = zeit.content.article.testing.create_article()
+        zeit.cms.config.set(
+            'zeit.workflow', 'datascience-ignore-uniqueid', 'http://xml.zeit.de/article'
+        )
+        p = article.body.create_item('p')
+        p.text = 'foo'
+        article = self.repository['article'] = article
+        payload = zeit.workflow.testing.publish_json(article, 'datascience')
+        self.assertEqual(payload, None)
+
     def test_datascience_payload_centerpage(self):
         cp = self.repository['testcontent']
         zope.interface.alsoProvides(cp, zeit.content.cp.interfaces.ICenterPage)


### PR DESCRIPTION
# Beschreibung
Ticket: https://zeit-online.atlassian.net/browse/WCM-498
Es können einzelne `uniqueId`s durch das `IgnoreMixin` ignoriert werden. Außerdem wurden die DataScience-Tests angepasst
## Nutzung
Um einzelne ID's zu ignorieren, muss die Umgebungsvariable gesetzt werden. Beispiel:
`zeit.workflow.datascience-ignore-uniqueids = 'http://xml.zeit.de/article http://xml.zeit.de/article-two'`
ID's sind dabei durch Leerzeichen zu trennen.
# Gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNG5tOW40N21qZzV1eHRrYXp5djVrNTA3MHVpemxxZnd5aTRycnpsdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mvHIlrcDnX76XbMKO9/giphy-downsized.gif)