### PR TITLE
ZO-788: Miscellaneous code cleanup

### DIFF
--- a/core/src/zeit/cms/content/metadata.py
+++ b/core/src/zeit/cms/content/metadata.py
@@ -50,6 +50,22 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
         use_default=True,
     )
 
+    for prop, ns, name in [
+        ('print_ressort', 'print', 'ressort'),
+        ('commentSectionEnable', 'document', 'show_commentthread'),
+        ('commentsAllowed', 'document', 'comments'),
+        ('commentsPremoderate', 'document', 'comments_premoderate'),
+        ('product', 'workflow', 'product-id'),
+        ('ir_mediasync_id', 'interred', 'mediasync_id'),
+        ('ir_article_id', 'interred', 'article_id'),
+    ]:
+        locals()[prop] = zeit.cms.content.dav.DAVProperty(
+            ICommonMetadata[prop], f'http://namespaces.zeit.de/CMS/{ns}', name
+        )
+
+    keywords = zeit.cms.tagging.tag.Tags()
+    recipe_categories = zeit.wochenmarkt.categories.RecipeCategories()
+
     authorships = zeit.cms.content.reference.ReferenceProperty(
         '.head.author', xml_reference_name='author'
     )
@@ -57,54 +73,15 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
         '.head.agency', xml_reference_name='related'
     )
 
