### PR TITLE
MAINT: Remove legacy liveblog and add small enhancements to tickaroo liveblog

### DIFF
--- a/core/docs/changelog/legacy_liveblog.maint
+++ b/core/docs/changelog/legacy_liveblog.maint
@@ -1,0 +1,1 @@
+MAINT: Remove legacy liveblog

--- a/core/docs/changelog/liveblog_lsc.fix
+++ b/core/docs/changelog/liveblog_lsc.fix
@@ -1,0 +1,1 @@
+FIX: Set LSC for tickaroo liveblogs

--- a/core/docs/changelog/liveblog_use_default.fix
+++ b/core/docs/changelog/liveblog_use_default.fix
@@ -1,0 +1,1 @@
+FIX: Set use_default for collapse_preceding_content in liveblogs

--- a/core/src/zeit/content/article/edit/browser/configure.zcml
+++ b/core/src/zeit/content/article/edit/browser/configure.zcml
@@ -501,27 +501,6 @@
     permission="zope.View"
     />
 
-  <!-- liveblog -->
-
-  <browser:page
-    for="zeit.content.article.edit.interfaces.ILiveblog"
-    layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="edit-liveblog"
-    class=".edit.EditLiveblog"
-    permission="zope.View"
-    />
-
-  <browser:viewlet
-    for="zeit.content.article.edit.interfaces.ILiveblog"
-    layer="zeit.cms.browser.interfaces.ICMSLayer"
-    view="zope.interface.Interface"
-    manager="zeit.edit.interfaces.IContentViewletManager"
-    name="edit-liveblog"
-    class="zeit.edit.browser.form.FormLoader"
-    permission="zope.View"
-    weight="10"
-    />
-
   <!-- tickaroo liveblog -->
 
   <browser:page

--- a/core/src/zeit/content/article/edit/browser/edit.py
+++ b/core/src/zeit/content/article/edit/browser/edit.py
@@ -394,17 +394,6 @@ class EditPuzzleForm(zeit.edit.browser.form.InlineForm):
         return 'puzzleform.{0}'.format(self.context.__name__)
 
 
-class EditLiveblog(zeit.edit.browser.form.InlineForm):
-    legend = None
-    form_fields = zope.formlib.form.FormFields(zeit.content.article.edit.interfaces.ILiveblog).omit(
-        *list(zeit.edit.interfaces.IBlock)
-    )
-
-    @property
-    def prefix(self):
-        return 'liveblog.{0}'.format(self.context.__name__)
-
-
 class EditTickarooLiveblog(zeit.edit.browser.form.InlineForm):
     legend = None
     form_fields = zope.formlib.form.FormFields(

--- a/core/src/zeit/content/article/edit/browser/tests/test_edit.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_edit.py
@@ -683,9 +683,6 @@ class TestFolding(zeit.content.article.edit.browser.testing.EditorTestCase):
     def test_video_should_be_foldable(self):
         self.assert_foldable('video')
 
-    def test_liveblog_should_be_foldable(self):
-        self.assert_foldable('liveblog')
-
     def test_division_should_be_foldable(self):
         self.assert_foldable('division')
 

--- a/core/src/zeit/content/article/edit/browser/tests/test_liveblog.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_liveblog.py
@@ -1,10 +1,7 @@
-import pytest
-
 import zeit.content.article.edit.browser.testing
 
 
 class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
-    @pytest.mark.xfail()
     def test_inline_form_saves_default_values(self):
         self.get_article(with_block='tickaroo_liveblog')
         b = self.browser

--- a/core/src/zeit/content/article/edit/browser/tests/test_liveblog.py
+++ b/core/src/zeit/content/article/edit/browser/tests/test_liveblog.py
@@ -1,31 +1,31 @@
+import pytest
+
 import zeit.content.article.edit.browser.testing
 
 
 class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
+    @pytest.mark.xfail()
     def test_inline_form_saves_default_values(self):
-        self.get_article(with_block='liveblog')
+        self.get_article(with_block='tickaroo_liveblog')
         b = self.browser
-        b.open('editable-body/blockname/@@edit-liveblog?show_form=1')
+        b.open('editable-body/blockname/@@edit-liveblog-tickaroo?show_form=1')
         b.getControl('Liveblog id').value = 'bloggy'
         b.getControl('Apply').click()
         b.reload()
         self.assertEqual('bloggy', b.getControl('Liveblog id').value)
-        self.assertEqual(['3'], b.getControl('Liveblog version').displayValue)
         self.assertTrue(b.getControl('Collapse preceding content').selected)
         self.assertEqual(['(nothing selected)'], b.getControl(('Timeline Content')).displayValue)
 
-    def test_inline_form_saves_values_including_version(self):
-        self.get_article(with_block='liveblog')
+    def test_inline_form_saves_values(self):
+        self.get_article(with_block='tickaroo_liveblog')
         b = self.browser
-        b.open('editable-body/blockname/@@edit-liveblog?show_form=1')
+        b.open('editable-body/blockname/@@edit-liveblog-tickaroo?show_form=1')
         b.getControl('Liveblog id').value = 'bloggy'
-        b.getControl('Liveblog version').displayValue = ['3']
         b.getControl(('Timeline Content')).displayValue = ['Highlighted events']
         b.getControl('Collapse preceding content').selected = False
         b.getControl('Apply').click()
         b.reload()
         self.assertEqual('bloggy', b.getControl('Liveblog id').value)
-        self.assertEqual(['3'], b.getControl('Liveblog version').displayValue)
         self.assertFalse(b.getControl('Collapse preceding content').selected)
         self.assertEqual(['Highlighted events'], b.getControl(('Timeline Content')).displayValue)
 
@@ -34,9 +34,11 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
     def test_liveblog_form_is_loaded(self):
         s = self.selenium
         self.add_article()
-        self.create_block('liveblog')
-        s.assertElementPresent('css=.block.type-liveblog .inline-form ' '.field.fieldname-blog_id')
-        s.assertElementPresent('css=.block.type-liveblog .inline-form ' '.field.fieldname-version')
+        self.create_block('tickaroo_liveblog')
         s.assertElementPresent(
-            'css=.block.type-liveblog .inline-form ' '.field.fieldname-collapse_preceding_content'
+            'css=.block.type-tickaroo_liveblog .inline-form .field.fieldname-liveblog_id'
+        )
+        s.assertElementPresent(
+            'css=.block.type-tickaroo_liveblog .inline-form '
+            '.field.fieldname-collapse_preceding_content'
         )

--- a/core/src/zeit/content/article/edit/configure.zcml
+++ b/core/src/zeit/content/article/edit/configure.zcml
@@ -266,17 +266,6 @@
       />
   </class>
 
-  <class class=".liveblog.Liveblog">
-    <require
-      interface=".interfaces.ILiveblog"
-      permission="zope.View"
-      />
-    <require
-      set_schema=".interfaces.ILiveblog"
-      permission="zeit.EditContent"
-      />
-  </class>
-
   <adapter
     factory=".liveblog.TickarooLiveblogFactory"
     provides=".interfaces.ITickarooLiveblog"

--- a/core/src/zeit/content/article/edit/interfaces.py
+++ b/core/src/zeit/content/article/edit/interfaces.py
@@ -399,33 +399,6 @@ class ICitationComment(IBlock):
     )
 
 
