### PR TITLE
WCM-605: Report server/client duration as seconds instead of ms

### DIFF
--- a/core/docs/changelog/WCM-605.change
+++ b/core/docs/changelog/WCM-605.change
@@ -1,0 +1,1 @@
+WCM-605: Report server/client duration as seconds instead of ms

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -194,7 +194,7 @@ deploy = [
     "opentelemetry-exporter-otlp",
     "opentelemetry-exporter-prometheus",
     "opentelemetry-sdk",
-    "opentelemetry-sdk-extension-prometheus-multiprocess",
+    "opentelemetry-sdk-extension-prometheus-multiprocess >= 1.2.0.dev0",
     "pastescript",
     "psycopg2-binary",
     "python-json-logger",

--- a/core/src/zeit/cms/application.zcml
+++ b/core/src/zeit/cms/application.zcml
@@ -23,5 +23,6 @@
     <include package="zope.generations" file="subscriber.zcml" />
     <include package="grokcore.component" file="meta.zcml" />
     <grok:grok package="zeit.cms.zope" />
+    <grok:grok package="zeit.cms.celery" />
 
 </configure>

--- a/core/src/zeit/cms/tests/test_application.py
+++ b/core/src/zeit/cms/tests/test_application.py
@@ -29,7 +29,7 @@ class Prometheus(zeit.cms.testing.ZeitCmsBrowserTestCase):
             b.open('http://localhost/metrics')
             assert b.headers.get('status') == '200 OK'
             metrics = [x.name for x in prometheus(b.contents)]
-            assert 'http_server_duration_milliseconds' in metrics
+            assert 'http_server_request_duration_seconds' in metrics
 
         for _ in range(2):  # Hopefully cover bootstrapping cases
             with self.assertRaises(urllib.error.HTTPError) as info:

--- a/core/src/zeit/cms/tests/test_tracing.py
+++ b/core/src/zeit/cms/tests/test_tracing.py
@@ -37,4 +37,5 @@ class TracingTest(zeit.cms.testing.ZeitCmsBrowserTestCase):
     def test_healthcheck_is_not_recorded(self):
         with zeit.cms.tracing.captrace() as trace:
             self.browser.open('/@@health-check')
-            self.assertEqual(0, len(trace.spans))
+            for span in trace.spans:
+                self.assertNotIn('health-check', span.name)


### PR DESCRIPTION
zusammen mit https://github.com/ZeitOnline/vivi-deployment/pull/1247 mergen