-    keywords = zeit.cms.tagging.tag.Tags()
-
-    recipe_categories = zeit.wochenmarkt.categories.RecipeCategories()
-
-    title = zeit.cms.content.property.ObjectPathProperty('.body.title', ICommonMetadata['title'])
-    subtitle = zeit.cms.content.property.ObjectPathProperty(
-        '.body.subtitle', ICommonMetadata['subtitle']
-    )
-    supertitle = zeit.cms.content.property.ObjectPathProperty(
-        '.body.supertitle', ICommonMetadata['supertitle']
-    )
-
-    teaserTitle = zeit.cms.content.property.ObjectPathProperty(
-        '.teaser.title', ICommonMetadata['teaserTitle']
-    )
-    teaserText = zeit.cms.content.property.ObjectPathProperty(
-        '.teaser.text', ICommonMetadata['teaserText']
-    )
-    teaserSupertitle = zeit.cms.content.property.ObjectPathProperty(
-        '.teaser.supertitle', ICommonMetadata['teaserSupertitle']
-    )
-
-    print_ressort = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['print_ressort'], zeit.cms.interfaces.PRINT_NAMESPACE, 'ressort'
-    )
-
-    commentsPremoderate = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['commentsPremoderate'], DOCUMENT_SCHEMA_NS, 'comments_premoderate'
-    )
-
-    commentsAllowed = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['commentsAllowed'], DOCUMENT_SCHEMA_NS, 'comments'
-    )
-
-    commentSectionEnable = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['commentSectionEnable'], DOCUMENT_SCHEMA_NS, 'show_commentthread'
-    )
-
-    product = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['product'], 'http://namespaces.zeit.de/CMS/workflow', 'product-id'
-    )
-
-    ir_mediasync_id = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['ir_mediasync_id'], zeit.cms.interfaces.IR_NAMESPACE, 'mediasync_id'
-    )
-    ir_article_id = zeit.cms.content.dav.DAVProperty(
-        ICommonMetadata['ir_article_id'], zeit.cms.interfaces.IR_NAMESPACE, 'article_id'
-    )
+    for prop, path in [
+        ('title', '.body.title'),
+        ('subtitle', '.body.subtitle'),
+        ('supertitle', '.body.supertitle'),
+        ('teaserTitle', '.teaser.title'),
+        ('teaserText', '.teaser.text'),
+        ('teaserSupertitle', '.teaser.supertitle'),
+    ]:
+        locals()[prop] = zeit.cms.content.property.ObjectPathProperty(path, ICommonMetadata[prop])
 
     _color_scheme = zeit.cms.content.dav.DAVProperty(
         ICommonMetadata['color_scheme'], DOCUMENT_SCHEMA_NS, 'color_scheme'

--- a/core/src/zeit/connector/testcontent/2006/49/Welt-in-Zahlen
+++ b/core/src/zeit/connector/testcontent/2006/49/Welt-in-Zahlen
@@ -4,7 +4,6 @@
 <!-- CMS/document -->
     <attribute name="text-length" ns="http://namespaces.zeit.de/CMS/document">1036</attribute>
 <!-- CMS/workflow -->
-    <attribute name="supertitle" ns="http://namespaces.zeit.de/CMS/document">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>allg_wiss</code>

--- a/core/src/zeit/connector/testcontent/2007/01/momente-des-reisens
+++ b/core/src/zeit/connector/testcontent/2007/01/momente-des-reisens
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/2007/test
+++ b/core/src/zeit/connector/testcontent/2007/test
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/4schanzentournee-abgesang
+++ b/core/src/zeit/connector/testcontent/online/2007/01/4schanzentournee-abgesang
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Arbeitsmarktzahlen
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Arbeitsmarktzahlen
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/EU-Beitritt-rumaenien-bulgarien
+++ b/core/src/zeit/connector/testcontent/online/2007/01/EU-Beitritt-rumaenien-bulgarien
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Flugsicherheit
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Flugsicherheit
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Ford-Beerdigung
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Ford-Beerdigung
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Gesundheitsreform-Die
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Gesundheitsreform-Die
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Guantanamo
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Guantanamo
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Lateinamerika-Jahresrueckblick
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Lateinamerika-Jahresrueckblick
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Mehrwertsteuer-Jobs
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Mehrwertsteuer-Jobs
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Merkel-Ansprache
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Merkel-Ansprache
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Querdax
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Querdax
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Querdax-05-01-07
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Querdax-05-01-07
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/RUND-Olympique-Marseille
+++ b/core/src/zeit/connector/testcontent/online/2007/01/RUND-Olympique-Marseille
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Rosia-Montana
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Rosia-Montana
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Saarland
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Saarland
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Anschlaege
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Anschlaege
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Kommentar
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Kommentar
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Prozess
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Prozess
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Verbuendete
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Saddam-Verbuendete
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Schrempp
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Schrempp
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Somalia
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Somalia
@@ -6,7 +6,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Somalia-Grill
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Somalia-Grill
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Somalia-Treffen
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Somalia-Treffen
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Spitzenkandidat-Stoiber
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Spitzenkandidat-Stoiber
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/Stern-Umfrage-Bayern
+++ b/core/src/zeit/connector/testcontent/online/2007/01/Stern-Umfrage-Bayern
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-mehrwertsteuer
+++ b/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-mehrwertsteuer
@@ -4,7 +4,6 @@
 <!-- CMS/document -->
     <attribute name="text-length" ns="http://namespaces.zeit.de/CMS/document">1036</attribute>
 <!-- CMS/workflow -->
-    <attribute name="supertitle" ns="http://namespaces.zeit.de/CMS/document">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>allg_wiss</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-mehrwertsteuer-erhoehung
+++ b/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-mehrwertsteuer-erhoehung
@@ -4,7 +4,6 @@
 <!-- CMS/document -->
     <attribute name="text-length" ns="http://namespaces.zeit.de/CMS/document">1036</attribute>
 <!-- CMS/workflow -->
-    <attribute name="supertitle" ns="http://namespaces.zeit.de/CMS/document">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>allg_wiss</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-spiegel
+++ b/core/src/zeit/connector/testcontent/online/2007/01/bildergalerie-spiegel
@@ -4,7 +4,6 @@
 <!-- CMS/document -->
     <attribute name="text-length" ns="http://namespaces.zeit.de/CMS/document">1036</attribute>
 <!-- CMS/workflow -->
-    <attribute name="supertitle" ns="http://namespaces.zeit.de/CMS/document">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>allg_wiss</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/elterngeld-schlieben
+++ b/core/src/zeit/connector/testcontent/online/2007/01/elterngeld-schlieben
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/eta-zapatero
+++ b/core/src/zeit/connector/testcontent/online/2007/01/eta-zapatero
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/eta-zapatero-kommentar
+++ b/core/src/zeit/connector/testcontent/online/2007/01/eta-zapatero-kommentar
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/eu-praesidentschaft-gustavsson
+++ b/core/src/zeit/connector/testcontent/online/2007/01/eu-praesidentschaft-gustavsson
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/finanztest-online-banking
+++ b/core/src/zeit/connector/testcontent/online/2007/01/finanztest-online-banking
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/finanztest-online-banking-tipps
+++ b/core/src/zeit/connector/testcontent/online/2007/01/finanztest-online-banking-tipps
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/flugzeugabsturz-indonesien
+++ b/core/src/zeit/connector/testcontent/online/2007/01/flugzeugabsturz-indonesien
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/internationale-presseschau-japan-irak-klima
+++ b/core/src/zeit/connector/testcontent/online/2007/01/internationale-presseschau-japan-irak-klima
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/lebenslagen-01
+++ b/core/src/zeit/connector/testcontent/online/2007/01/lebenslagen-01
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/mein-leben-mit-musik-52
+++ b/core/src/zeit/connector/testcontent/online/2007/01/mein-leben-mit-musik-52
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/rauchen-verbessert-die-welt
+++ b/core/src/zeit/connector/testcontent/online/2007/01/rauchen-verbessert-die-welt
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/rund-Sprachforschung
+++ b/core/src/zeit/connector/testcontent/online/2007/01/rund-Sprachforschung
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/saddam-exekution
+++ b/core/src/zeit/connector/testcontent/online/2007/01/saddam-exekution
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/saddam-grab
+++ b/core/src/zeit/connector/testcontent/online/2007/01/saddam-grab
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/saddam-hinrichtung-2006
+++ b/core/src/zeit/connector/testcontent/online/2007/01/saddam-hinrichtung-2006
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/saddam-luttwak
+++ b/core/src/zeit/connector/testcontent/online/2007/01/saddam-luttwak
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/saddam-nachruf
+++ b/core/src/zeit/connector/testcontent/online/2007/01/saddam-nachruf
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/somalia-donnerstag
+++ b/core/src/zeit/connector/testcontent/online/2007/01/somalia-donnerstag
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/somalia-kismayu
+++ b/core/src/zeit/connector/testcontent/online/2007/01/somalia-kismayu
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/studiVZ
+++ b/core/src/zeit/connector/testcontent/online/2007/01/studiVZ
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/teddy-kollek-nachruf
+++ b/core/src/zeit/connector/testcontent/online/2007/01/teddy-kollek-nachruf
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/terror-abschuss-schaeuble
+++ b/core/src/zeit/connector/testcontent/online/2007/01/terror-abschuss-schaeuble
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/thailand-anschlaege
+++ b/core/src/zeit/connector/testcontent/online/2007/01/thailand-anschlaege
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/connector/testcontent/online/2007/01/weissrussland-russland-gas
+++ b/core/src/zeit/connector/testcontent/online/2007/01/weissrussland-russland-gas
@@ -5,7 +5,6 @@
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="text-length">1036</attribute>
     <attribute ns="http://namespaces.zeit.de/CMS/document" name="pagelabel">Online</attribute>
 <!-- CMS/workflow -->
-    <attribute ns="http://namespaces.zeit.de/CMS/document" name="supertitle">Spitzmarke hierher</attribute>
     <countings>
       <counting type="agof">
         <code>online</code>

--- a/core/src/zeit/content/article/edit/tests/test_body.py
+++ b/core/src/zeit/content/article/edit/tests/test_body.py
@@ -210,6 +210,8 @@ class CheckinTest(zeit.content.article.testing.FunctionalTestCase):
         co = manager.checkout()
         zeit.cms.content.field.apply_default_values(co, zeit.content.article.interfaces.IArticle)
         img = zeit.content.image.interfaces.IImages(co)
+        image = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')
+        img.image = image
         img.fill_color = '#xxxxxx'
         manager = ICheckinManager(co)
         self.assertFalse(manager.canCheckin)

--- a/core/src/zeit/content/author/author.py
+++ b/core/src/zeit/content/author/author.py
@@ -23,6 +23,7 @@ import zeit.cms.repository.interfaces
 import zeit.cms.type
 import zeit.cms.workflow.dependency
 import zeit.content.author.interfaces
+import zeit.content.image.imagereference
 import zeit.find.interfaces
 
 
@@ -131,12 +132,8 @@ class AuthorType(zeit.cms.type.XMLContentTypeDeclaration):
 
 @zope.component.adapter(zeit.content.author.interfaces.IAuthor)
 @zope.interface.implementer(zeit.content.image.interfaces.IImages)
-class AuthorImages(zeit.cms.related.related.RelatedBase):
-    image = zeit.cms.content.reference.SingleResource('.image_group', 'image')
-
-    fill_color = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.image_group', 'fill_color', zeit.content.image.interfaces.IImages['fill_color']
-    )
+class AuthorImages(zeit.content.image.imagereference.ImagesAdapter):
+    _image = zeit.cms.content.reference.SingleReferenceProperty('.image_group', 'image')
 
 
 @grok.subscribe(

--- a/core/src/zeit/content/image/imagereference.py
+++ b/core/src/zeit/content/image/imagereference.py
@@ -14,17 +14,39 @@ import zeit.content.image.interfaces
 @zope.component.adapter(zeit.cms.content.interfaces.IXMLContent)
 @zope.interface.implementer(zeit.content.image.interfaces.IImages)
 class ImagesAdapter(zeit.cms.related.related.RelatedBase):
-    image = zeit.cms.content.reference.SingleResource('.head.image', 'image')
+    _image = zeit.cms.content.reference.SingleReferenceProperty('.head.image', 'image')
 
-    fill_color = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.head.image', 'fill_color', zeit.content.image.interfaces.IImages['fill_color']
-    )
+    @property
+    def image(self):
+        ref = self._image
+        return ref.target if ref else None
+
+    @image.setter
+    def image(self, value):
+        if value is not None:
+            value = self._image.create(value)
+        self._image = value
+
+    @property
+    def fill_color(self):
+        ref = self._image
+        return ref.fill_color if ref else None
+
+    @fill_color.setter
+    def fill_color(self, value):
+        ref = self._image
+        if ref:
+            ref.fill_color = value
 
 
 @grok.implementer(zeit.content.image.interfaces.IImageReference)
 class ImageReference(zeit.cms.content.reference.Reference):
     grok.name('image')
     grok.provides(zeit.cms.content.interfaces.IReference)