-class LiveblogVersions(zeit.cms.content.sources.SimpleFixedValueSource):
-    values = {'3': '3'}
-
-
-class ILiveblog(IBlock):
-    blog_id = zope.schema.TextLine(title=_('Liveblog id'))
-
-    version = zope.schema.Choice(
-        title=_('Liveblog version'), source=LiveblogVersions(), default='3', required=False
-    )
-
-    collapse_preceding_content = zope.schema.Bool(
-        title=_('Collapse preceding content'), default=True, required=False
-    )
-
-    # BBB
-    show_timeline_in_teaser = zope.schema.Bool(
-        title=_('Show liveblog in teaser'), default=True, required=False
-    )
-
-    timeline_template = zope.schema.Choice(
-        title=_('Timeline Content'),
-        required=False,
-        source=zeit.content.modules.interfaces.TimelineTemplateSource(),
-    )
-
-
 class ITickarooLiveblog(IBlock, zeit.content.modules.interfaces.ITickarooLiveblog):
     pass
 

--- a/core/src/zeit/content/article/edit/liveblog.py
+++ b/core/src/zeit/content/article/edit/liveblog.py
@@ -78,7 +78,7 @@ def set_lsc_default_for_liveblogs(context, event):
     if event.publishing:
         return
     for block in context.body.values():
-        if zeit.content.article.edit.interfaces.ILiveblog.providedBy(block):
+        if zeit.content.article.edit.interfaces.ITickarooLiveblog.providedBy(block):
             zeit.cms.content.interfaces.ISemanticChange(context).has_semantic_change = True
             break
 

--- a/core/src/zeit/content/article/edit/liveblog.py
+++ b/core/src/zeit/content/article/edit/liveblog.py
@@ -1,5 +1,4 @@
 import grokcore.component as grok
-import pendulum
 import zope.component
 
 from zeit.cms.i18n import MessageFactory as _
@@ -8,67 +7,6 @@ import zeit.content.article.edit.block
 import zeit.content.article.edit.interfaces
 import zeit.content.modules.interfaces
 import zeit.content.modules.liveblog
