### PR TITLE
MAINT: Do not send retract request if text to speech player is deactivated

### DIFF
--- a/core/docs/changelog/tts-retract.maint
+++ b/core/docs/changelog/tts-retract.maint
@@ -1,0 +1,1 @@
+Do not send retract request if text to speech player is deactivated

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -363,6 +363,11 @@ class Speechbert(grok.Adapter, IgnoreMixin):
             payload['series'] = self.context.serie.serienname
         return {k: v for k, v in payload.items() if v}
 
+    def retract_json(self):
+        if self.context.audio_speechbert is False or self.ignore('retract'):
+            return None
+        return {}
+
 
 @grok.implementer(zeit.workflow.interfaces.IPublisherData)
 class TMS(grok.Adapter):


### PR DESCRIPTION
Aufgefallen bei Auswertung der TTS Events, das dort immer wieder AUDIO_DELETED erscheint von der Nachtwache obwohl kein TTS aktiviert und existiert