### PR TITLE
WCM-973: Use title from metadata for filename in @@edit-images

### DIFF
--- a/core/docs/changelog/WCM-973_meta_title_filename.change
+++ b/core/docs/changelog/WCM-973_meta_title_filename.change
@@ -1,0 +1,1 @@
+WCM-973: Use title from metadata for filename in @@edit-images if not uploading from an article etc.

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -123,6 +123,8 @@ class EditForm(zeit.cms.browser.view.Base):
         for name in filenames:
             imggroup = self.context[name]
 
+            meta = imggroup[imggroup.master_image].getXMPMetadata()
+
             if from_name:
                 while True:
                     suffix = ''
@@ -134,8 +136,11 @@ class EditForm(zeit.cms.browser.view.Base):
                     name_index += 1
                     if not self.context.get(name):
                         break
+            elif meta['title'] is not None:
+                name = zeit.cms.interfaces.normalize_filename(meta['title']) + '-bild'
+            else:
+                name = ''
 
-            meta = imggroup[imggroup.master_image].getXMPMetadata()
             result.append(
                 {
                     'cur_name': imggroup.__name__,

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -219,6 +219,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
+        assert b.getControl(name='name[0]').value == 'cycling-bel-renewi-bild'
         assert b.getControl(name='copyright[0]').value == 'DAVID PINTENS/Belga/AFP via Getty Images'
         assert (
             b.getControl(name='caption[0]').value
@@ -226,6 +227,11 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             + '"Renewi Tour" multi-stage cycling race'
         )
         assert b.getControl(name='title[0]').value == 'CYCLING-BEL-RENEWI'
+
+    def test_editimages_correctly_names_image_without_xmp(self):
+        b = self.browser
+        b.open('/repository/2007/03/@@edit-images?files=group')
+        assert b.getControl(name='name[0]').value == ''
 
     def test_editimages_correctly_names_multiple_images(self):
         b = self.browser


### PR DESCRIPTION
[WCM-973](https://zeit-online.atlassian.net/browse/WCM-973)
Jetzt gibt es automatisch eine Fehler wenn das Feld leer bleibt (das muss noch ne schöne Fehlermeldung werden).

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![giphy-132](https://github.com/user-attachments/assets/a2a86217-ad3d-4b8d-8664-03580ba01691)


[WCM-973]: https://zeit-online.atlassian.net/browse/WCM-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