### PR TITLE
WCM-1070: Normalize target file names in new image upload

### DIFF
--- a/core/docs/changelog/WCM-1070_normalize_filenames.change
+++ b/core/docs/changelog/WCM-1070_normalize_filenames.change
@@ -1,0 +1,1 @@
+WCM-1070: Normalize target file names in new image upload

--- a/core/src/zeit/content/image/browser/imageupload.edit-images.pt
+++ b/core/src/zeit/content/image/browser/imageupload.edit-images.pt
@@ -3,9 +3,9 @@
     <table class="edit-image-table">
       <tr><th></th><th i18n:translate="">Filename</th><th i18n:translate="">Copyright</th><th i18n:translate="">Title</th><th i18n:translate="">Caption</th></tr>
       <tr tal:repeat="item view/rows">
-        <td><img tal:attributes="src item/thumbnail"><input type="hidden" tal:attributes="value item/cur_name; name string:cur_name[${repeat/item/index}]" /></td>
+        <td><img tal:attributes="src item/thumbnail"><input type="hidden" tal:attributes="value item/tmp_name; name string:tmp_name[${repeat/item/index}]" /></td>
         <td>
-            <input tal:attributes="value item/name; name string:name[${repeat/item/index}]" required="required">
+            <input tal:attributes="value item/target_name; name string:target_name[${repeat/item/index}]" required="required">
             <div class="error" tal:condition="item/error">
                 <span class="error" tal:content="item/error"></span>
             </div>

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -121,8 +121,9 @@ class EditForm(zeit.cms.browser.view.Base):
         for file in self._files:
             tmp_name = file['tmp_name']
             name = file['target_name']
-            if name != tmp_name:
-                renamer.renameItem(tmp_name, name)
+            # Since tmp_name ends with '.tmp', and target_name is normalized
+            # (which replaces the '.' with '-'), the two always differ.
+            renamer.renameItem(tmp_name, name)
             with zeit.cms.checkout.helper.checked_out(
                 self.context[name], temporary=False, raise_if_error=True
             ) as imagegroup:

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -187,9 +187,12 @@ class EditForm(zeit.cms.browser.view.Base):
         index = 0
         while f'tmp_name[{index}]' in self.request.form:
             tmp_name = self.request.form[f'tmp_name[{index}]']
+            target_name = zeit.cms.interfaces.normalize_filename(
+                self.request.form[f'target_name[{index}]']
+            )
             yield {
                 'tmp_name': tmp_name,
-                'target_name': self.request.form[f'target_name[{index}]'],
+                'target_name': target_name,
                 'title': self.request.form[f'title[{index}]'],
                 'copyright': self.request.form[f'copyright[{index}]'],
                 'caption': self.request.form[f'caption[{index}]'],

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -102,27 +102,27 @@ class EditForm(zeit.cms.browser.view.Base):
 
     def handle_cancel(self):
         for file in self._files:
-            del self.context[file['cur_name']]
+            del self.context[file['tmp_name']]
         self.redirect(self.url(name=''), status=303)
 
     def handle_submit(self):
         renamer = zope.copypastemove.interfaces.IContainerItemRenamer(self.context)
         taken_names = set()
         for file in self._files:
-            if (file['name'] != file['cur_name'] and file['name'] in self.context) or (
-                file['name'] in taken_names
-            ):
-                self._errors[file['cur_name']] = _('File name is already in use')
-            taken_names.add(file['name'])
+            if (
+                file['target_name'] != file['tmp_name'] and file['target_name'] in self.context
+            ) or (file['target_name'] in taken_names):
+                self._errors[file['tmp_name']] = _('File name is already in use')
+            taken_names.add(file['target_name'])
 
         if self._errors:
             return super().__call__()
 
         for file in self._files:
-            cur_name = file['cur_name']
-            name = file['name']
-            if name != cur_name:
-                renamer.renameItem(cur_name, name)
+            tmp_name = file['tmp_name']
+            name = file['target_name']
+            if name != tmp_name:
+                renamer.renameItem(tmp_name, name)
             with zeit.cms.checkout.helper.checked_out(
                 self.context[name], temporary=False, raise_if_error=True
             ) as imagegroup:
@@ -141,7 +141,7 @@ class EditForm(zeit.cms.browser.view.Base):
                 ).renameable = False
 
         if len(self._files) == 1:
