### PR TITLE
WCM-649: Unregister ZAR interfaces, so they are not used again

### DIFF
--- a/core/docs/changelog/WCM-649.change
+++ b/core/docs/changelog/WCM-649.change
@@ -1,0 +1,1 @@
+WCM-649: Unregister ZAR package


### PR DESCRIPTION
### Checklist

- [ ] ~~Documentation~~
- [x] Changelog
- [x] Tests, entfernt, weil das ganze Vertical ohnehin zeitnah rausfliegt und die Interfaces nicht mehr registriert sind
- [ ] ~~Translations~~

### gif
![garbage](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExemZzcWN0b2x5bW01emE5bm13MnhxOTk1N2tyY2NtZ2RnMXJzbTA1YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/hS2Oh3m0CkhFe/giphy.gif)