### PR TITLE
WCM-636: Use email instead of displayName for principal

### DIFF
--- a/core/docs/changelog/wcm-636.change
+++ b/core/docs/changelog/wcm-636.change
@@ -1,0 +1,1 @@
+WCM-636: Use email instead of userDisplayName to avoid requesting it from AD every time

--- a/core/src/zeit/authentication/azure.py
+++ b/core/src/zeit/authentication/azure.py
@@ -1,5 +1,4 @@
 import logging
-import urllib.parse
 
 from zope.cachedescriptors.property import Lazy as cachedproperty
 import msal
@@ -66,21 +65,6 @@ class AzureAD:
         if 'error' in token:
             raise RuntimeError(str(token))
         return token['access_token']
-
-    def get_user(self, upn):
-        """Look up user by userPrincipalName, for which ZEIT AD uses the
-        (pseudo-) email address. Returns a dict with keys `displayName` and
-        `userPrincipalName`.
-        """
-        try:
-            return self._request(
-                'GET /users/%s' % urllib.parse.quote(upn),
-                params={'$select': 'displayName,userPrincipalName'},
-            )
-        except requests.exceptions.RequestException as e:
-            if getattr(e.response, 'status_code', 599) != 404:
-                log.warning('AD get_user(%r) failed', upn, exc_info=True)
-            return None
 
     def search_users(self, query):
         """Search for users by substring of their displayName.

--- a/core/src/zeit/authentication/tests/test_azure.py
+++ b/core/src/zeit/authentication/tests/test_azure.py
@@ -75,16 +75,15 @@ class ADIntegrationTest(zeit.authentication.testing.FunctionalTestCase):
         gsm.unregisterUtility(self.ad, zeit.authentication.azure.IActiveDirectory)
         super().tearDown()
 
-    def test_getPrincipal_sends_query_via_microsoft_graph_api(self):
+    def test_getPrincipal_only_responds_for_ids_looking_like_email_address(self):
         auth = zeit.authentication.oidc.AzureADAuthenticator()
-        email = os.environ['ZEIT_AD_TESTUSER']
+        email = 'user@example.com'
         p = auth.principalInfo(email)
         self.assertEqual(p.id, email)
-
-    def test_getPrincipal_returns_none_when_not_found(self):
-        auth = zeit.authentication.oidc.AzureADAuthenticator()
-        p = auth.principalInfo('nonexistent@zeit.de')
-        self.assertEqual(None, p)
+        self.assertEqual(p.login, email)
+        self.assertEqual(p.title, email)
+        self.assertEqual(p.description, email)
+        self.assertEqual(None, auth.principalInfo('zope.manager'))
 
     def test_search_returns_list_of_ids(self):
         auth = zeit.authentication.oidc.AzureADAuthenticator()


### PR DESCRIPTION
Stop all the request to AD to figure out, what the users name is 🛑  

### Checklist

- [x] [Documentation](https://github.com/ZeitOnline/vivi-deployment/pull/1297)
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjRncWJoYWVna3Zid3UwNG94amtzbWc3aDAxNmFzcGUzbW8zb2RyNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EOpZ7XsVfTN2E/giphy.gif)