### PR TITLE
WCM-867: publisher ignores completely set by config instead of hardcoded conditions

### DIFF
--- a/core/docs/changelog/wcm-867.change
+++ b/core/docs/changelog/wcm-867.change
@@ -1,0 +1,1 @@
+WCM-867: publisher ignores completely set by config instead of hardcoded conditions

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -275,12 +275,6 @@ class IgnoreMixin:
         return grok.name.bind().get(self.__class__)
 
     def ignore(self, method):
-        if (
-            zeit.cms.content.interfaces.ICommonMetadata.providedBy(self.context)
-            and self.context.product
-            and self.context.product.is_news
-        ):
-            return True
         if method == 'publish':
             for attribute, setting in self.attr_setting_mapping.items():
                 if self.is_on_ignorelist(attribute, *setting):

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -247,9 +247,8 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         json = zeit.workflow.testing.publish_json(article, 'speechbert')
         assert json is not None
         with checked_out(article) as co:
-            co.product = zeit.cms.content.sources.Product(
-                id='dpaBY', title='DPA Bayern', show='source', is_news=True
-            )
+            co.ressort = 'News'
+        zeit.cms.config.set('zeit.workflow', 'speechbert-ignore-ressorts', 'news')
         json = zeit.workflow.testing.publish_json(article, 'speechbert')
         assert json is None
 


### PR DESCRIPTION
vivi-deployment PR um bisheriges Verhalten beizubehalten

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXE2a3UxNzJnZXFveXo5Y2FhbGpmbXg2M3FwdTAyY3c1aTNkZmg0diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uY9JuJj3KhlZdow37L/giphy.gif)