### PR TITLE
WCM-611: Fetch volume content from content-storage

### DIFF
--- a/core/docs/changelog/WCM-611.change
+++ b/core/docs/changelog/WCM-611.change
@@ -1,0 +1,1 @@
+WCM-611: Switch publish volume content from elasticsearch to content-storage

--- a/core/src/zeit/content/volume/browser/tests/test_admin.py
+++ b/core/src/zeit/content/volume/browser/tests/test_admin.py
@@ -80,16 +80,16 @@ class VolumeAdminBrowserTest(zeit.content.volume.testing.BrowserTestCase):
         b.open('http://localhost/++skin++vivi/repository/2015/01/ausgabe/@@publish-all')
 
     def test_publish_button_publishes_volume_content(self):
-        self.elastic.search.return_value = zeit.cms.interfaces.Result([{'url': '/testcontent'}])
+        connector = zope.component.getUtility(zeit.cms.interfaces.IConnector)
+        connector.search_result = ['http://xml.zeit.de/testcontent']
         self.publish_content()
         self.assertTrue(IPublishInfo(self.repository['testcontent']).published)
         self.assertTrue(IPublishInfo(self.repository['2015']['01']['ausgabe']).published)
 
     def test_referenced_boxes_of_articles_are_published_as_well(self):
         self.create_article_with_references()
-        self.elastic.search.return_value = zeit.cms.interfaces.Result(
-            [{'url': '/article_with_ref'}]
-        )
+        connector = zope.component.getUtility(zeit.cms.interfaces.IConnector)
+        connector.search_result = ['http://xml.zeit.de/article_with_ref']
         self.publish_content()
         self.assertTrue(
             zeit.cms.workflow.interfaces.IPublishInfo(self.repository['portraitbox']).published
@@ -100,9 +100,8 @@ class VolumeAdminBrowserTest(zeit.content.volume.testing.BrowserTestCase):
 
     def test_referenced_image_is_not_published(self):
         self.create_article_with_references()
-        self.elastic.search.return_value = zeit.cms.interfaces.Result(
-            [{'url': '/article_with_ref'}]
-        )
+        connector = zope.component.getUtility(zeit.cms.interfaces.IConnector)
+        connector.search_result = ['http://xml.zeit.de/article_with_ref']
         self.publish_content()
         self.assertFalse(
             zeit.cms.workflow.interfaces.IPublishInfo(self.repository['image']).published

--- a/core/src/zeit/content/volume/volume.py
+++ b/core/src/zeit/content/volume/volume.py
@@ -272,7 +272,6 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
         volume_year = :year
         AND volume_number = :volume
         AND product IN :products
-        NOT channels @> '[["zeit-magazin", "wochenmarkt"]]'
         """
         query = select(ConnectorModel).where(
             sql(query).bindparams(


### PR DESCRIPTION
unsere Elastic Query für die heutige Ausgabe sieht so aus:
```
{"query": 
 {"bool": 
	{"filter": 
	 [
		 {"term": {"payload.document.year": 2025}}, 
		 {"term": {"payload.document.volume": 15}}, 
		 {"bool": {"should": [
			 {"term": {"payload.workflow.product-id": "ZEI"}}, 
			 {"term": {"payload.workflow.product-id": "ZMLB"}}, 
			 {"term": {"payload.workflow.product-id": "ZECH"}}, 
			 {"term": {"payload.workflow.product-id": "ZEOE"}}, 
			 {"term": {"payload.workflow.product-id": "ZESA"}}, 
			 {"term": {"payload.workflow.product-id": "ZEIH"}}, 
			 {"term": {"payload.workflow.product-id": "ZBGE"}}, 
			 {"term": {"payload.workflow.product-id": "ZBGO"}}, 
			 {"term": {"payload.workflow.product-id": "ZBL"}}, 
			 {"term": {"payload.workflow.product-id": "ZBKS"}}, 
			 {"term": {"payload.workflow.product-id": "ZBR"}}, 
			 {"term": {"payload.workflow.product-id": "ZBC"}}, 
			 {"term": {"payload.workflow.product-id": "ZBA"}}, 
			 {"term": {"payload.workflow.product-id": "ZBF"}}, 
			 {"term": {"payload.workflow.product-id": "ZEDO"}}, 
			 {"term": {"payload.workflow.product-id": "ZBD"}}, 
			 {"term": {"payload.workflow.product-id": "ZMHH"}}, 
			 {"term": {"payload.workflow.product-id": "ZMMU"}}, 
			 {"term": {"payload.workflow.product-id": "ZMFR"}}, 
			 {"term": {"payload.workflow.product-id": "ZMSY"}}, 
			 {"term": {"payload.workflow.product-id": "ZMZU"}}, 
			 {"term": {"payload.workflow.product-id": "ZECW"}}, 
			 {"term": {"payload.workflow.product-id": "ZEAR"}}]}}, 
		 {"bool": {
			 "must_not": 
			 {"term": {"payload.document.channels": "zeit-magazin wochenmarkt"}}}}, 
		 {"term": {"doc_type": "article"}}, 
		 {"term": {"payload.workflow.published": False}}, 
		 {"term": {"payload.workflow.urgent": True}}], 
	 "must_not": [
		 {"term": {"url": "/2025/15/ausgabe"}}]}},
 
 "_source": ("url", "doc_type", "doc_id", "payload", "title", "teaser", "author")}
```
 das habe ich in diese SQL Query übersetzt
```
SELECT ...
FROM properties
WHERE
        volume_year = 2025
        AND volume_number = 11
        AND product IN ('ZEI', 'ZMLB')
        NOT channels @> '[["zeit-magazin", "wochenmarkt"]]'

        AND type='article'
        AND published=false
        AND unsorted @@ '$.workflow.urgent == "yes"'
```

Für diesen PR ist der `must_not` Clause, der die Ausgabe ausschließt, noch nicht notwendig. Das kommt erst in [WCM-693](https://zeit-online.atlassian.net/browse/WCM-693)
### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDBiOWVld2tjbDJ6bjRsemUyN3Z6MGZsb3FxMXk2eGVnZGdmamlicyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7WTMQQfvtQ2LKisM/giphy.gif)

[WCM-693]: https://zeit-online.atlassian.net/browse/WCM-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