### PR TITLE
WCM-195: display link next to tag title

### DIFF
--- a/core/docs/changelog/WCM-195.change
+++ b/core/docs/changelog/WCM-195.change
@@ -1,0 +1,1 @@
+WCM-195: display link next to tag title

--- a/core/src/zeit/cms/tagging/browser/resources/tag.js
+++ b/core/src/zeit/cms/tagging/browser/resources/tag.js
@@ -163,6 +163,8 @@ zeit.cms.tagging.Widget = gocept.Class.extend({
                     var el = $('a', this);
                     el.addClass('with-topic-page');
                     el.attr('href', href);
+                    const url = new URL(href);
+                    el.text(`${el.text()} | ${url.pathname}`);
                 }
             });
         });

--- a/core/src/zeit/cms/tagging/browser/tests/test_widget.py
+++ b/core/src/zeit/cms/tagging/browser/tests/test_widget.py
@@ -179,6 +179,8 @@ class InputWidgetUI(zeit.cms.testing.SeleniumTestCase, zeit.cms.tagging.testing.
         sel.assertXpathCount('//li/a[@href="http://localhost/live-prefix/thema/t1"]', 1)
         self.assertEqual(
             'with-topic-page',
-            sel.selenium.find_element_by_link_text('t1 (Test)').get_attribute('class'),
+            sel.selenium.find_element_by_link_text(
+                't1 (Test) | /live-prefix/thema/t1'
+            ).get_attribute('class'),
         )
         sel.assertXpathCount('//li/a[@href="http://localhost/live-prefix/thema/t2"]', 0)

--- a/core/src/zeit/cms/tagging/browser/widget.py
+++ b/core/src/zeit/cms/tagging/browser/widget.py
@@ -146,5 +146,6 @@ class DisplayWidget(grok.MultiAdapter, zope.formlib.itemswidgets.ItemsWidgetBase
         for item in self._getFormValue():
             link = self.tags_with_topicpages.get(item.uniqueId)
             css_class = self.tag_highling_css_class if link else ''
-            items.append(Tag(item.title, link, css_class))
+            title = f'{item.title} | {urllib.parse.urlparse(link).path}' if link else item.title
+            items.append(Tag(title, link, css_class))
         return items


### PR DESCRIPTION
### Beschreibung
Ticket: [WCM-195](https://zeit-online.atlassian.net/browse/WCM-195)

Der Link wird jetzt hinter dem jeweiligen Tag angezeigt, wenn es einen gibt:
![image](https://github.com/user-attachments/assets/a5df99b1-178a-4dc4-8e57-57a70d8dfb23)

### Checklist

- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWhkeHM2ajVpdmxtMTJhZzRxeDZxODhyemFzdTNqcTF4ZXUwM2Y2OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TXvbvcWwnkUjS/giphy-downsized.gif)

[WCM-195]: https://zeit-online.atlassian.net/browse/WCM-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