### PR TITLE
WCM-694: remove option to restrict time range in scheduled query because it does not improve performance

### DIFF
--- a/core/docs/changelog/WCM-694.change
+++ b/core/docs/changelog/WCM-694.change
@@ -1,0 +1,1 @@
+WCM-694: remove option to restrict time range in scheduled query because it does not improve performance

--- a/core/src/zeit/workflow/cli.py
+++ b/core/src/zeit/workflow/cli.py
@@ -15,9 +15,6 @@ log = logging.getLogger(__name__)
 
 def _handle_scheduled_content(action, sql_query, **params):
     bind_params = {key: value for key, value in params.items()}
-    age = int(zeit.cms.config.get('zeit.workflow', 'scheduled-query-restrict-days', 60))
-    bind_params['age'] = age
-    sql_query += """ AND last_updated >= CURRENT_DATE - INTERVAL ':age days'"""
     query = select(ConnectorModel)
     query = query.where(sql(sql_query).bindparams(**bind_params))
     repository = zope.component.getUtility(zeit.cms.repository.interfaces.IRepository)


### PR DESCRIPTION
`last_updated` ist auch durch unsere Datenmigrationen nicht viel weniger

### Checklist

- [x] Documentation
- [x] Changelog
- [ ] ~~Tests~~
- [ ] ~~Translations~~

### gif
![]()