+
+    fill_color = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'fill_color', zeit.content.image.interfaces.IImages['fill_color']
+    )
 
     # XXX The *_original XML paths must be kept in sync with
     # z.c.image.metadata.XMLReferenceUpdater

--- a/core/src/zeit/content/image/interfaces.py
+++ b/core/src/zeit/content/image/interfaces.py
@@ -377,6 +377,22 @@ class IThumbnails(zope.container.interfaces.IReadContainer):
     source_image = zope.schema.Choice(source=bareImageSource)
 
 
+class IMasterImage(zope.interface.Interface):
+    """Marks an image in an image group as master for the other images."""
+
+
+class IImageReference(zeit.cms.content.interfaces.IReference, IImageMetadata):
+    """Reference to an image, allows overriding metadata locally for the
+    referring content object."""
+
+    fill_color = zope.schema.TextLine(
+        title=_('Alpha channel fill color'),
+        required=False,
+        max_length=6,
+        constraint=zeit.cms.content.interfaces.hex_literal,
+    )
+
+
 class IImages(zope.interface.Interface):
     """An object which references images."""
 
@@ -387,21 +403,9 @@ class IImages(zope.interface.Interface):
         source=imageGroupSource,
     )
 
-    fill_color = zope.schema.TextLine(
-        title=_('Alpha channel fill color'),
-        required=False,
-        max_length=6,
-        constraint=zeit.cms.content.interfaces.hex_literal,
-    )
-
-
-class IMasterImage(zope.interface.Interface):
-    """Marks an image in an image group as master for the other images."""
-
-
-class IImageReference(zeit.cms.content.interfaces.IReference, IImageMetadata):
-    """Reference to an image, allows overriding metadata locally for the
-    referring content object."""
+    # BBB Pass-through to IImageReference. `IImages.images` should maybe
+    # be a ReferenceField instead of a Choice?
+    fill_color = IImageReference['fill_color'].bind(object())
 
 
 class IMDB(zope.interface.Interface):

