### PR TITLE
WCM-888: Add metric to count unreported but reportable vgwort content

### DIFF
--- a/core/docs/changelog/WCM-888.change
+++ b/core/docs/changelog/WCM-888.change
@@ -1,0 +1,1 @@
+WCM-888: Add metric to count unreported but reportable vgwort content


### PR DESCRIPTION
Darauf könnten wir einen Alarm der Art `vivi_vgwort_unreported_total > 0` ansetzen.