### PR TITLE
MAINT: Bit nicer article editor styling

### DIFF
--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -169,9 +169,12 @@
   margin: 0 10px;
   padding: 0px 10px;
   position: relative;
-  border-bottom: 1px solid #DDD;
   height: 26px;
   line-height: 26px;
+}
+
+.folded .edit-bar {
+  border-bottom: 1px solid #DDD;
 }
 
 .location-workingcopy.type-article #editor-forms div.editable-area > div.edit-bar {
@@ -378,8 +381,8 @@
 
 .type-article .editable-area .block-inner{
   padding-top: 0px !important;
-  border-radius: 5px 5px 0px 0px;
   border: 1px solid #DDD;
+  border-top-width: 0;
 }
 
 .type-article #article-editor-header .block-inner .object-details,

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -1861,10 +1861,22 @@
     clear: none;
 }
 
-.type-article #form-article-content-main-image > .fieldname-main_image_variant_name {
-  position: relative;
-  top: -2.1em;
-  left: 19em;
+.type-article #form-article-content-main-image {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1em;
+}
+.type-article #form-article-content-main-image > * {
+    flex: 1;
+}
+
+#form-article-content-main-image .fieldname-main_image_variant_name .value {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    line-height: 22px;
 }
 
 .type-article #form-article-content-main-image .label {
@@ -1872,8 +1884,6 @@
 }
 .type-article #form-article-content-main-image > .fieldname-main_image_variant_name div.value:before {
     content: "Seitenverhältnis";
-    float: left;
-    padding-right: 0.5em;
     color: #4c4c4c;
     font-weight: bold;
     text-transform: uppercase;

--- a/core/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/core/src/zeit/content/article/edit/browser/resources/editor.css
@@ -1830,8 +1830,8 @@
 /* breaking news */
 
 #breaking-retract {
-    margin-top: 10px;
-    margin-bottom: 5px;
+    padding-top: 10px;
+    padding-bottom: 5px;
 }
 
 #breaking-retract-banner {

--- a/core/src/zeit/edit/browser/resources/editor.css
+++ b/core/src/zeit/edit/browser/resources/editor.css
@@ -611,10 +611,13 @@ textarea {
 
 /* Fieldsets */
 
+#editor-forms > .inline-form {
+  margin: 1em 10px;
+}
+
 #cp-content fieldset {
   background: none 0;
   border: medium none;
-  margin: 0 0 0 10px;
   padding: 0;
 }
 


### PR DESCRIPTION
Ein paar Kleinigkeiten:
- `border-radius` an den Artikel-Formular-Blöcken wird umgedreht (oben keiner, unten schon)
- Zusätzlicher Rahmen zwischen Formular-Kopf und Inhalt kommt weg
- Das Eilmeldung-Zurückziehen-Element reißt keine Lücken mehr in sein Formular
- Das Memo-Eingabefeld oben wird ein bisschen gleichmäßiger positioniert
- Das Seitenverhältnis-Eingabefeld an Bildern bricht responsiv um in schmaleren Fenstern