### PR TITLE
WCM-928: only add automated categories within the first checkin

### DIFF
--- a/core/docs/changelog/wcm-928.change
+++ b/core/docs/changelog/wcm-928.change
@@ -1,0 +1,1 @@
+WCM-928: only add automated categories within the first checkin

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -612,7 +612,8 @@ def update_recipes_of_article(context, event):
             categories.append(complexity)
         if time := source.find(f'time-{recipe.time}'):
             categories.append(time)
-    if category := _categorize_by_ingredients_diet(ingredients):
+    # Only guess diet categories once, so the user can remove them.
+    if not context.recipe_titles and (category := _categorize_by_ingredients_diet(ingredients)):
         categories.append(category)
 
     context.recipe_titles = titles

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -592,6 +592,13 @@ class WochenmarktArticles(zeit.content.article.testing.FunctionalTestCase):
             ('gurke', 'tomate'),
             article.recipe_ingredients,
         )
+        # remove category manually, it should not be re-added
+        with checked_out(self.repository['article']) as co:
+            co.recipe_categories = (i for i in co.recipe_categories if i.id != 'vegane-rezepte')
+        article = self.repository['article']
+        categories = [category.id for category in article.recipe_categories]
+        self.assertNotIn('vegane-rezepte', categories)
+        self.assertEqual(6, len(article.recipe_categories))
 
     def test_recipe_category_is_added_on_checkin_with_multiple_diets(self):
         ingredients = zeit.wochenmarkt.sources.ingredientsSource(None).factory


### PR DESCRIPTION
### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()