-            url = self.url(self.context[self._files[0]['name']], name='@@variant.html')
+            url = self.url(self.context[self._files[0]['target_name']], name='@@variant.html')
         else:
             url = self.url(name='')
         self.redirect(url, status=303)
@@ -152,8 +152,8 @@ class EditForm(zeit.cms.browser.view.Base):
         if isinstance(filenames, str):
             filenames = (filenames,)
         name_index = 1
-        for name in filenames:
-            imggroup = self.context[name]
+        for tmp_name in filenames:
+            imggroup = self.context[tmp_name]
 
             meta = imggroup[imggroup.master_image].getXMPMetadata()
 
@@ -175,8 +175,8 @@ class EditForm(zeit.cms.browser.view.Base):
                 name = ''
 
             yield {
-                'cur_name': imggroup.__name__,
-                'name': name,
+                'tmp_name': tmp_name,
+                'target_name': name,
                 'title': meta['title'],
                 'copyright': meta['copyright'],
                 'caption': meta['caption'],
@@ -185,21 +185,20 @@ class EditForm(zeit.cms.browser.view.Base):
 
     def _parse_post_request(self):
         index = 0
-        while f'cur_name[{index}]' in self.request.form:
-            cur_name = self.request.form[f'cur_name[{index}]']
-            name = self.request.form[f'name[{index}]']
+        while f'tmp_name[{index}]' in self.request.form:
+            tmp_name = self.request.form[f'tmp_name[{index}]']
             yield {
-                'cur_name': cur_name,
-                'name': name,
+                'tmp_name': tmp_name,
+                'target_name': self.request.form[f'target_name[{index}]'],
                 'title': self.request.form[f'title[{index}]'],
                 'copyright': self.request.form[f'copyright[{index}]'],
                 'caption': self.request.form[f'caption[{index}]'],
-                'thumbnail': self.url(self.context[cur_name], 'thumbnail'),
+                'thumbnail': self.url(self.context[tmp_name], 'thumbnail'),
             }
             index += 1
 
     def rows(self):
         for file in self._files:
             res = dict(file)
-            res['error'] = self._errors.get(file['cur_name'], False)
+            res['error'] = self._errors.get(file['tmp_name'], False)
             yield res

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -238,7 +238,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         )
         b.getForm(name='imageupload').submit()
         b.getForm(name='edit-images').submit()
-        self.assertEndsWith('/repository/online/2007/01/Somalia-bild/@@variant.html', b.url)
+        self.assertEndsWith('/repository/online/2007/01/somalia-bild/@@variant.html', b.url)
 
     def test_editimages_correctly_names_single_image_for_article_that_clashes_with_existing_image(
         self,
@@ -374,7 +374,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         self.assertTrue('required' in b.getControl(name='target_name[0]')._elem.attrs)
 
     def test_editimages_shows_error_on_used_file_name(self):
-        self.repository['online']['2007']['01']['Somalia-bild'] = (
+        self.repository['online']['2007']['01']['somalia-bild'] = (
             zeit.content.image.imagegroup.ImageGroup()
         )
         b = self.browser
@@ -393,7 +393,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         b.getForm(name='imageupload').submit()
         b.getControl(name='target_name[0]').value = 'Somalia-bild'
         b.getForm(name='edit-images').submit()
-        self.assertEqual(b.getControl(name='target_name[0]').value, 'Somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[0]').value, 'somalia-bild')
         self.assertEllipsis(
             '...<span class="error">File name is already in use</span>...', b.contents
         )
@@ -422,8 +422,8 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         b.getControl(name='target_name[0]').value = 'Somalia-bild'
         b.getControl(name='target_name[1]').value = 'Somalia-bild'
         b.getForm(name='edit-images').submit()
-        self.assertEqual(b.getControl(name='target_name[0]').value, 'Somalia-bild')
-        self.assertEqual(b.getControl(name='target_name[1]').value, 'Somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[0]').value, 'somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[1]').value, 'somalia-bild')
         self.assertEllipsis(
             '...<span class="error">File name is already in use</span>...', b.contents
         )

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -220,7 +220,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'Somalia-bild'
+        assert b.getControl(name='target_name[0]').value == 'Somalia-bild'
 
     def test_editimages_redirects_to_single_image(self):
         b = self.browser
