### PR TITLE
MAINT: use AudioBuilder for audio tests

### DIFF
--- a/core/src/zeit/content/article/tests/test_article.py
+++ b/core/src/zeit/content/article/tests/test_article.py
@@ -411,14 +411,14 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         self.article = self.get_article()
         self.article.title = ''
         self.article.body.create_item('image')
-        self.audio = AudioBuilder().build(self.repository)
+        self.audio = AudioBuilder().build()
         self.info = zeit.content.audio.interfaces.IPodcastEpisodeInfo(self.audio)
 
     def test_filter_audios_by_audio_type(self):
         self.repository['article'] = self.article
-        tts = AudioBuilder().with_audio_type('tts').build(self.repository, 'tts')
-        pc1 = AudioBuilder().with_audio_type('podcast').build(self.repository, 'pc1')
-        pc2 = AudioBuilder().with_audio_type('podcast').build(self.repository, 'pc2')
+        tts = AudioBuilder().with_audio_type('tts').unique_id('http://xml.zeit.de/tts').build()
+        pc1 = AudioBuilder().with_audio_type('podcast').unique_id('http://xml.zeit.de/pc1').build()
+        pc2 = AudioBuilder().with_audio_type('podcast').unique_id('http://xml.zeit.de/pc2').build()
         audios_refs = zeit.content.audio.interfaces.IAudioReferences(self.article)
         audios_refs.add(tts)
         audios_refs.add(pc1)
@@ -474,7 +474,7 @@ class AudioArticle(zeit.content.article.testing.FunctionalTestCase):
         assert self.info.podcast.id != self.article.serie.url
 
     def test_other_than_podcast_type_does_not_edit_content(self):
-        AudioBuilder().with_audio_type('premium').build(self.repository)
+        AudioBuilder().with_audio_type('premium').build()
         self._add_audio_to_article()
 
         assert self.article.header_layout == 'default'

--- a/core/src/zeit/content/audio/browser/tests/test_audio.py
+++ b/core/src/zeit/content/audio/browser/tests/test_audio.py
@@ -5,7 +5,7 @@ from zeit.content.audio.testing import AudioBuilder, BrowserTestCase
 
 class AudioObjectDetails(BrowserTestCase):
     def test_displays_details(self):
-        audio = AudioBuilder().build(self.repository)
+        audio = AudioBuilder().build()
         b = self.browser
         b.open('/repository/audio/@@object-details')
         self.assert_ellipsis(
@@ -23,7 +23,7 @@ class AudioObjectDetails(BrowserTestCase):
     def test_displays_additional_info_only_if_available(self):
         AudioBuilder().with_duration(0).with_url('').with_title('mytitle').with_audio_type(
             'tts'
-        ).build(self.repository)
+        ).build()
         b = self.browser
         b.open('/repository/audio/@@object-details')
         self.assert_ellipsis(
@@ -38,7 +38,7 @@ class AudioObjectDetails(BrowserTestCase):
         )
 
     def test_cannot_delete_if_permissions_missing(self):
-        AudioBuilder().build(self.repository)
+        AudioBuilder().build()
         b = self.browser
         b.open('/repository/audio')
         with self.assertRaises(LinkNotFoundError):
@@ -49,10 +49,8 @@ class AudioObjectDetails(BrowserTestCase):
             (1500, '25:00'),
             (7512, '02:05:12'),
         ]
-        audio = AudioBuilder().build(self.repository)
         for duration, expected in test_cases:
-            audio.duration = duration
-            self.repository['audio'] = audio
+            AudioBuilder().with_duration(duration).build()
             b = self.browser
             b.open('/repository/audio/@@object-details')
             self.assert_ellipsis(f'...<dd>{expected}</dd>...', b.contents)

--- a/core/src/zeit/content/audio/browser/tests/test_audioupdate.py
+++ b/core/src/zeit/content/audio/browser/tests/test_audioupdate.py
@@ -8,14 +8,14 @@ import zeit.simplecast.testing
 
 class AudioUpdateTest(BrowserTestCase):
     def test_request_audio_update_unavailable_to_normal_user(self):
-        AudioBuilder().build(self.repository)
+        AudioBuilder().build()
         browser = self.browser
         browser.login('user', 'userpw')
         browser.open('/repository/audio')
         self.assertNotIn('Update audio from simplecast', browser.contents)
 
     def test_request_audio_update_unavailable_for_checked_out_object(self):
-        AudioBuilder().build(self.repository)
+        AudioBuilder().build()
         browser = self.browser
         browser.login('producer', 'producerpw')
         browser.open('/repository/audio')
@@ -24,7 +24,7 @@ class AudioUpdateTest(BrowserTestCase):
         self.assertNotIn('Update audio from simplecast', browser.contents)
 
     def test_audio_is_updated(self):
