### PR TITLE
WCM-933: Calculate variant preview images in editor directly from the source image without an intermediary thumbnail

### DIFF
--- a/core/docs/changelog/WCM-933.change
+++ b/core/docs/changelog/WCM-933.change
@@ -1,0 +1,1 @@
+WCM-933: Calculate variant preview images in editor directly from the source image without an intermediary thumbnail

--- a/core/src/zeit/content/image/browser/variant.py
+++ b/core/src/zeit/content/image/browser/variant.py
@@ -81,5 +81,6 @@ class Editor:
         # Force generating thumbnail source if does not exist yet, so not each
         # variant preview tries to do it simultaneously later on (which only
         # leads to conflicts).
-        zeit.content.image.interfaces.IThumbnails(self.context).source_image
+        thumbnails = zeit.content.image.interfaces.IThumbnails(self.context)
+        thumbnails.source_image(thumbnails.master_image(''))
         return super().__call__()

--- a/core/src/zeit/content/image/browser/variant.py
+++ b/core/src/zeit/content/image/browser/variant.py
@@ -17,7 +17,7 @@ class VariantSerializeMixin:
             data[field] = getattr(variant, field, None)
 
         base_url = self.url(zeit.content.image.interfaces.IImageGroup(variant))
-        image_url = '%s/%s/raw' % (base_url, variant.relative_image_path)
+        image_url = '%s/%s/raw' % (base_url, variant.relative_thumbnail_path)
         data['url'] = image_url
 
         return data

--- a/core/src/zeit/content/image/imagegroup.py
+++ b/core/src/zeit/content/image/imagegroup.py
@@ -336,7 +336,7 @@ class VariantTraverser:
             except (IndexError, ValueError):
                 continue
             else:
-                if any(i <= 0 for i in [width, height]):
+                if any(i < 0 for i in [width, height]):
                     return INVALID_SIZE
                 return [width, height]
         return None

--- a/core/src/zeit/content/image/interfaces.py
+++ b/core/src/zeit/content/image/interfaces.py
@@ -325,7 +325,7 @@ class IVariant(zope.interface.Interface):
     max_height = zope.interface.Attribute('Shorthand to access height of max_size')
     fallback_width = zope.interface.Attribute('Shorthand to access width of fallback_size')
     fallback_height = zope.interface.Attribute('Shorthand to access height of fallback_size')
