### PR TITLE
WCM-633: remove key from internal objectlog structure instead of removing from objectlog db

### DIFF
--- a/core/docs/changelog/WCM-633.change
+++ b/core/docs/changelog/WCM-633.change
@@ -1,0 +1,1 @@
+WCM-633: remove key from internal objectlog structure instead of removing from objectlog db

--- a/core/src/zeit/objectlog/objectlog.py
+++ b/core/src/zeit/objectlog/objectlog.py
@@ -79,7 +79,7 @@ class ObjectLog(persistent.Persistent):
                     remove.append(key)
             except ZODB.POSException.POSKeyError:
                 logger.warning('ZODB.POSException.POSKeyError, removing lost key %s', key)
-                remove.append(key)
+                self._object_log.pop(key, None)
         for key in remove:
             del self._object_log[key]
 


### PR DESCRIPTION
…

### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

### gif
![]()