-        audio = AudioBuilder().build(self.repository)
+        audio = AudioBuilder().build()
         simplecast = zope.component.getUtility(zeit.simplecast.interfaces.ISimplecast)
         simplecast.fetch_episode.return_value = zeit.simplecast.testing.EPISODE_200
         browser = self.browser
@@ -36,7 +36,7 @@ class AudioUpdateTest(BrowserTestCase):
         simplecast.publish.assert_called_once()
 
     def test_simplecast_request_failed_displays_error(self):
-        AudioBuilder().build(self.repository)
+        AudioBuilder().build()
         simplecast = zope.component.getUtility(zeit.simplecast.interfaces.ISimplecast)
         simplecast.fetch_episode.return_value = {}
         browser = self.browser

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -2,9 +2,15 @@ from functools import partialmethod
 from typing import Optional, TypeVar
 import importlib.resources
 
-from zeit.cms.repository.interfaces import IRepository
+from zeit.cms.repository.interfaces import IFolder, IRepository
+from zeit.content.article.interfaces import IArticle
 from zeit.content.audio.audio import Audio
-from zeit.content.audio.interfaces import IPodcastEpisodeInfo, ISpeechInfo, Podcast
+from zeit.content.audio.interfaces import (
+    IAudioReferences,
+    IPodcastEpisodeInfo,
+    ISpeechInfo,
+    Podcast,
+)
 import zeit.cms.testing
 import zeit.content.image.testing
 
@@ -76,7 +82,10 @@ class AudioBuilder:
         raise ValueError(f'Unknown attribute {attribute_name}')
 
     def build(
-        self, repository: Optional[IRepository] = None, unique_id: Optional[str] = 'audio'
+        self,
+        repository: Optional[IRepository | IFolder] = None,
+        unique_id: Optional[str] = 'audio',
+        reference: Optional[IArticle] = None,
     ) -> Audio:
         audio = Audio()
         audio_type = self.attributes['audio']['audio_type']
@@ -93,6 +102,10 @@ class AudioBuilder:
                 setattr(tts, attribute, value)
         if repository is not None:
             repository[unique_id] = audio
+
+        if reference:
+            references = IAudioReferences(reference)
+            references.add(audio)
 
         return audio
 

--- a/core/src/zeit/content/audio/testing.py
+++ b/core/src/zeit/content/audio/testing.py
@@ -1,8 +1,8 @@
 from functools import partialmethod
-from typing import Optional, TypeVar
+from typing import TypeVar
 import importlib.resources
 