--- a/core/src/zeit/content/image/tests/test_imagereference.py
+++ b/core/src/zeit/content/image/tests/test_imagereference.py
@@ -69,6 +69,9 @@ class ImageReferenceTest(zeit.content.image.testing.FunctionalTestCase):
         self.assertEqual('', ref.caption)
 
     def test_colorpicker_should_generate_proper_xml(self):
+        image = ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')
         content = self.repository['testcontent']
-        zeit.content.image.interfaces.IImages(content).fill_color = 'F00F00'
+        img = zeit.content.image.interfaces.IImages(content)
+        img.image = image
+        img.fill_color = 'F00F00'
         assert len(content.xml.xpath('//head/image[@fill_color="F00F00"]')) == 1

--- a/core/src/zeit/content/video/video.py
+++ b/core/src/zeit/content/video/video.py
@@ -8,9 +8,9 @@ import zeit.cms.content.interfaces
 import zeit.cms.content.metadata
 import zeit.cms.content.reference
 import zeit.cms.interfaces
-import zeit.cms.related.related
 import zeit.cms.type
 import zeit.cms.workflow.dependency
+import zeit.content.image.imagereference
 import zeit.content.video.interfaces
 import zeit.push.interfaces
 
@@ -138,12 +138,8 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
 
 @zope.component.adapter(zeit.content.video.interfaces.IVideo)
 @zope.interface.implementer(zeit.content.image.interfaces.IImages)