@@ -260,7 +260,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'Somalia-bild-2'
+        assert b.getControl(name='target_name[0]').value == 'Somalia-bild-2'
 
     def test_editimages_correctly_names_single_image_that_clashes_with_existing_image(self):
         self.repository['cycling-bel-renewi-bild'] = zeit.content.image.imagegroup.ImageGroup()
@@ -278,7 +278,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'cycling-bel-renewi-bild-2'
+        assert b.getControl(name='target_name[0]').value == 'cycling-bel-renewi-bild-2'
 
     def test_editimages_correctly_shows_xmp_data(self):
         b = self.browser
@@ -295,7 +295,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'cycling-bel-renewi-bild'
+        assert b.getControl(name='target_name[0]').value == 'cycling-bel-renewi-bild'
         assert b.getControl(name='copyright[0]').value == 'DAVID PINTENS/Belga/AFP via Getty Images'
         assert (
             b.getControl(name='caption[0]').value
@@ -307,7 +307,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
     def test_editimages_correctly_names_image_without_xmp(self):
         b = self.browser
         b.open('/repository/2007/03/@@edit-images?files=group')
-        assert b.getControl(name='name[0]').value == ''
+        assert b.getControl(name='target_name[0]').value == ''
 
     def test_editimages_correctly_names_multiple_images(self):
         b = self.browser
@@ -325,8 +325,8 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'Somalia-bild-1'
-        assert b.getControl(name='name[1]').value == 'Somalia-bild-2'
+        assert b.getControl(name='target_name[0]').value == 'Somalia-bild-1'
+        assert b.getControl(name='target_name[1]').value == 'Somalia-bild-2'
 
     def test_editimages_correctly_names_many_images(self):
         b = self.browser
@@ -352,9 +352,9 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        assert b.getControl(name='name[0]').value == 'Somalia-bild-01'
-        assert b.getControl(name='name[1]').value == 'Somalia-bild-02'
-        assert b.getControl(name='name[9]').value == 'Somalia-bild-10'
+        assert b.getControl(name='target_name[0]').value == 'Somalia-bild-01'
+        assert b.getControl(name='target_name[1]').value == 'Somalia-bild-02'
+        assert b.getControl(name='target_name[9]').value == 'Somalia-bild-10'
 
     def test_editimages_can_handle_non_renaming(self):
         b = self.browser
@@ -371,8 +371,8 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        filename = b.getControl(name='cur_name[0]').value
-        b.getControl(name='name[0]').value = filename
+        filename = b.getControl(name='tmp_name[0]').value
+        b.getControl(name='target_name[0]').value = filename
         b.getForm(name='edit-images').submit()
         assert zeit.cms.interfaces.ICMSContent(f'http://xml.zeit.de/online/2007/01/{filename}')
 
@@ -391,7 +391,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        self.assertTrue('required' in b.getControl(name='name[0]')._elem.attrs)
+        self.assertTrue('required' in b.getControl(name='target_name[0]')._elem.attrs)
 
     def test_editimages_shows_error_on_used_file_name(self):
         self.repository['online']['2007']['01']['Somalia-bild'] = (
@@ -411,9 +411,9 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        b.getControl(name='name[0]').value = 'Somalia-bild'
+        b.getControl(name='target_name[0]').value = 'Somalia-bild'
         b.getForm(name='edit-images').submit()
-        self.assertEqual(b.getControl(name='name[0]').value, 'Somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[0]').value, 'Somalia-bild')
         self.assertEllipsis(
             '...<span class="error">File name is already in use</span>...', b.contents
         )
@@ -439,11 +439,11 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
             ],
         )
         b.getForm(name='imageupload').submit()