-
-
-@grok.implementer(zeit.content.article.edit.interfaces.ILiveblog)
-class Liveblog(zeit.content.article.edit.block.Block):
-    type = 'liveblog'
-
-    blog_id = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'blogID', zeit.content.article.edit.interfaces.ILiveblog['blog_id']
-    )
-    _version = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'version', zeit.content.article.edit.interfaces.ILiveblog['version'], use_default=True
-    )
-    collapse_preceding_content = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.',
-        'collapse-preceding-content',
-        zeit.content.article.edit.interfaces.ILiveblog['collapse_preceding_content'],
-        use_default=True,
-    )
-
-    # BBB
-    show_timeline_in_teaser = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.',
-        'show-timeline-in-teaser',
-        zeit.content.article.edit.interfaces.ILiveblog['show_timeline_in_teaser'],
-        use_default=True,
-    )
-
-    timeline_template = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.',
-        'timeline_template',
-        zeit.content.article.edit.interfaces.ILiveblog['timeline_template'],
-    )
-
-    LIVEBLOG_VERSION_UPDATE = pendulum.datetime(2018, 8, 6)
-
-    @property
-    def version(self):
-        # XXX Cannot use the version property, since we had `use_default=True`
-        # since 3.38.5, and thus we have old articles without a version in XML
-        # that mean "2", and newer with the same XML that mean "3". Sigh.
-        version = self.xml.get('version')
-        if version:
-            return version
-
-        article = zeit.content.article.interfaces.IArticle(self)
-        dfr = zeit.cms.workflow.interfaces.IPublishInfo(article).date_first_released
-        if not dfr:
-            return '3'
-        elif dfr > self.LIVEBLOG_VERSION_UPDATE:
-            return '3'
-        else:
-            return '2'
-
-    @version.setter
-    def version(self, value):
-        self._version = value
-
-
-class Factory(zeit.content.article.edit.block.BlockFactory):
-    produces = Liveblog
-    title = _('Liveblog')
 
 
 @grok.subscribe(

--- a/core/src/zeit/content/article/edit/tests/test_liveblog.py
+++ b/core/src/zeit/content/article/edit/tests/test_liveblog.py
@@ -1,8 +1,9 @@
 import lxml.builder
+import pytest
 
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.interfaces import ISemanticChange
-from zeit.content.article.edit.liveblog import Liveblog
+from zeit.content.article.edit.liveblog import TickarooLiveblog
 import zeit.content.article.testing
 import zeit.edit.interfaces
 
@@ -12,10 +13,11 @@ class LSCDefaultTest(zeit.content.article.testing.FunctionalTestCase):
         super().setUp()
         self.repository['article'] = zeit.content.article.testing.create_article()
         with checked_out(self.repository['article']) as co:
-            co.body.create_item('liveblog')
+            co.body.create_item('tickaroo_liveblog')
             self.assertFalse(ISemanticChange(co).has_semantic_change)
 
-    def test_article_with_liveblog_old_has_lsc_on_checkout(self):
+    @pytest.mark.xfail()
+    def test_article_with_liveblog_has_lsc_on_checkout(self):
         with checked_out(self.repository['article']) as co:
             self.assertTrue(ISemanticChange(co).has_semantic_change)
 
@@ -29,24 +31,19 @@ class LSCDefaultTest(zeit.content.article.testing.FunctionalTestCase):
 
 class LiveblogTest(zeit.content.article.testing.FunctionalTestCase):
     def get_liveblog(self):
-        liveblog = Liveblog(None, lxml.builder.E.liveblog())
+        liveblog = TickarooLiveblog(None, lxml.builder.E.liveblog())
         return liveblog
 
     def test_liveblog_should_be_set(self):
         liveblog = self.get_liveblog()
-        liveblog.blog_id = '290'
+        liveblog.liveblog_id = '290'
         liveblog.invalid_attribute = 'this should not be set'
         liveblog.timeline_template = 'highlighted'
-        self.assertEqual('290', liveblog.xml.xpath('.')[0].get('blogID'))
+        self.assertEqual('290', liveblog.xml.xpath('.')[0].get('liveblog_id'))
         self.assertEqual('highlighted', liveblog.xml.xpath('.')[0].get('timeline_template'))
         self.assertIsNone(liveblog.xml.xpath('.')[0].get('invalid_attribute'))
 
-    def test_liveblog_version_should_be_set(self):
-        liveblog = self.get_liveblog()
-        self.assertIsNone(liveblog.xml.xpath('.')[0].get('version'))
-        liveblog.version = '3'
-        self.assertEqual('3', liveblog.xml.xpath('.')[0].get('version'))
-
+    @pytest.mark.xfail()
     def test_liveblog_collapse_preceding_content_should_be_set(self):
         liveblog = self.get_liveblog()
         self.assertTrue(liveblog.collapse_preceding_content)

--- a/core/src/zeit/content/article/edit/tests/test_liveblog.py
+++ b/core/src/zeit/content/article/edit/tests/test_liveblog.py
@@ -43,7 +43,6 @@ class LiveblogTest(zeit.content.article.testing.FunctionalTestCase):
         self.assertEqual('highlighted', liveblog.xml.xpath('.')[0].get('timeline_template'))
         self.assertIsNone(liveblog.xml.xpath('.')[0].get('invalid_attribute'))
 
-    @pytest.mark.xfail()
     def test_liveblog_collapse_preceding_content_should_be_set(self):
         liveblog = self.get_liveblog()
         self.assertTrue(liveblog.collapse_preceding_content)

--- a/core/src/zeit/content/article/edit/tests/test_liveblog.py
+++ b/core/src/zeit/content/article/edit/tests/test_liveblog.py
@@ -1,5 +1,4 @@
 import lxml.builder
-import pytest
 
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.interfaces import ISemanticChange
@@ -16,7 +15,6 @@ class LSCDefaultTest(zeit.content.article.testing.FunctionalTestCase):
             co.body.create_item('tickaroo_liveblog')
             self.assertFalse(ISemanticChange(co).has_semantic_change)
 
-    @pytest.mark.xfail()
     def test_article_with_liveblog_has_lsc_on_checkout(self):
         with checked_out(self.repository['article']) as co:
             self.assertTrue(ISemanticChange(co).has_semantic_change)

--- a/core/src/zeit/content/modules/interfaces.py
+++ b/core/src/zeit/content/modules/interfaces.py
@@ -255,6 +255,7 @@ class LiveblogSource(zeit.cms.content.sources.SearchableXMLSource):
 
     attribute = 'id'
     default_filename = 'liveblog.xml'
+    config_url = 'liveblog-source'
     product_configuration = 'zeit.content.modules'
 
 

--- a/core/src/zeit/content/modules/liveblog.py
+++ b/core/src/zeit/content/modules/liveblog.py
@@ -10,7 +10,10 @@ class TickarooLiveblog(zeit.edit.block.Element):
     liveblog_id = ObjectPathAttributeProperty('.', 'liveblog_id', ITickarooLiveblog['liveblog_id'])
 
     collapse_preceding_content = ObjectPathAttributeProperty(
-        '.', 'collapse_preceding_content', ITickarooLiveblog['collapse_preceding_content']
+        '.',
+        'collapse_preceding_content',
+        ITickarooLiveblog['collapse_preceding_content'],
+        use_default=True,
     )
 
     collapse_highlighted_events = ObjectPathAttributeProperty(

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -15,6 +15,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         'jobticker-source': f'file://{HERE}/tests/fixtures/jobticker.xml',
         'subject-source': f'file://{HERE}/tests/fixtures/mail-subjects.xml',
         'embed-provider-source': f'file://{HERE}/tests/fixtures/embed-providers.xml',
+        'liveblog-source': f'file://{HERE}/tests/fixtures/liveblog-source.xml',
         'newsletter-source': f'file://{HERE}/tests/fixtures/newsletter.xml',
         'recipe-metadata-source': f'file://{HERE}/tests/fixtures/recipe-metadata.xml',
     },

--- a/core/src/zeit/content/modules/tests/fixtures/liveblog-source.xml
+++ b/core/src/zeit/content/modules/tests/fixtures/liveblog-source.xml
@@ -1,0 +1,19 @@
+<liveblog xmlns:cp="http://namespaces.zeit.de/CMS/cp" xmlns:py="http://codespeak.net/lxml/objectify/pytype" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!--
+  Hinweis:
+  Bei dieser Konfiguration, wo sie `<select>`-Formelemente definiert,
+  ist darauf zu achten, dass die gewuenschte Default-Option an erster Stelle stehen muss!
+  -->
+  <status>
+    <status id="active">Liveblog aktiv</status>
+    <status id="inactive">Liveblog inaktiv</status>
+  </status>
+  <themes>
+    <theme id="default">Default</theme>
+    <theme id="solo">Solo</theme>
+  </themes>
+  <intersection_types>
+    <intersection_type id="date">Datum</intersection_type>
+    <intersection_type id="chapter">Kapitel</intersection_type>
+  </intersection_types>
+</liveblog>


### PR DESCRIPTION
Zuerst klaue ich die Tests vom alten Liveblog, die Tickaroo-Liveblogs hatten nämlich noch gar keine Tests. Dabei fällt mir auf, dass zwei Kleinigkeiten fehlen, also versuche ich sie zu fixen. Und am Ende kommt das alte Liveblog weg. 

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![giphy-29](https://github.com/user-attachments/assets/a35d83a9-c76e-4b68-b9f4-417f55114266)
