### PR TITLE
FIX: Called wrong method for vgwort metrics

### DIFF
--- a/core/docs/changelog/vgwort.fix
+++ b/core/docs/changelog/vgwort.fix
@@ -1,0 +1,1 @@
+Called wrong method for vgwort metrics

--- a/core/src/zeit/retresco/metrics.py
+++ b/core/src/zeit/retresco/metrics.py
@@ -87,7 +87,7 @@ def _collect_vgwort_report():
     connector = zope.component.getUtility(zeit.connector.interfaces.IConnector)
     query = select(ConnectorModel)
     query = query.where(sql(sql_query))
-    metric.labels(environment()).set(connector.search_sql_counts(query))
+    metric.labels(environment()).set(connector.search_sql_count(query))
 
 
 def _collect_vgwort_token_count():


### PR DESCRIPTION
### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

### gif
![]()