### PR TITLE
WCM-694: add timeout setting for scheduled publish/retract query

### DIFF
--- a/core/docs/changelog/WCM-694.change
+++ b/core/docs/changelog/WCM-694.change
@@ -1,0 +1,1 @@
+WCM-694: add timeout setting for scheduled publish/retract query

--- a/core/src/zeit/workflow/cli.py
+++ b/core/src/zeit/workflow/cli.py
@@ -14,11 +14,12 @@ log = logging.getLogger(__name__)
 
 
 def _handle_scheduled_content(action, sql_query, **params):
+    query_timeout = int(zeit.cms.config.get('zeit.workflow', 'scheduled-query-timeouts-ms', 10000))
     bind_params = {key: value for key, value in params.items()}
     query = select(ConnectorModel)
     query = query.where(sql(sql_query).bindparams(**bind_params))
     repository = zope.component.getUtility(zeit.cms.repository.interfaces.IRepository)
-    results = repository.search(query)
+    results = repository.search(query, query_timeout)
     for content in results:
         publish = zeit.cms.workflow.interfaces.IPublish(content)
         for _ in commit_with_retry():


### PR DESCRIPTION
The AND condition in retract triggers a bitmap heap scan. Running it will be a bit slower than are regular 5s timeout. Rerunning will eventually be faster cause postgres seems to cache the results, but we do not run the retract cronjob enough to reliable hit that cache situation

### Checklist

- [x] Documentation
- [x] Changelog
- [ ] ~~Tests~~
- [ ] ~~Translations~~

### gif
![]()