### PR TITLE
ZO-7097: Do not load zeit.tickaroo by default, only when required for vivi UI

### DIFF
--- a/core/docs/changelog/ZO-7097.change
+++ b/core/docs/changelog/ZO-7097.change
@@ -1,0 +1,1 @@
+ZO-7097: Do not load zeit.tickaroo by default, only when required for vivi UI

--- a/core/src/zeit/content/article/ctesting.zcml
+++ b/core/src/zeit/content/article/ctesting.zcml
@@ -14,8 +14,7 @@
   <include package="zeit.edit" />
   <include package="zeit.edit.browser" />
 
-  <include package="zeit.content.modules" />
-  <include package="zeit.content.modules.browser" />
+  <include package="zeit.content.modules" file="ctesting.zcml" />
 
   <include package="zeit.content.image" />
   <include package="zeit.content.image.browser" />

--- a/core/src/zeit/content/cp/ctesting.zcml
+++ b/core/src/zeit/content/cp/ctesting.zcml
@@ -9,6 +9,6 @@
 
   <include package="zeit.content.image" />
   <include package="zeit.content.image.browser" />
-  <include package="zeit.content.modules" />
+  <include package="zeit.content.modules" file="ctesting.zcml" />
 
 </configure>

--- a/core/src/zeit/content/modules/configure.zcml
+++ b/core/src/zeit/content/modules/configure.zcml
@@ -4,8 +4,6 @@
 
   <grok:grok package="." exclude="browser" />
 
-  <include package="zeit.tickaroo" />
-
   <class class=".jobticker.Feed">
     <require
       attributes="id title teaser landing_url feed_url"

--- a/core/src/zeit/content/modules/configure.zcml
+++ b/core/src/zeit/content/modules/configure.zcml
@@ -4,7 +4,6 @@
 
   <grok:grok package="." exclude="browser" />
 
-  <include package="zeit.cmp" />
   <include package="zeit.tickaroo" />
 
   <class class=".jobticker.Feed">

--- a/core/src/zeit/content/modules/ctesting.zcml
+++ b/core/src/zeit/content/modules/ctesting.zcml
@@ -1,0 +1,14 @@
+<configure
+   xmlns="http://namespaces.zope.org/zope"
+   xmlns:meta="http://namespaces.zope.org/meta"
+   i18n_domain="zope"
+   >
+
+  <include package="zeit.content.modules" />
+  <include package="zeit.content.modules.browser" />
+
+  <include package="zeit.content.text" />
+  <include package="zeit.tickaroo" />
+  <include package="zeit.wochenmarkt" />
+
+</configure>

--- a/core/src/zeit/content/modules/ftesting.zcml
+++ b/core/src/zeit/content/modules/ftesting.zcml
@@ -9,6 +9,7 @@
   <include package="zeit.content.modules" />
   <include package="zeit.content.modules.browser" />
 
+  <include package="zeit.cmp" />
   <include package="zeit.content.text" />
   <include package="zeit.wochenmarkt" />
 

--- a/core/src/zeit/content/modules/ftesting.zcml
+++ b/core/src/zeit/content/modules/ftesting.zcml
@@ -6,11 +6,8 @@
 
   <include package="zeit.cms" file="ftesting.zcml" />
 
-  <include package="zeit.content.modules" />
-  <include package="zeit.content.modules.browser" />
+  <include package="zeit.content.modules" file="ctesting.zcml" />
 
   <include package="zeit.cmp" />
-  <include package="zeit.content.text" />
-  <include package="zeit.wochenmarkt" />
 
 </configure>

--- a/core/src/zeit/content/modules/testing.py
+++ b/core/src/zeit/content/modules/testing.py
@@ -4,7 +4,6 @@ import zeit.cmp.testing
 import zeit.cms.content.add
 import zeit.cms.testing
 import zeit.content.modules
-import zeit.content.text.text
 import zeit.wochenmarkt.ingredients
 import zeit.wochenmarkt.testing
 


### PR DESCRIPTION
### Checklist

- [x] Stattdessen in site.zcml laden: ZeitOnline/vivi-deployment@bc7951a
- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~