-from zeit.cms.repository.interfaces import IFolder, IRepository
+from zeit.cms.checkout.helper import checked_out
 from zeit.content.article.interfaces import IArticle
 from zeit.content.audio.audio import Audio
 from zeit.content.audio.interfaces import (
@@ -46,6 +46,9 @@ class AudioBuilder:
         >>> AudioBuilder().with_title('foo').build()
     """
 
+    reference = None
+    _unique_id = 'http://xml.zeit.de/audio'
+
     def __init__(self):
         self.attributes = {
             'audio': {
@@ -81,12 +84,15 @@ class AudioBuilder:
                 return self
         raise ValueError(f'Unknown attribute {attribute_name}')
 
-    def build(
-        self,
-        repository: Optional[IRepository | IFolder] = None,
-        unique_id: Optional[str] = 'audio',
-        reference: Optional[IArticle] = None,
-    ) -> Audio:
+    def referenced_by(self, article: IArticle):
+        self.reference = article
+        return self
+
+    def unique_id(self, unique_id: str):
+        self._unique_id = unique_id
+        return self
+
+    def build(self) -> Audio:
         audio = Audio()
         audio_type = self.attributes['audio']['audio_type']
         for attribute, value in self.attributes['audio'].items():
@@ -100,12 +106,19 @@ class AudioBuilder:
             audio.external_id = ''
             for attribute, value in self.attributes[audio_type].items():
                 setattr(tts, attribute, value)
-        if repository is not None:
-            repository[unique_id] = audio
 
-        if reference:
-            references = IAudioReferences(reference)
-            references.add(audio)
+        unique_id_components = self._unique_id.split('/')
+        container_url = '/'.join(unique_id_components[:-1]) + '/'
+        container = zeit.cms.interfaces.ICMSContent(container_url)
+        name = unique_id_components[-1]
+
+        container[name] = audio
+        audio = container[name]
+
+        if self.reference:
+            with checked_out(self.reference, raise_if_error=True) as co:
+                references = IAudioReferences(co)
+                references.add(audio)
 
         return audio
 

--- a/core/src/zeit/content/audio/tests/test_audio.py
+++ b/core/src/zeit/content/audio/tests/test_audio.py
@@ -51,7 +51,7 @@ class PodcastSourceTest(FunctionalTestCase):
         self.assertEqual((), audio.authorships)
 
     def test_get_podcast_image(self):
-        audio = AudioBuilder().build(self.repository)
+        audio = AudioBuilder().build()
         images = zeit.content.image.interfaces.IImages(audio)
         assert images.image.uniqueId == 'http://xml.zeit.de/2006/DSC00109_2.JPG'
         assert images.fill_color == 'e5ded8', (
@@ -67,19 +67,19 @@ class PodcastSourceTest(FunctionalTestCase):
 
 class WorkflowTest(FunctionalTestCase):
     def test_podcast_not_published_if_requirements_not_met_url(self):
-        audio = AudioBuilder().with_url('').build(self.repository)
+        audio = AudioBuilder().with_url('').build()
         workflow = zeit.cms.workflow.interfaces.IPublishInfo(audio)
         assert workflow.can_publish() == zeit.cms.workflow.interfaces.CAN_PUBLISH_ERROR
         assert 'Audio URL is missing' in workflow.error_messages[0]
 
     def test_podcast_not_published_if_requirements_not_met_is_published(self):
-        audio = AudioBuilder().with_is_published(False).build(self.repository)
+        audio = AudioBuilder().with_is_published(False).build()
         workflow = zeit.cms.workflow.interfaces.IPublishInfo(audio)
         assert workflow.can_publish() == zeit.cms.workflow.interfaces.CAN_PUBLISH_ERROR
         assert 'Podcast Episode is not published by Provider' in workflow.error_messages[0]
 
     def test_podcast_not_retracted_if_requirements_not_met_is_not_published(self):
-        audio = AudioBuilder().build(self.repository)
+        audio = AudioBuilder().build()
         workflow = zeit.cms.workflow.interfaces.IPublishInfo(audio)
         assert workflow.can_retract() == zeit.cms.workflow.interfaces.CAN_RETRACT_ERROR
         assert 'Podcast Episode is published by Provider' in workflow.error_messages[0]
@@ -90,7 +90,7 @@ class SpeechTest(FunctionalTestCase):
         super().setUp()
         article = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
         uuid = zeit.cms.content.interfaces.IUUID(article).shortened
-        AudioBuilder().with_audio_type('tts').with_article_uuid(uuid).build(self.repository)
+        AudioBuilder().with_audio_type('tts').with_article_uuid(uuid).build()
 
     def test_create_tts_audio(self):
         article = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')

--- a/core/src/zeit/entitlements/tests/test_entitlements.py
+++ b/core/src/zeit/entitlements/tests/test_entitlements.py
@@ -1,6 +1,5 @@
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
-from zeit.content.audio.interfaces import IAudioReferences
 from zeit.content.audio.testing import AudioBuilder
 import zeit.entitlements
 import zeit.entitlements.testing
@@ -34,10 +33,10 @@ class Entitlements(zeit.entitlements.testing.FunctionalTestCase):
         self.assertEqual({'wochenmarkt', 'zplus'}, zeit.entitlements.accepted(self.content))
 
     def test_podcast_audio_reference_adds_entitlement(self):
-        audio = AudioBuilder().build(self.repository)
-        with checked_out(self.repository['testcontent']) as co:
+        content = self.repository['testcontent']
+        AudioBuilder().referenced_by(content).build()
+        with checked_out(content) as co:
             co.access = 'abo'
-            IAudioReferences(co).add(audio)
         self.assertEqual(
             {'podcast', 'zplus'}, zeit.entitlements.accepted(self.repository['testcontent'])
         )

--- a/core/src/zeit/mediaservice/tests/test_mediaservice.py
+++ b/core/src/zeit/mediaservice/tests/test_mediaservice.py
@@ -5,6 +5,7 @@ from zeit.cms.checkout.helper import checked_out
 from zeit.cms.workflow.interfaces import IPublishInfo
 from zeit.content.article.article import Article
 from zeit.content.article.interfaces import IArticle
+from zeit.content.audio.testing import AudioBuilder
 import zeit.cms.content.field
 import zeit.cms.content.sources
 import zeit.cms.interfaces
@@ -114,11 +115,7 @@ class TestVolumeArticleAudios(zeit.mediaservice.testing.SQLTestCase):
         article_uuid = zeit.cms.content.interfaces.IUUID(article).shortened
         audio_folder = zeit.cms.content.add.find_or_create_folder('premium', 'audio', '2025', '01')
 
-        audio = zeit.content.audio.audio.Audio()
-        audio.audio_type = 'premium'
-        audio_folder[article_uuid] = audio
-        references = zeit.content.audio.interfaces.IAudioReferences(article)
-        references.add(audio_folder[article_uuid])
+        AudioBuilder().with_audio_type('premium').build(audio_folder, article_uuid, article)
         zeit.mediaservice.mediaservice.create_audio_objects(volume.uniqueId)
         transaction.commit()
 
@@ -141,9 +138,7 @@ class TestVolumeArticleAudios(zeit.mediaservice.testing.SQLTestCase):
         article_uuid = zeit.cms.content.interfaces.IUUID(article).shortened
         audio_folder = zeit.cms.content.add.find_or_create_folder('premium', 'audio', '2025', '01')
 
-        audio = zeit.content.audio.audio.Audio()
-        audio.audio_type = 'custom'  # This is just used as a marker
-        audio_folder[article_uuid] = audio
+        AudioBuilder().with_audio_type('custom').build(audio_folder, article_uuid, article)
         zeit.mediaservice.mediaservice.create_audio_objects(volume.uniqueId)
         assert audio_folder[article_uuid].audio_type == 'custom'
 
@@ -153,13 +148,11 @@ class TestVolumeArticleAudios(zeit.mediaservice.testing.SQLTestCase):
         article_uuid = zeit.cms.content.interfaces.IUUID(article).shortened
         audio_folder = zeit.cms.content.add.find_or_create_folder('premium', 'audio', '2025', '01')
 
-        audio = zeit.content.audio.audio.Audio()
-        audio.audio_type = 'premium'
-        audio_folder[article_uuid] = audio
+        audio = AudioBuilder().with_audio_type('premium').build(audio_folder, article_uuid)
         with checked_out(article, raise_if_error=True) as co:
             co.has_audio = True
             references = zeit.content.audio.interfaces.IAudioReferences(co)
-            references.add(audio_folder[article_uuid])
+            references.add(audio)
 
         transaction.commit()
         with checked_out(article, raise_if_error=True) as co:

--- a/core/src/zeit/retresco/tests/test_content.py
+++ b/core/src/zeit/retresco/tests/test_content.py
@@ -191,7 +191,7 @@ class ContentTest(zeit.retresco.testing.FunctionalTestCase):
         self.assertEqual(3, kpi.subscriptions)
 
     def test_convert_tms_result_with_audio_to_cmscontent(self):
-        audio = zeit.content.audio.testing.AudioBuilder().build(self.repository)
+        audio = zeit.content.audio.testing.AudioBuilder().build()
         article = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
         with checked_out(article) as co:
             audios = IAudioReferences

--- a/core/src/zeit/retresco/tests/test_convert.py
+++ b/core/src/zeit/retresco/tests/test_convert.py
@@ -476,11 +476,8 @@ class ConvertTest(zeit.retresco.testing.FunctionalTestCase):
         )
 
     def test_converts_article_with_audio(self):
-        audio = zeit.content.audio.testing.AudioBuilder().build(self.repository)
         article = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
-        with checked_out(article) as co:
-            audios = zeit.content.audio.interfaces.IAudioReferences
-            audios(co).items = (self.repository['audio'],)
+        audio = zeit.content.audio.testing.AudioBuilder().referenced_by(article).build()
         article = zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/Somalia')
         data = zeit.retresco.interfaces.ITMSRepresentation(article)()
         assert data['payload']['head']['audio_references'] == [audio.uniqueId]

--- a/core/src/zeit/speech/tests/test_connection.py
+++ b/core/src/zeit/speech/tests/test_connection.py
@@ -125,10 +125,7 @@ class TestSpeech(FunctionalTestCase):
         audio = self.create_audio(TTS_CREATED)
         assert IAudioReferences(ICMSContent(self.article_uid)).items == (audio,)
         self.repository.connector.search_result = [(self.article.uniqueId)]
-        podcast = AudioBuilder().build(self.repository)
-        with checked_out(self.article) as co:
-            references = IAudioReferences(co)
-            references.add(podcast)
+        podcast = AudioBuilder().referenced_by(self.article).build()
         assert IAudioReferences(ICMSContent(self.article_uid)).items == (audio, podcast)
         self.repository.connector.search_result = [(self.article_uid)]
         with mock.patch('zeit.speech.connection.Speech._find', return_value=audio):
@@ -138,7 +135,7 @@ class TestSpeech(FunctionalTestCase):
         assert audio.items == (podcast,)
 
     def test_unable_to_remove_anything_because_article_is_missing(self):
-        audio = AudioBuilder().with_audio_type('tts').build(self.repository)
+        audio = AudioBuilder().with_audio_type('tts').build()
         self.repository.connector.search_result = []
         with mock.patch('zeit.speech.connection.Speech._find', return_value=audio):
             Speech().delete(TTS_DELETED)


### PR DESCRIPTION
Keep audio tests somehow consistent beyond the different type of audio tests
