### PR TITLE
WCM-195: truncate keywords using ellipsis and show them on hover in full height

### DIFF
--- a/core/docs/changelog/WCM-195.change
+++ b/core/docs/changelog/WCM-195.change
@@ -1,0 +1,1 @@
+WCM-195: truncate keywords using ellipsis and show them on hover in full height

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -648,7 +648,6 @@ a.button.configure_search:hover {
 .ingredients-widget ol li,
 .keyword-widget ol li {
     clear: both;
-    cursor: default;
     padding-top: 4px;
     padding-bottom: 4px;
     border-bottom: 1px solid #dddddd;

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -657,6 +657,12 @@ a.button.configure_search:hover {
     cursor: move;
 }
 
+.keyword-widget ol li {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 0.5em;
+}
+
 .recipe-categories-widget .icon,
 .ingredients-widget .icon,
 .keyword-widget .icon {
@@ -664,7 +670,6 @@ a.button.configure_search:hover {
     float: right;
     width: 18px;
     height: 18px;
-    margin-left: 1em;
     padding-top: 0px;
     line-height: 18px;
     background: url("./icons/icons_sprites.png") no-repeat scroll transparent;
@@ -689,6 +694,24 @@ a.button.configure_search:hover {
 
 .keyword-widget .toggle-pin:hover, .keyword-widget .pinned {
     background-position: 1px -2665px;
+}
+
+.keyword-widget a {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    flex-grow: 1;
+}
+
+.keyword-widget ol li:hover {
+    height: unset;
+}
+
+.keyword-widget ol li:hover a {
+    white-space: wrap;
+    background: white;
+    overflow: visible;
 }
 
 .keyword-widget a.with-topic-page{


### PR DESCRIPTION
[Sonja fiel auf](https://zeit-online.atlassian.net/browse/WCM-195?focusedCommentId=107004), dass Keyword-Texte durch die neuen Links viele Zeilenumbrüche haben und somit mit anderen Keywords überlappen. Das sieht merkwürdig aus. Zum Beispiel beim Keyword `Justizminsterium der Vereinigten Staaten (Organisation)` (damit kann man auf jeden Fall auch gut testen) und ähnlich langen Keywords gibt es Probleme.

In diesem PR wurden alle Keywords durch `text-overflow: ellipsis;` ausgepunktet. Beim Hovern werden sie komplett angezeigt.

Alter Stand:
![image](https://github.com/user-attachments/assets/5ffb1991-46f0-438c-af65-b97e1620f103)

Neuer Stand (mit Keyword auf Justizministerium der USA):
![image](https://github.com/user-attachments/assets/20b3dd82-77c9-4570-83b0-7f9c223b42c7)
