### PR TITLE
WCM-179: Make sure delete button can be reached

### DIFF
--- a/core/docs/changelog/wcm-179.change
+++ b/core/docs/changelog/wcm-179.change
@@ -1,0 +1,1 @@
+WCM-179: Move delete button so it can be reached

--- a/core/src/zeit/cms/browser/resources/cms_widgets.css
+++ b/core/src/zeit/cms/browser/resources/cms_widgets.css
@@ -392,7 +392,7 @@
 
 .objectsequencewidget li a[rel="remove"],
 .drop-object-widget .object-reference a[rel="remove"] {
-  background: url("./icons/icons_sprites.png") no-repeat scroll 68px -417px;
+  background: url("./icons/icons_sprites.png") no-repeat scroll 58px -417px;
   background-color: rgba(0,0,0,0.6);
   border-radius: 2px 2px 2px 2px;
   border: 1px solid #000000;
@@ -401,13 +401,10 @@
   display: none;
   font-size: 14px;
   height: 18px;
-  margin-right: 16px;
-  margin-top: 48px;
-  padding-left: 1em;
-  padding-right: 2.2em;
-  padding-top: 2px;
+  margin: 10px;
+  padding: 2px 20px 2px 4px;
   position: absolute;
-  right: 20px;
+  right: 0px;
   top: 0;
 }
 
@@ -433,7 +430,7 @@
 .object-reference a[rel="remove"]:hover,
 .objectsequencewidget li a[rel="remove"]:hover,
 .drop-object-widget .object-reference a[rel="remove"].button:hover {
-  border: 1px solid #fff;
+  background-color: #444;
 }
 
 .object-widget.droppable-active  a[rel="remove"] {

--- a/core/src/zeit/content/cp/browser/resources/editor.css
+++ b/core/src/zeit/content/cp/browser/resources/editor.css
@@ -235,9 +235,9 @@
   width: 75%;
 }
 
-
 .teaser-block-properties-form .object-reference {
-  width: 80%
+  position: relative;
+  width: 80%;
 }
 
 /* Teaser visualisations */


### PR DESCRIPTION
WCM-179

Das Element für die CP hat nur 80% Breite, der Button ist aber relativ zum Formular (100% Breite) ausgerichtet, also außerhalb des CP-Elements. Der Button wird nur angezeigt, wenn das CP-Element gehovert wird, um zu ihm zu kommen, verlässt der Zeiger das CP-Element aber und der Button verschwindet. Meine Lösung ist, den Button relativ zum CP-Element zu positionieren. Außerdem verschiebe ich ihn ein bisschen und ändere das Styling minimal.