### PR TITLE
WCM-831: add print ressort filtering for webhooks

### DIFF
--- a/core/docs/changelog/WCM-831.change
+++ b/core/docs/changelog/WCM-831.change
@@ -1,0 +1,1 @@
+WCM-831: add filter for print ressort in webhooks

--- a/core/src/zeit/cms/checkout/tests/test_webhook.py
+++ b/core/src/zeit/cms/checkout/tests/test_webhook.py
@@ -129,6 +129,22 @@ class WebhookExcludeTest(zeit.cms.testing.ZeitCmsTestCase):
             co.product = Product('ZEDE')
         self.assertTrue(hook.should_exclude(self.repository['testcontent']))
 
+    def test_match_print_ressort(self):
+        hook = zeit.cms.checkout.webhook.Hook('checkin', None)
+        hook.add_exclude('print_ressort', 'Wissen')
+        self.assertFalse(hook.should_exclude(self.repository['testcontent']))
+        with checked_out(self.repository['testcontent']) as co:
+            co.print_ressort = 'Wissen'
+        self.assertTrue(hook.should_exclude(self.repository['testcontent']))
+
+    def test_match_has_print_ressort(self):
+        hook = zeit.cms.checkout.webhook.Hook('checkin', None)
+        hook.add_exclude('print_ressort', '*')
+        self.assertFalse(hook.should_exclude(self.repository['testcontent']))
+        with checked_out(self.repository['testcontent']) as co:
+            co.print_ressort = 'Wissen'
+        self.assertTrue(hook.should_exclude(self.repository['testcontent']))
+
     def test_skip_auto_renameable(self):
         hook = zeit.cms.checkout.webhook.Hook(None, None)
         self.assertFalse(hook.should_exclude(self.repository['testcontent']))

--- a/core/src/zeit/cms/checkout/webhook.py
+++ b/core/src/zeit/cms/checkout/webhook.py
@@ -147,6 +147,13 @@ class Hook:
             return False
         return content.product and content.product.counter == value
 
+    def _match_print_ressort(self, content, value):
+        if not ICommonMetadata.providedBy(content):
+            return False
+        if value == '*':
+            return content.print_ressort is not None
+        return content.print_ressort == value
+
     def _match_path_prefix(self, content, value):
         path = content.uniqueId.replace(zeit.cms.interfaces.ID_NAMESPACE, '/')
         return path.startswith(value)


### PR DESCRIPTION
Dieser PR erlaubt es, in den Webhooks zusätzlich nach Print-Ressorts zu filtern. Es gibt die Möglichkeit, ein Sternchen zu setzen: In diesem Fall wird geprüft, ob `print_ressort` an der jeweiligen Ressource existiert.

### Checklist

- [x] Documentation: https://github.com/ZeitOnline/vivi-deployment/pull/1324
- [x] Changelog
- [x] Tests


### gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDZ5YnBqdW5kNmpsaGdzYW96MGF2OXU0cmM1YzV3MHcybjN0dHJ4ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oQzmXr9FploiZmZshV/giphy.gif)