### PR TITLE
WCM-195: fix keyword widget design

### DIFF
--- a/core/docs/changelog/WCM-195.change
+++ b/core/docs/changelog/WCM-195.change
@@ -1,0 +1,1 @@
+WCM-195: fix keyword widget design

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -653,12 +653,13 @@ a.button.configure_search:hover {
     border-bottom: 1px solid #dddddd;
     width: 100%;
     height: 18px;
+    min-height: 18px;
     cursor: move;
 }
 
 .keyword-widget ol li {
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: row;
     gap: 0.5em;
 }
 


### PR DESCRIPTION
Problem wurde gefixt:
![grafik](https://github.com/user-attachments/assets/a0f6b48d-3049-4c92-91e1-e0779cd1f772)

