### PR TITLE
ES-145: Ignore product IDs during publish, based on setting

### DIFF
--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -267,6 +267,8 @@ class IgnoreMixin:
         'genre': ('genres', zeit.content.article.interfaces.IArticleMetadata),
         'template': ('templates', zeit.content.article.interfaces.IArticleMetadata),
         'ressort': ('ressorts', zeit.cms.content.interfaces.ICommonMetadata),
+        # TODO: This returns an object, not a string. We would need to check product.id!
+        'product': ('products', zeit.cms.content.interfaces.ICommonMetadata),
         'uniqueId': ('uniqueids', zeit.cms.interfaces.ICMSContent),
     }
 

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -264,6 +264,17 @@ class Publisher3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         payload = zeit.workflow.testing.publish_json(article, 'summy')
         assert payload == {}
 
+    def test_summy_ignore_products_list(self):
+        article = ICMSContent('http://xml.zeit.de/online/2022/08/trockenheit')
+
+        payload = zeit.workflow.testing.publish_json(article, 'summy')
+        assert payload is not None
+        assert len(payload['text']) > 1
+
+        zeit.cms.config.set('zeit.workflow', 'summy-ignore-products', 'dpaSN')
+        payload = zeit.workflow.testing.publish_json(article, 'summy')
+        assert payload == {}
+
     def test_summy_payload(self):
         article = ICMSContent('http://xml.zeit.de/zeit-magazin/wochenmarkt/rezept')
         zeit.cms.config.set('zeit.workflow', 'summy-ignore-ressorts', 'valid_ressort')


### PR DESCRIPTION
Wir möchten, dass Inhalte bestimmter Product-IDs nicht zu Summy geschickt werden beim Publish. 

Das Feature gibt es schon für Genres und Ressorts. Analog dazu wird es für Produkte implementiert.

**Jedoch:** aus ICommomMetadata kommen Produkte als Objekte raus, und nicht als String wie Ressort oder Genre. Deshalb wird der Code noch nicht funktionieren. Es ist nur mein erster Aufschlag. Da würde ich gern mit einem Python-Profi drüber sprechen. (Und: finde nur ich den Code sehr schwierig zu lesen? 😬)

https://zeit-online.atlassian.net/browse/ES-145

### Checklist

- [ ] Documentation
- [ ] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()