### PR TITLE
Fix/faulty parameter name

### DIFF
--- a/core/docs/changelog/ENG-232.change
+++ b/core/docs/changelog/ENG-232.change
@@ -1,0 +1,1 @@
+ENG-232: fix faulty parameter name in publisher"

--- a/core/src/zeit/workflow/publish_3rdparty.py
+++ b/core/src/zeit/workflow/publish_3rdparty.py
@@ -523,4 +523,4 @@ class Followings(grok.Adapter, IgnoreMixin):
             f'{zeit.cms.interfaces.ID_NAMESPACE}serie/{article.serie.url}'
         )
         series = zeit.cms.content.interfaces.IUUID(series_content).shortened
-        return {'parent_id': series}
+        return {'parent_uuid': series}

--- a/core/src/zeit/workflow/tests/test_publish_3rdparty.py
+++ b/core/src/zeit/workflow/tests/test_publish_3rdparty.py
@@ -656,4 +656,4 @@ class FollowingsPayloadTest(zeit.workflow.testing.FunctionalTestCase):
         expected_uuid = zeit.cms.content.interfaces.IUUID(cp).shortened
 
         data = zeit.workflow.testing.publish_json(article, 'followings')
-        self.assertEqual(data['parent_id'], expected_uuid)
+        self.assertEqual(data['parent_uuid'], expected_uuid)


### PR DESCRIPTION
### Checklist

Leider war der Parameter Name falsch. Ich habe ihn von `parent_id` auf `parent_uuid` geändert. Sorry.

### gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTlhdDhjaWxkNGJkcGUybDN4bTlraXA3aDdnMGZrOTZ1NnNsYmwyYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FaMmrCXe5zx2QZfkh6/giphy.gif)