### PR TITLE
WCM-749: Wire up celery worker healthcheck

### DIFF
--- a/core/docs/changelog/WCM-749.change
+++ b/core/docs/changelog/WCM-749.change
@@ -1,0 +1,1 @@
+WCM-749: Wire up celery worker healthcheck

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -184,6 +184,7 @@ test = [
 deploy = [
     "alembic",
     "celery-redis-prometheus>=1.5.0.dev0",
+    "celery-worker-healthcheck",
     "flower",
     "fluent-logger",
     "grpcio-status",  # warning instead of required by google-api-core


### PR DESCRIPTION
DEPLOYMENT_BRANCH=WCM-749-celery-healthcheck

Benötigt https://github.com/ZeitOnline/vivi-deployment/pull/1286