### PR TITLE
ENG-344: add`author` to followings

### DIFF
--- a/core/docs/changelog/ENG-344.change
+++ b/core/docs/changelog/ENG-344.change
@@ -1,0 +1,1 @@
+ENG-344: send author to publisher in followings


### PR DESCRIPTION
### Beschreibung
Ticket: [ENG-344](https://zeit-online.atlassian.net/browse/ENG-344)

Dieser PR (der letzte der Following-Reihe), fügt zu `series` und `podcast` auch noch Author hinzu. Da eine Serie mehrere Autoren haben kann, und die `parent_uuid` sowohl auf Autoren als auch Serien zutrifft, wird sie nun als Array gesendet. Daher muss der Publisher auch nochmal kurz angepasst werden.

[ENG-344]: https://zeit-online.atlassian.net/browse/ENG-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Test
`bin/test -k test_followings_`

### Gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXU5YjFqMGhoaHozdmc0YzZxZWszd3VsZjlhanc3MWp2ZDFzbXBtOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JrRuA6pRwv1KlxrYQX/giphy.gif)