### PR TITLE
WCM-789: Continue publish if TMS fails, retry it asynchronously

### DIFF
--- a/core/docs/changelog/WCM-789.change
+++ b/core/docs/changelog/WCM-789.change
@@ -1,0 +1,1 @@
+WCM-789: Continue publish if TMS fails, retry it asynchronously

--- a/core/src/zeit/retresco/update.py
+++ b/core/src/zeit/retresco/update.py
@@ -46,7 +46,10 @@ def index_before_publish(context, event):
     # speaking that "already happened" on checkin, to support the "checkin
     # and publish immediately" use case -- since there publish likely
     # happens *before* the index_async job created by checkin ran.
-    index_on_checkin(context, enrich=True)
+    try:
+        index_on_checkin(context, enrich=True)
+    except zeit.retresco.interfaces.TechnicalError:
+        index_async.apply_async((context.uniqueId,), countdown=5)
 
 
 @grok.subscribe(zeit.cms.interfaces.ICMSContent, zeit.cms.workflow.interfaces.IRetractedEvent)

--- a/core/src/zeit/retresco/update.py
+++ b/core/src/zeit/retresco/update.py
@@ -49,7 +49,12 @@ def index_before_publish(context, event):
     try:
         index_on_checkin(context, enrich=True)
     except zeit.retresco.interfaces.TechnicalError:
-        index_async.apply_async((context.uniqueId,), countdown=5)
+        # Retry (with TMS-publish!) asynchronously. Note that this is only a
+        # "partial publish", and especially the frontend caches are not
+        # invalidated (again), so even if the retry succeeds quickly, it still
+        # takes the normal cache TTL (default 10min) until changes are visible
+        # (e.g. a new article will not show intextlinks in that period).
+        index_async.apply_async((context.uniqueId,), {'publish': True}, countdown=5)
 
 
 @grok.subscribe(zeit.cms.interfaces.ICMSContent, zeit.cms.workflow.interfaces.IRetractedEvent)
@@ -121,24 +126,24 @@ def index_workflow_properties(context, event):
 
 
 @zeit.cms.celery.task(bind=True, queue='search')
-def index_async(self, uniqueId, enrich=True):
+def index_async(self, uniqueId, enrich=True, publish=False):
     context = zeit.cms.interfaces.ICMSContent(uniqueId, None)
     if context is None:
         log.warning('Could not index %s because it does not exist any longer.', uniqueId)
         return
     try:
-        index_on_checkin(context, enrich=enrich)
+        index_on_checkin(context, enrich=enrich, publish=publish)
     except zeit.retresco.interfaces.TechnicalError:
         delay = int(zeit.cms.config.get('zeit.retresco', 'retry-delay-seconds', 60))
         self.retry(countdown=delay)
 
 
-def index_on_checkin(context, enrich=True):
+def index_on_checkin(context, enrich=True, publish=False):
     if not FEATURE_TOGGLES.find('tms_enrich_on_checkin'):
         enrich = False
     meta = zeit.cms.content.interfaces.ICommonMetadata(context, None)
     has_keywords = meta is not None and meta.keywords
-    index(context, enrich=enrich, update_keywords=enrich and not has_keywords)
+    index(context, enrich=enrich, update_keywords=enrich and not has_keywords, publish=publish)
 
 
 # Preserve previously stored fields during re-index.

--- a/core/src/zeit/retresco/update.py
+++ b/core/src/zeit/retresco/update.py
@@ -126,7 +126,8 @@ def index_async(self, uniqueId, enrich=True):
     try:
         index_on_checkin(context, enrich=enrich)
     except zeit.retresco.interfaces.TechnicalError:
-        self.retry()
+        delay = int(zeit.cms.config.get('zeit.retresco', 'retry-delay-seconds', 60))
+        self.retry(countdown=delay)
 
 
 def index_on_checkin(context, enrich=True):
@@ -207,7 +208,8 @@ def unindex_async(self, uuid):
     try:
         conn.delete_id(uuid)
     except zeit.retresco.interfaces.TechnicalError:
-        self.retry()
+        delay = int(zeit.cms.config.get('zeit.retresco', 'retry-delay-seconds', 60))
+        self.retry(countdown=delay)
 
 
 # Mostly relevant for bulk reindex, since zeit.content.quiz is not used anymore


### PR DESCRIPTION
### Checklist

- [x] Documentation: ZeitOnline/vivi-deployment@57207f5
- [x] Changelog
- [ ] Tests: Hat jemand eine Idee? Mir ist nichts Kosten/Nutzen-angemessenes eingefallen. Das mit Celery und allem aufzusetzen, lohnt sich glaube ich nicht, und nur zu prüfen, dass wir irgendwelche Flags irgendwo reinstecken scheint mir nicht relevant genug.
- [x] ~Translations~