-class VideoImage(zeit.cms.related.related.RelatedBase):
-    image = zeit.cms.content.reference.SingleResource('.body.video_still', 'image')
-
-    fill_color = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.body.video_still', 'fill_color', zeit.content.image.interfaces.IImages['fill_color']
-    )
+class VideoImage(zeit.content.image.imagereference.ImagesAdapter):
+    _image = zeit.cms.content.reference.SingleReferenceProperty('.body.video_still', 'image')
 
 
 @zope.interface.implementer(zeit.content.video.interfaces.IVideoRendition)

--- a/core/src/zeit/retresco/configure.zcml
+++ b/core/src/zeit/retresco/configure.zcml
@@ -34,6 +34,11 @@
       provides=".interfaces.ITMSContent"
       name="video"
       />
+    <utility
+      component=".content.TMSVolume"
+      provides=".interfaces.ITMSContent"
+      name="volume"
+      />
 
     <class class=".tagger.Tagger">
       <require

--- a/core/src/zeit/retresco/content.py
+++ b/core/src/zeit/retresco/content.py
@@ -17,6 +17,7 @@ import zeit.content.gallery.gallery
 import zeit.content.gallery.interfaces
 import zeit.content.link.link
 import zeit.content.video.video
+import zeit.content.volume.volume
 import zeit.retresco.interfaces
 
 
@@ -81,13 +82,6 @@ class Content:
             # See zeit.content.audio.interfaces.IAudioReferences
             head.append(E.audio(href=id))
 
-        if 'covers' in self._tms_payload_head:
-            # See zeit.content.volume.volume.Volume.set_cover
-            covers = E.covers()
-            self.xml.append(covers)
-            for cover in self._tms_payload_head['covers']:
-                covers.append(E.cover(**cover))
-
     def _build_xml_image(self):
         """Teaser images are usually contained in the document head and
         reference an image group.
@@ -143,6 +137,19 @@ class TMSVideo(Content, zeit.content.video.video.Video):
             return
         image.tag = 'video_still'
         self.xml.find('body').append(image)
+
+
+class TMSVolume(Content, zeit.content.volume.volume.Volume):
+    def _build_xml_head(self):
+        super()._build_xml_head()
+        if 'covers' not in self._tms_payload_head:
+            return
+        # See zeit.content.volume.volume.Volume.set_cover
+        E = lxml.objectify.E
+        covers = E.covers()
+        self.xml.append(covers)
+        for cover in self._tms_payload_head['covers']:
+            covers.append(E.cover(**cover))
 
 
 @grok.implementer(zeit.cms.content.interfaces.IKPI)

--- a/core/src/zeit/retresco/tests/test_content.py
+++ b/core/src/zeit/retresco/tests/test_content.py
@@ -163,6 +163,7 @@ class ContentTest(zeit.retresco.testing.FunctionalTestCase):
         content = zeit.retresco.interfaces.ITMSContent(data)
         self.assertIsInstance(content, zeit.content.volume.volume.Volume)
         self.compare(zeit.content.volume.interfaces.IVolume, volume, content, ['xml'])
+        self.assertEqual(self.repository['testcontent'], content.get_cover('portrait', 'ZEI'))
 
     def test_blogpost_is_treated_as_link(self):
         link = zeit.content.link.link.Link()

--- a/core/src/zeit/retresco/tests/test_convert.py
+++ b/core/src/zeit/retresco/tests/test_convert.py
@@ -95,7 +95,6 @@ class ConvertTest(zeit.retresco.testing.FunctionalTestCase):
                         'revision': '11',
                         'serie': '-',
                         'show_commentthread': False,
-                        'supertitle': 'Spitzmarke hierher',
                         'template': 'article',
                         'text-length': 1036,
                         'title': 'R\xfcckkehr der Warlords',


### PR DESCRIPTION
Extrahiert aus https://github.com/ZeitOnline/vivi/compare/ZO-788

Diese Commits haben mit dem eigentlichen Thema (Properties von XML nach DAV verlagern), in dessen Zusammenhang sie mir damals über den Weg liefen, wohl nicht _direkt_ was zu tun, ich finde sie aber generell immernoch sinnvoll.