### PR TITLE
WCM-736: Adjust keyword widget to separate TMS API and UI URLs

### DIFF
--- a/core/docs/changelog/WCM-736.change
+++ b/core/docs/changelog/WCM-736.change
@@ -1,0 +1,1 @@
+WCM-736: Adjust keyword widget to separate TMS API and UI URLs

--- a/core/src/zeit/cms/tagging/browser/widget.pt
+++ b/core/src/zeit/cms/tagging/browser/widget.pt
@@ -31,7 +31,7 @@
 <div tal:condition="view/display_tms_link">
   <a i18n:translate=""
      target="_blank"
-     tal:attributes="href string:http://${view/tms_host}/documents/show/${view/uuid}">Show in TMS</a>
+     tal:attributes="href string:${view/tms_ui_url}/documents/show/${view/uuid}">Show in TMS</a>
 </div>
 
 </div>

--- a/core/src/zeit/cms/tagging/browser/widget.py
+++ b/core/src/zeit/cms/tagging/browser/widget.py
@@ -76,21 +76,13 @@ class Widget(grok.MultiAdapter, zope.formlib.widget.SimpleInputWidget, zeit.cms.
         return tuple(result)
 
     def display_tms_link(self):
-        return self.tms_host and self.request.interaction.checkPermission(
+        return self.tms_ui_url and self.request.interaction.checkPermission(
             'zeit.cms.tagging.ViewInTMS', self.context
         )
 
     @property
-    def tms_host(self):
-        try:
-            # XXX This dependency is the wrong way around, but creating
-            # an abstraction instead doesn't really seem worthwile either.
-            import zeit.retresco.interfaces
-
-            tms = zope.component.getUtility(zeit.retresco.interfaces.ITMS)
-            return urllib.parse.urlparse(tms.primary['url']).netloc
-        except (ImportError, LookupError):
-            return None
+    def tms_ui_url(self):
+        return zeit.cms.config.get('zeit.retresco', 'ui-url')
 
     @property
     def uuid(self):

--- a/core/src/zeit/retresco/testing.py
+++ b/core/src/zeit/retresco/testing.py
@@ -80,7 +80,7 @@ class TMSMockLayer(plone.testing.Layer):
         registry = zope.component.getGlobalSiteManager()
         self['old_tms'] = registry.queryUtility(zeit.retresco.interfaces.ITMS)
         self['tms_mock'] = mock.Mock()
-        self['tms_mock'].primary = {'url': 'http://tms.example.com'}
+        self['tms_mock'].url = 'http://tms.example.com'
         self['tms_mock'].get_article_topiclinks.return_value = []
         registry.registerUtility(self['tms_mock'], zeit.retresco.interfaces.ITMS)
 


### PR DESCRIPTION
Benötigt https://github.com/ZeitOnline/vivi-deployment/pull/1307