### PR TITLE
WCM-999: premium audio does not change article header automatically to podcast

### DIFF
--- a/core/docs/changelog/wcm-999.change
+++ b/core/docs/changelog/wcm-999.change
@@ -1,0 +1,1 @@
+WCM-999: premium audio does not change article header automatically

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -379,11 +379,11 @@ def set_podcast_header_when_article_has_podcast_audio(context, event):
     if not audio.items:
         return
 
-    context.header_layout = 'podcast'
-
     main_audio = audio.items[0]
     if main_audio.audio_type != 'podcast':
         return
+
+    context.header_layout = 'podcast'
 
     if not context.title:
         context.title = main_audio.title

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -477,7 +477,7 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         AudioBuilder().with_audio_type('premium').build(self.repository)
         self._add_audio_to_article()
 
-        assert 'podcast' == self.article.header_layout
+        assert 'default' == self.article.header_layout
         assert self.audio.title != self.article.title
         assert self.info.summary != self.article.teaserText
         assert len(self.article.body.values()) == 1, (

--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -441,12 +441,12 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
                 )
             )
         # without items, no changes
-        assert 'podcast' != self.article.header_layout
+        assert self.article.header_layout != 'podcast'
 
     def test_podcast_updates_article_information(self):
         self._add_audio_to_article()
 
-        assert 'podcast' == self.article.header_layout
+        assert self.article.header_layout == 'podcast'
         assert self.audio.title == self.article.title
         assert self.audio.title == self.article.teaserTitle
         assert self.info.summary == self.article.teaserText
@@ -466,7 +466,7 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         )
         self._add_audio_to_article()
 
-        assert 'podcast' == self.article.header_layout
+        assert self.article.header_layout == 'podcast'
         assert self.audio.title != self.article.title
         assert self.audio.title != self.article.teaserTitle
         assert self.info.summary != self.article.teaserText
@@ -477,7 +477,7 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         AudioBuilder().with_audio_type('premium').build(self.repository)
         self._add_audio_to_article()
 
-        assert 'default' == self.article.header_layout
+        assert self.article.header_layout == 'default'
         assert self.audio.title != self.article.title
         assert self.info.summary != self.article.teaserText
         assert len(self.article.body.values()) == 1, (


### PR DESCRIPTION
…

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExenE2dHViZTdwbG9jOTVqZXFpNzE1YXB1bDVobmV2OTVwajZ3N25xNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IYIlvuWc21U4g/giphy.gif)