### PR TITLE
WCM-950: get podcast image cover directly from podcast object same way as audio object

### DIFF
--- a/core/docs/changelog/wcm-950.change
+++ b/core/docs/changelog/wcm-950.change
@@ -1,0 +1,1 @@
+WCM-950: get podcast image cover directly from podcast object same way as audio object

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -6,7 +6,7 @@ import zope.interface
 
 from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.interfaces import AUDIO_SCHEMA_NS
-from zeit.content.audio.interfaces import IAudio, IPodcastEpisodeInfo, ISpeechInfo, Podcast
+from zeit.content.audio.interfaces import IAudio, IPodcast, IPodcastEpisodeInfo, ISpeechInfo
 import zeit.cms.content.dav
 import zeit.cms.content.interfaces
 import zeit.cms.content.metadata
@@ -85,7 +85,7 @@ def audio_image(context):
 
 @grok.implementer(zeit.content.image.interfaces.IImages)
 class PodcastImage(grok.Adapter):
-    grok.context(Podcast)
+    grok.context(IPodcast)
 
     @property
     def fill_color(self):

--- a/core/src/zeit/content/audio/audio.py
+++ b/core/src/zeit/content/audio/audio.py
@@ -6,7 +6,7 @@ import zope.interface
 
 from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.interfaces import AUDIO_SCHEMA_NS
-from zeit.content.audio.interfaces import IAudio, IPodcastEpisodeInfo, ISpeechInfo
+from zeit.content.audio.interfaces import IAudio, IPodcastEpisodeInfo, ISpeechInfo, Podcast
 import zeit.cms.content.dav
 import zeit.cms.content.interfaces
 import zeit.cms.content.metadata
@@ -77,31 +77,24 @@ class AudioType(zeit.cms.type.XMLContentTypeDeclaration):
 @grok.implementer(zeit.content.image.interfaces.IImages)
 def audio_image(context):
     if context.audio_type == 'podcast':
-        return PodcastImage(context)
+        info = IPodcastEpisodeInfo(context)
+        if info.podcast:
+            return zeit.content.image.interfaces.IImages(info.podcast)
     return zeit.content.image.imagereference.ImagesAdapter(context)
 
 
-@zope.interface.implementer(zeit.content.image.interfaces.IImages)
-class PodcastImage:
-    def __init__(self, context):
-        self.context = context
-
-    def _get_podcast(self):
-        if self.context.audio_type == 'podcast':
-            info = IPodcastEpisodeInfo(self.context)
-            return info.podcast
+@grok.implementer(zeit.content.image.interfaces.IImages)
+class PodcastImage(grok.Adapter):
+    grok.context(Podcast)
 
     @property
     def fill_color(self):
-        podcast = self._get_podcast()
-        if podcast:
-            return podcast.color
+        return self.context.color
 
     @property
     def image(self):
-        podcast = self._get_podcast()
-        if podcast and podcast.image:
-            return zeit.cms.interfaces.ICMSContent(podcast.image, None)
+        if self.context.image:
+            return zeit.cms.interfaces.ICMSContent(self.context.image, None)
 
 
 @grok.implementer(ISpeechInfo)

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -69,6 +69,7 @@ class IPodcast(zope.interface.Interface):
     rss_image = zope.schema.URI(title=_('rss_image'))
 
 
+@zope.interface.implementer(IPodcast)
 class Podcast(zeit.cms.content.sources.AllowedBase):
     def __init__(
         self,

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -55,6 +55,12 @@ class PodcastSourceTest(FunctionalTestCase):
         assert images.fill_color == 'e5ded8', (
             'Fill color should match color audio/tests/fixtures/podcasts.xml'
         )
+        podcast = zeit.content.audio.interfaces.IPodcastEpisodeInfo(audio).podcast
+        images = zeit.content.image.interfaces.IImages(podcast)
+        assert images.image.uniqueId == 'http://xml.zeit.de/2006/DSC00109_2.JPG'
+        assert images.fill_color == 'e5ded8', (
+            'Fill color should match color audio/tests/fixtures/podcasts.xml'
+        )
 
 
 class WorkflowTest(FunctionalTestCase):


### PR DESCRIPTION
Für das Thumbnail im Feed möchte ich das Bild sowohl vom Audio als auch vom Podcast Objekt holen können

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()