### PR TITLE
FIX: Correctly set copyright in @@edit-images

### DIFF
--- a/core/docs/changelog/copyright.fix
+++ b/core/docs/changelog/copyright.fix
@@ -1,0 +1,1 @@
+FIX: Correctly set copyright in imageupload

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -100,7 +100,7 @@ class EditForm(zeit.cms.browser.view.Base):
                 metadata = zeit.content.image.interfaces.IImageMetadata(imagegroup)
                 metadata.copyright = (
                     None,
-                    None,
+                    'Andere',
                     self.request.form[f'copyright[{index}]'],
                     None,
                     False,


### PR DESCRIPTION
Hardgecodet den Copyright-Holder auf Andere setzen. Sauberer wäre aus meiner Sicht, `None` zu nehmen und einen guten Default zu haben, aber das ist schwierig, da die Auswahl konfigurierbar ist.

### Checklist

- [ ] Documentation
- [x] Changelog
- [ ] Tests
- [ ] Translations

## GIF

![giphy-135](https://github.com/user-attachments/assets/932aaf56-3efb-480a-8e99-d7e992f1fe56)