-        b.getControl(name='name[0]').value = 'Somalia-bild'
-        b.getControl(name='name[1]').value = 'Somalia-bild'
+        b.getControl(name='target_name[0]').value = 'Somalia-bild'
+        b.getControl(name='target_name[1]').value = 'Somalia-bild'
         b.getForm(name='edit-images').submit()
-        self.assertEqual(b.getControl(name='name[0]').value, 'Somalia-bild')
-        self.assertEqual(b.getControl(name='name[1]').value, 'Somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[0]').value, 'Somalia-bild')
+        self.assertEqual(b.getControl(name='target_name[1]').value, 'Somalia-bild')
         self.assertEllipsis(
             '...<span class="error">File name is already in use</span>...', b.contents
         )

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -469,6 +469,27 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         assert len(images) == 0
         assert b.url.endswith('/repository/online/2007/01/')
 
+    def test_editimages_normalizes_user_input_file_name(self):
+        b = self.browser
+        b.open('/repository/online/2007/01/Somalia/@@upload-images')
+        file_input = b.getControl(name='files')
+        add_file_multi(
+            file_input,
+            [
+                (
+                    fixture_bytes('new-hampshire-450x200.jpg'),
+                    'new-hampshire-450x200.jpg',
+                    'image/jpg',
+                ),
+            ],
+        )
+        b.getForm(name='imageupload').submit()
+        b.getControl(name='target_name[0]').value = 'this is not normal(ized)'
+        b.getForm(name='edit-images').submit()
+        assert zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/online/2007/01/this-is-not-normal-ized'
+        )
+
 
 class AddCentralImageUploadTest(zeit.content.image.testing.SeleniumTestCase):
     def test_new_image_upload_is_present(self):

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -356,26 +356,6 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         assert b.getControl(name='target_name[1]').value == 'Somalia-bild-02'
         assert b.getControl(name='target_name[9]').value == 'Somalia-bild-10'
 
-    def test_editimages_can_handle_non_renaming(self):
-        b = self.browser
-        b.open('/repository/online/2007/01/Somalia/@@upload-images')
-        file_input = b.getControl(name='files')
-        add_file_multi(
-            file_input,
-            [
-                (
-                    fixture_bytes('new-hampshire-450x200.jpg'),
-                    'new-hampshire-450x200.jpg',
-                    'image/jpg',
-                ),
-            ],
-        )
-        b.getForm(name='imageupload').submit()
-        filename = b.getControl(name='tmp_name[0]').value
-        b.getControl(name='target_name[0]').value = filename
-        b.getForm(name='edit-images').submit()
-        assert zeit.cms.interfaces.ICMSContent(f'http://xml.zeit.de/online/2007/01/{filename}')
-
     def test_empty_file_name_raises_error(self):
         b = self.browser
         b.open('/repository/online/2007/01/Somalia/@@upload-images')


### PR DESCRIPTION
Da ist ein kleines Refactoring drin (Umbenennung von `cur_name` zu `tmp_name` und `name` zu `target_name`), und die Normalisierung zieht ein paar Änderungen in den Tests nach sich. Also besser commitweise angucken.

### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3R4cWI5MzU0b3NwcnFlcTJ3Z3BvOXFqNDBvOHMydmoyMmM1NWJteSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMAvRY92qUXj7dC/giphy.gif)