### PR TITLE
WCM-692: Switch image purchase report from elasticsearch to content-storage

### DIFF
--- a/core/docs/changelog/WCM-692.change
+++ b/core/docs/changelog/WCM-692.change
@@ -1,0 +1,1 @@
+WCM-692: Switch image purchase report from elasticsearch to content-storage

--- a/core/src/zeit/connector/migrations/postdeploy/20250331_1407-20a7ba9a2def_create_index_for_image_separately_.py
+++ b/core/src/zeit/connector/migrations/postdeploy/20250331_1407-20a7ba9a2def_create_index_for_image_separately_.py
@@ -1,0 +1,40 @@
+"""create index for image_separately_purchased
+
+Revision ID: 20a7ba9a2def
+Revises: f83e173d7e5b
+Create Date: 2025-03-31 14:07:43.479218
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20a7ba9a2def'
+down_revision: Union[str, None] = 'f83e173d7e5b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f('ix_properties_image_separately_purchased'),
+            'properties',
+            ['image_separately_purchased'],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f('ix_properties_image_separately_purchased'),
+            'properties',
+            ['image_separately_purchased'],
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/core/src/zeit/connector/migrations/predeploy/20250331_1407-2f7a8b0212ae_add_image_separately_purchased_column.py
+++ b/core/src/zeit/connector/migrations/predeploy/20250331_1407-2f7a8b0212ae_add_image_separately_purchased_column.py
@@ -1,0 +1,34 @@
+"""add image_separately_purchased column
+
+Revision ID: 2f7a8b0212ae
+Revises: ef06d4a56605
+Create Date: 2025-03-31 14:07:03.986842
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2f7a8b0212ae'
+down_revision: Union[str, None] = 'ef06d4a56605'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'properties',
+        sa.Column(
+            'image_separately_purchased',
+            sa.Boolean(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('properties', 'image_separately_purchased')

--- a/core/src/zeit/connector/models.py
+++ b/core/src/zeit/connector/models.py
@@ -101,7 +101,9 @@ class ContentTypes:
     author_vgwort_code = mapped_column(Unicode, info={'namespace': 'author', 'name': 'vgwort_code'})
 
     centerpage_type = mapped_column(Unicode, info={'namespace': 'zeit.content.cp', 'name': 'type'})
-
+    image_separately_purchased = mapped_column(
+        Boolean, info={'namespace': 'image', 'name': 'single_purchase', 'migration': 'wcm_695'}
+    )
     gallery_type = mapped_column(
         Unicode, info={'namespace': 'zeit.content.gallery', 'name': 'type'}
     )
@@ -222,6 +224,7 @@ class Content(Base, CommonMetadata, ContentTypes, Timestamps, Miscellaneous, VGW
                     'author_hdok_id',
                     'author_ssoid',
                     'centerpage_type',
+                    'image_separately_purchased',
                     'print_ressort',
                     'product',
                     'published',


### PR DESCRIPTION
Basiert auf #1065 wegen alemic Migrationen, den also zuerst mergen.

### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~
- [x] Datenmigration ZeitOnline/vivi-deployment@077ca75

### gif
![]()