### PR TITLE
ES-172: Add utility for kilkaya-teaser-splittests

### DIFF
--- a/core/src/zeit/sourcepoint/configure.zcml
+++ b/core/src/zeit/sourcepoint/configure.zcml
@@ -2,4 +2,7 @@
   <utility
     name="addefend"
     factory=".connection.addefend_from_product_config" />
+  <utility
+    name="kilkaya-teaser-splittests"
+    factory=".connection.kilkaya_teaser_splittests_from_product_config" />
 </configure>

--- a/core/src/zeit/sourcepoint/connection.py
+++ b/core/src/zeit/sourcepoint/connection.py
@@ -17,6 +17,11 @@ def addefend_from_product_config():
     return zeit.sourcepoint.javascript.JavaScript.from_product_config('addefend')
 
 
+@grok.implementer(zeit.sourcepoint.interfaces.IJavaScript)
+def kilkaya_teaser_splittests_from_product_config():
+    return zeit.sourcepoint.javascript.JavaScript.from_product_config('kilkaya-teaser-splittests')
+
+
 @zeit.cms.cli.runner(principal=zeit.cms.cli.from_config('zeit.sourcepoint', 'update-principal'))
 def update():
     parser = argparse.ArgumentParser()

--- a/core/src/zeit/sourcepoint/testing.py
+++ b/core/src/zeit/sourcepoint/testing.py
@@ -10,6 +10,9 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
         'addefend-url': 'http://example.com',
         'addefend-javascript-folder': 'http://xml.zeit.de/addefend/',
         'addefend-filename': 'adf',
+        'kilkaya-teaser-splittests-url': 'http://example.com',
+        'kilkaya-teaser-splittests-javascript-folder': 'http://xml.zeit.de/kilkaya/',
+        'kilkaya-teaser-splittests-filename': 'kil',
     },
     bases=(zeit.cms.testing.CONFIG_LAYER,),
 )


### PR DESCRIPTION
Um in `zeit.web` bequem die aktuellste Datei zu finden, könnten wir der Sauberkeit halber eine Utility benutzen.

DEPLOYMENT_BRANCH=es-172_kilkaya_teaser_splittests