-    relative_image_path = zope.interface.Attribute(
+    relative_thumbnail_path = zope.interface.Attribute(
         'Image path relative to the ImageGroup the Variant lives in'
     )
     is_default = zope.interface.Attribute(

--- a/core/src/zeit/content/image/tests/test_imagegroup.py
+++ b/core/src/zeit/content/image/tests/test_imagegroup.py
@@ -115,9 +115,6 @@ class ImageGroupTest(zeit.content.image.testing.FunctionalTestCase):
 
     def test_invalid_size_raises_keyerror(self):
         with self.assertRaises(NotFound):
-            self.traverse('square__0x200')
-
-        with self.assertRaises(NotFound):
             self.traverse('square__-1x200')
 
     def test_variant_url_returns_path_with_fill_color_if_given(self):

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -133,7 +133,12 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
             id='original', focus_x=5.0 / 16, focus_y=3.0 / 8, zoom=0.5, aspect_ratio='original'
         )
         self.assertImage(
-            ['        ', '  x     ', '        ', '        '],
+            [
+                '        ',
+                '  x     ',
+                '        ',
+                '        ',
+            ],
             self.transform.create_variant_image(variant),
         )
 

--- a/core/src/zeit/content/image/tests/test_transform.py
+++ b/core/src/zeit/content/image/tests/test_transform.py
@@ -86,6 +86,15 @@ class CreateVariantImageTest(zeit.content.image.testing.FunctionalTestCase):
         image = self.transform.create_variant_image(variant, size=(10, 10))
         self.assertEqual((5, 5), image.getImageSize())
 
+    def test_fits_mask_to_image_size(self):
+        variant = Variant(id='square', focus_x=0.5, focus_y=0.5, zoom=1, aspect_ratio='1:1')
+        image = self.transform.create_variant_image(variant, size=(5, 0))
+        self.assertEqual((5, 5), image.getImageSize())
+
+        variant = Variant(id='portrait', focus_x=0.5, focus_y=0.5, zoom=1, aspect_ratio='1:2')
+        image = self.transform.create_variant_image(variant, size=(5, 0))
+        self.assertEqual((4, 8), image.getImageSize())
+
     def test_focus_point_after_crop_has_same_relative_position_as_before(self):
         variant = Variant(
             id='square', focus_x=5.0 / 16, focus_y=3.0 / 8, zoom=1, aspect_ratio='1:1'

--- a/core/src/zeit/content/image/tests/test_variant.py
+++ b/core/src/zeit/content/image/tests/test_variant.py
@@ -100,10 +100,8 @@ class VariantProperties(zeit.content.image.testing.FunctionalTestCase):
         self.assertEqual(False, self.variants['square'].is_default)
 
     def test_relative_path_links_to_thumbnail_of_that_variant(self):
-        self.assertEqual('thumbnails/default', self.variants['default'].relative_thumbnail_path)
-        self.assertEqual('thumbnails/square', self.variants['square'].relative_thumbnail_path)
+        self.assertEqual('default__1000x0', self.variants['default'].relative_thumbnail_path)
+        self.assertEqual('square__1000x0', self.variants['square'].relative_thumbnail_path)
 
     def test_relative_path_contains_max_size_to_distinguish_variant_sizes(self):
-        self.assertEqual(
-            'thumbnails/cinema__320x180', self.variants['cinema-small'].relative_thumbnail_path
-        )
+        self.assertEqual('cinema__320x180', self.variants['cinema-small'].relative_thumbnail_path)

--- a/core/src/zeit/content/image/tests/test_variant.py
+++ b/core/src/zeit/content/image/tests/test_variant.py
@@ -99,11 +99,11 @@ class VariantProperties(zeit.content.image.testing.FunctionalTestCase):
         self.assertEqual(True, self.variants['default'].is_default)
         self.assertEqual(False, self.variants['square'].is_default)
 
-    def test_relative_path_variants_link_to_thumbnail_of_that_variant(self):
-        self.assertEqual('thumbnails/default', self.variants['default'].relative_image_path)
-        self.assertEqual('thumbnails/square', self.variants['square'].relative_image_path)
+    def test_relative_path_links_to_thumbnail_of_that_variant(self):
+        self.assertEqual('thumbnails/default', self.variants['default'].relative_thumbnail_path)
+        self.assertEqual('thumbnails/square', self.variants['square'].relative_thumbnail_path)
 
     def test_relative_path_contains_max_size_to_distinguish_variant_sizes(self):
         self.assertEqual(
-            'thumbnails/cinema__320x180', self.variants['cinema-small'].relative_image_path
+            'thumbnails/cinema__320x180', self.variants['cinema-small'].relative_thumbnail_path
         )

--- a/core/src/zeit/content/image/transform.py
+++ b/core/src/zeit/content/image/transform.py
@@ -124,6 +124,10 @@ class ImageTransform:
                 target_width, target_height = self._fit_ratio_to_image(
                     target_width, target_height, override_ratio
                 )
+            else:
+                target_width, target_height = self._fit_size_to_ratio(
+                    target_width, target_height, w, h, target_ratio
+                )
 
         x, y = self._determine_crop_position(variant, target_width, target_height)
         image = self._crop(self.image, x, y, x + target_width, y + target_height)
@@ -150,6 +154,24 @@ class ImageTransform:
         else:
             width = int(source_height * target_ratio)
             height = source_height
+        return width, height
+
+    def _fit_size_to_ratio(
+        self, source_width, source_height, target_width, target_height, target_ratio
+    ):
+        """Keep the main dimension the same and adjust the other one to fit the
+        target ratio. Allow for either dimension to be 0 to fall back on the
+        source dimension instead."""
+        if not target_width:
+            target_width = source_width
+        if not target_height:
+            target_height = source_height
+        if target_ratio >= 1:
+            width = min(target_width, source_width)
+            height = int(width / target_ratio)
+        else:
+            height = min(target_height, source_height)
+            width = int(height * target_ratio)
         return width, height
 
     def _determine_crop_position(self, variant, target_width, target_height):

--- a/core/src/zeit/content/image/variant.py
+++ b/core/src/zeit/content/image/variant.py
@@ -6,6 +6,7 @@ from zope.cachedescriptors.property import Lazy as cachedproperty
 import grokcore.component as grok
 import zope.schema
 
+from zeit.cms.content.sources import FEATURE_TOGGLES
 from zeit.cms.interfaces import CONFIG_CACHE
 import zeit.cms.content.sources
 import zeit.content.image.interfaces
@@ -157,13 +158,19 @@ class Variant(zeit.cms.content.sources.AllowedBase):
     def is_default(self):
         return self.id == self.DEFAULT_NAME
 
+    THUMBNAIL_WIDTH = 1000
+
     @property
     def relative_thumbnail_path(self):
-        if self.max_size is None:
-            return '%s/%s' % (zeit.content.image.imagegroup.Thumbnails.NAME, self.name)
-        return '{}/{}__{}'.format(
-            zeit.content.image.imagegroup.Thumbnails.NAME, self.name, self.max_size
-        )
+        if FEATURE_TOGGLES.find('image_variant_preview_from_thumbnail'):
+            if self.max_size is None:
+                return '%s/%s' % (zeit.content.image.imagegroup.Thumbnails.NAME, self.name)
+            return '{}/{}__{}'.format(
+                zeit.content.image.imagegroup.Thumbnails.NAME, self.name, self.max_size
+            )
+
+        size = self.max_size or f'{self.THUMBNAIL_WIDTH}x0'
+        return f'{self.name}__{size}'
 
 
 class VariantSource(

--- a/core/src/zeit/content/image/variant.py
+++ b/core/src/zeit/content/image/variant.py
@@ -158,7 +158,7 @@ class Variant(zeit.cms.content.sources.AllowedBase):
         return self.id == self.DEFAULT_NAME
 
     @property
-    def relative_image_path(self):
+    def relative_thumbnail_path(self):
         if self.max_size is None:
             return '%s/%s' % (zeit.content.image.imagegroup.Thumbnails.NAME, self.name)
         return '{}/{}__{}'.format(


### PR DESCRIPTION
### Checklist

- [ ] Documentation kommt noch
- [x] Changelog
- [x] Tests
- [x] ~Translations~