### PR TITLE
ENG-232: add publish on new podcast series

### DIFF
--- a/core/docs/changelog/ENG-232.change
+++ b/core/docs/changelog/ENG-232.change
@@ -1,0 +1,1 @@
+ENG-232: send followings to publisher

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -504,3 +504,23 @@ class AudioDataScience(DataScience):
 
 class VideoDataScience(DataScience):
     grok.context(zeit.content.video.interfaces.IVideo)
+
+
+@grok.implementer(zeit.workflow.interfaces.IPublisherData)
+class Followings(grok.Adapter, IgnoreMixin):
+    grok.context(zeit.content.article.interfaces.IArticle)
+    grok.name('followings')
+
+    def _json(self):
+        article = self.context
+        if article.serie is None:
+            return None
+        # Check if the Article has a podcast
+        audio_refs = zeit.content.audio.interfaces.IAudioReferences(article, None)
+        if audio_refs is None or not bool(audio_refs.get_by_type('podcast')):
+            return None
+        series_content = zeit.cms.interfaces.ICMSContent(
+            f'{zeit.cms.interfaces.ID_NAMESPACE}serie/{article.serie.url}'
+        )
+        series = zeit.cms.content.interfaces.IUUID(series_content).shortened
+        return {'parent_id': series}

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -636,3 +636,24 @@ class DatasciencePayloadTest(zeit.workflow.testing.FunctionalTestCase):
         video = self.repository['video'] = video
         data = zeit.workflow.testing.publish_json(video, 'datascience')
         self.assertEqual(data['body'], lxml.etree.tostring(video.xml, encoding=str))
+
+
+class FollowingsPayloadTest(zeit.workflow.testing.FunctionalTestCase):
+    layer = zeit.content.article.testing.LAYER
+
+    def test_followings_payload_audio(self):
+        from zeit.content.audio.testing import AudioBuilder
+
+        article = ICMSContent('http://xml.zeit.de/online/2022/08/kaenguru-comics-folge-448')
+        self.repository['serie'] = zeit.cms.repository.folder.Folder()
+        self.repository['serie']['chefsache'] = zeit.content.cp.centerpage.CenterPage()
+        cp = self.repository['serie']['chefsache']
+        audio = AudioBuilder().with_audio_type('podcast').build()
+        audio = self.repository['audio'] = audio
+
+        audios_refs = zeit.content.audio.interfaces.IAudioReferences(article)
+        audios_refs.add(audio)
+        expected_uuid = zeit.cms.content.interfaces.IUUID(cp).shortened
+
+        data = zeit.workflow.testing.publish_json(article, 'followings')
+        self.assertEqual(data['parent_id'], expected_uuid)

--- a/core/src/zeit/workflow/tests/test_retract_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_retract_3rdparty.py
@@ -136,3 +136,14 @@ class Retract3rdPartyTest(zeit.workflow.testing.FunctionalTestCase):
         )
         data = data_factory.retract_json()
         assert data is None
+
+    def test_followings_retract(self):
+        article = ICMSContent('http://xml.zeit.de/online/2022/08/kaenguru-comics-folge-448')
+        zope.interface.alsoProvides(article, zeit.content.cp.interfaces.ICenterPage)
+        zope.interface.alsoProvides(article, zeit.content.audio.interfaces.IAudioReferences)
+
+        data_factory = zope.component.getAdapter(
+            article, zeit.workflow.interfaces.IPublisherData, name='followings'
+        )
+        data = data_factory.retract_json()
+        assert data == {}


### PR DESCRIPTION
### Beschreibung
Dieser PR fügt das third-party Ziel "followings" hinzu. Dabei soll bei jeder neuen Podcast-Folge ein `post` zu den `merkl`-Followings durchgeführt werden. Ein `delete` soll beim `retracten` geschehen. Bei Artikeln wird hier geprüft, ob sie einen Podcast haben. Wenn ja, werden sie gepublished

### Tasks
- [x] Dokumentation
- [x] Tests
### Gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXh0OTZoNXloejRzeDQ2N2JrbGtqZmpnYTU0NDlsZ3pnMjJsYzhybiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/j2FvSxxKF0ctNKDaSY/giphy.gif)

## Related
https://github.com/ZeitOnline/publisher/pull/646