### PR TITLE
WCM-901: keep XMP metadata of image when resizing it

### DIFF
--- a/core/docs/changelog/wcm-901.change
+++ b/core/docs/changelog/wcm-901.change
@@ -1,0 +1,1 @@
+WCM-901: keep XMP metadata of image when resizing it

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -32,7 +32,7 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
 
         image = zeit.content.image.image.LocalImage()
         with image.open('w') as f:
-            pil_image.save(f, 'PNG', exif=exif.tobytes())
+            pil_image.save(f, 'jpeg', exif=exif.tobytes(), xmp=b'xmp-sample')
         return image
 
     ascii_to_color = {
@@ -48,7 +48,7 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
     def draw_image(self, pixels):
         width = len(pixels[0])
         height = len(pixels)
-        image = PIL.Image.new('RGBA', (width, height), (255, 255, 255, 255))
+        image = PIL.Image.new('RGB', (width, height), (255, 255, 255))
         draw = PIL.ImageDraw.ImageDraw(image)
         for x in range(width):
             for y in range(height):
@@ -288,5 +288,6 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
             resized_pil_image = PIL.Image.open(img)
             resized_exif = resized_pil_image.getexif()
 
+        self.assertEqual(resized_pil_image.info['xmp'], b'xmp-sample')
         self.assertEqual(resized_exif[PIL.ExifTags.Base.Make], 'Make')
         self.assertEqual(resized_exif[PIL.ExifTags.Base.Model], 'Model')

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -40,7 +40,7 @@ class ImageTransform:
         orig_width, orig_height = self.image.size
         # keep image metadata
         orig_exif = self.image.getexif()
-
+        orig_xmp = self.image.info.get('xmp')
         # width and height need to be int rather than float,
         # so we use // instead of / as division operator.
         if width is None:
@@ -49,7 +49,7 @@ class ImageTransform:
             height = orig_height * width // orig_width
 
         image = self.image.resize((int(width), int(height)), filter)
-        return self._construct_image(image, exif=orig_exif)
+        return self._construct_image(image, exif=orig_exif, xmp=orig_xmp)
 
     def create_variant_image(self, variant, size=None, fill_color=None, format=None):
         """Create variant image from source image.


### PR DESCRIPTION
IPTC und Exif sind Standards von gestern und XMP enthält diese Metainformationen.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2Z1NDk1ZHh1a2t5MDVhNzVsNG51bmowbnNrNDJoZG82N21icmRwNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uWKCg3WFJmGXiNt4ey/giphy.gif)