### PR TITLE
ES-275: Add release_frequency & contact_email attributes to Podcast

### DIFF
--- a/core/docs/changelog/ES-275.change
+++ b/core/docs/changelog/ES-275.change
@@ -1,0 +1,1 @@
+ES-275: Add release_frequency & contact_email attributes to Podcast

--- a/core/src/zeit/content/audio/interfaces.py
+++ b/core/src/zeit/content/audio/interfaces.py
@@ -67,6 +67,8 @@ class IPodcast(zope.interface.Interface):
     category = zope.interface.Attribute('category')
     podcast_type = zope.schema.Choice(title=_('Type'), readonly=True, source=PodcastTypeSource())
     rss_image = zope.schema.URI(title=_('rss_image'))
+    release_frequency = zope.interface.Attribute('release_frequency')
+    contact_email = zope.interface.Attribute('contact_email')
 
 
 @zope.interface.implementer(IPodcast)
@@ -86,6 +88,8 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         category=None,
         podcast_type=None,
         rss_image=None,
+        release_frequency=None,
+        contact_email=None,
     ):
         super().__init__(id, title, available=None)
         self.external_id = external_id
@@ -101,6 +105,8 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
         self.category = category
         self.podcast_type = podcast_type
         self.rss_image = rss_image
+        self.release_frequency = release_frequency
+        self.contact_email = contact_email
 
     def __eq__(self, other):
         return (
@@ -118,6 +124,8 @@ class Podcast(zeit.cms.content.sources.AllowedBase):
             and self.category == other.category
             and self.podcast_type == other.podcast_type
             and self.rss_image == other.rss_image
+            and self.release_frequency == other.release_frequency
+            and self.contact_email == other.contact_email
         )
 
 
@@ -153,6 +161,8 @@ class PodcastSource(zeit.cms.content.sources.ObjectSource, zeit.cms.content.sour
             node.get('category'),
             node.get('podcast_type'),
             node.get('rss_image'),
+            node.get('release_frequency'),
+            node.get('contact_email'),
         )
         return podcast
 

--- a/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
+++ b/core/src/zeit/content/audio/tests/fixtures/podcasts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <podcasts>
-    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_' explicit='True' category='News' author='Author Mc Cat Face' podcast_type='serial' rss_image="https://rss_image">
+    <podcast id="cat-jokes-pawdcast" title="Cat Jokes Pawdcast" external_id="1234" subtitle="A podcast of cat jokes" color='e5ded8' image='http://xml.zeit.de/2006/DSC00109_2.JPG' feed='https://feeds.example.com/aRDC72E_' explicit='True' category='News' author='Author Mc Cat Face' podcast_type='serial' rss_image="https://rss_image" release_frequency="Every Meowday" contact_email="pawdcast@example.com">
         <distribution_channel id="itunes" href="http://example.com/itunes">Apple Podcasts</distribution_channel>
         <distribution_channel id="google" href="http://example.com/google">Google Podcasts</distribution_channel>
     </podcast>

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -39,6 +39,8 @@ class PodcastSourceTest(FunctionalTestCase):
             'News',
             'serial',
             'https://rss_image',
+            'Every Meowday',
+            'pawdcast@example.com',
         )
         assert values[0] == podcast
 


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/ES-275

Ermöglicht zwei neue Attribute an Podcast-Objekten in der `podcasts.xml`:

- `release_frequency` – optionales Freitextfeld für die Erscheinungsfrequenz eines Podcasts (kann aber auch z.B. "Dokupodcast in 8 Episoden" sein, das ist gewollt und okay)
- `contact_email` – optionales Freitextfeld für eine Kontakt-Email der Podcastmacher:innen (keine Validierung der Email)

✅  Wording der Attribute ist auch von der Redaktion bestätigt.

Ursprünglich war auch noch ein Attribut `genres` angedacht, das soll aber komplexer ausgestaltet werden als nur eine einfache String-Liste, daher lassen wir das bis zur Implementierung eines Podcast-Contentobjekts außen vor.

### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~

### gif

<img width="300" src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldWlrOWw0b2Y5c2xkZHp0ODJlMGN4N3F4N3FkbTBvdjN5OGFmMG0xeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/25UxpWoNBu8nOtURm9/giphy.gif"/>