### PR TITLE
WCM-1056: medienservice preview feed with authentication

### DIFF
--- a/core/docs/changelog/WCM-1056.change
+++ b/core/docs/changelog/WCM-1056.change
@@ -1,0 +1,1 @@
+WCM-1056: Use medienservice preview_feed and authenticate via ops keycloak to do it

--- a/core/src/zeit/mediaservice/configure.zcml
+++ b/core/src/zeit/mediaservice/configure.zcml
@@ -10,4 +10,9 @@
    factory=".connection.from_product_config"
    />
 
+   <utility
+   provides="zeit.mediaservice.interfaces.IKeycloak"
+   factory=".connection.keycloak_from_product_config"
+   />
+
 </configure>

--- a/core/src/zeit/mediaservice/connection.py
+++ b/core/src/zeit/mediaservice/connection.py
@@ -11,14 +11,19 @@ class Connection:
         self.feed_url = feed_url
 
     def get_audio_infos(self, year, volume):
+        result = {}
+        keycloak = zope.component.getUtility(zeit.mediaservice.interfaces.IKeycloak)
+        auth_header = keycloak.authenticate()
+        if not auth_header:
+            return result
         response = requests.get(
             self.feed_url,
             params={'year': year, 'number': volume},
+            headers=auth_header,
             timeout=2,
         )
         data = response.json()
-        result = {}
-        volumes = data['dataFeedElement']
+        volumes = data.get('dataFeedElement', None)
         if not volumes:
             return result
         for part_of_volume in volumes[0]['item'].get('hasPart', []):
@@ -64,7 +69,7 @@ class Connection:
 @zope.interface.implementer(zeit.mediaservice.interfaces.IConnection)
 def from_product_config():
     conf = zeit.cms.config.package('zeit.mediaservice')
-    return Connection(conf['feed-url'])
+    return Connection(conf['preview-feed-url'])
 
 
 class Keycloak:
@@ -74,14 +79,19 @@ class Keycloak:
         self.discovery_url = discovery_url
 
     def authenticate(self):
-        url = f'{self.discovery_url}/protocol/openid-connect/token'
-        response = requests.post(
-            url,
-            data={'grant_type': 'client_credentials'},
-            auth=(self.client_id, self.client_secret),
-        )
-        if not response.ok:
-            response.raise_for_status()
+        try:
+            url = f'{self.discovery_url}/protocol/openid-connect/token'
+            response = requests.post(
+                url,
+                data={'grant_type': 'client_credentials'},
+                auth=(self.client_id, self.client_secret),
+            )
+            if not response.ok:
+                response.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            current_span = opentelemetry.trace.get_current_span()
+            current_span.record_exception(err)
+            return None
         return {'Authorization': 'Bearer ' + response.json()['access_token']}
 
 

--- a/core/src/zeit/mediaservice/connection.py
+++ b/core/src/zeit/mediaservice/connection.py
@@ -65,3 +65,31 @@ class Connection:
 def from_product_config():
     conf = zeit.cms.config.package('zeit.mediaservice')
     return Connection(conf['feed-url'])
+
+
+class Keycloak:
+    def __init__(self, client_id, client_secret, discovery_url):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.discovery_url = discovery_url
+
+    def authenticate(self):
+        url = f'{self.discovery_url}/protocol/openid-connect/token'
+        response = requests.post(
+            url,
+            data={'grant_type': 'client_credentials'},
+            auth=(self.client_id, self.client_secret),
+        )
+        if not response.ok:
+            response.raise_for_status()
+        return {'Authorization': 'Bearer ' + response.json()['access_token']}
+
+
+@zope.interface.implementer(zeit.mediaservice.interfaces.IKeycloak)
+def keycloak_from_product_config():
+    conf = zeit.cms.config.package('zeit.mediaservice')
+    return Keycloak(
+        conf['client-id'],
+        conf['client-secret'],
+        conf['discovery-url'],
+    )

--- a/core/src/zeit/mediaservice/ftesting.zcml
+++ b/core/src/zeit/mediaservice/ftesting.zcml
@@ -15,4 +15,9 @@
    factory="zeit.mediaservice.mock_connection.MockConnection"
    />
 
+<utility
+   provides="zeit.mediaservice.interfaces.IKeycloak"
+   factory="zeit.mediaservice.mock_connection.MockKeycloak"
+   />
+
 </configure>

--- a/core/src/zeit/mediaservice/interfaces.py
+++ b/core/src/zeit/mediaservice/interfaces.py
@@ -5,3 +5,8 @@ class IConnection(zope.interface.Interface):
     def get_audio_infos(self, year, volume):
         """Returns information about available premium audio MP3s for a given volume. The result
         is a dict with one entry per mediasync id. Each entry has `url` and `duration` fields."""
+
+
+class IKeycloak(zope.interface.Interface):
+    def authenticate(self):
+        """Authenticates vivi. Returns a authentication header with token if successful."""

--- a/core/src/zeit/mediaservice/mock_connection.py
+++ b/core/src/zeit/mediaservice/mock_connection.py
@@ -20,3 +20,9 @@ class MockConnection:
                 'duration': None,
             },
         }
+
+
+@zope.interface.implementer(zeit.mediaservice.interfaces.IKeycloak)
+class MockKeycloak:
+    def authenticate(self):
+        return {'Authorization': 'Bearer mock_token'}

--- a/core/src/zeit/mediaservice/testing.py
+++ b/core/src/zeit/mediaservice/testing.py
@@ -18,3 +18,4 @@ ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 
 class FunctionalTestCase(zeit.cms.testing.FunctionalTestCase):
     layer = ZOPE_LAYER
+    preview_feed_url = 'https://preview-feed-url.foo/issue'

--- a/core/src/zeit/mediaservice/testing.py
+++ b/core/src/zeit/mediaservice/testing.py
@@ -6,6 +6,9 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     {
         'medienservice-folder': 'premium',
         'audio-folder': 'audio',
+        'client-id': 'client-id',
+        'client-secret': 'client-secret',
+        'discovery-url': 'https://discovery-url.foo',
     },
     bases=zeit.content.article.testing.CONFIG_LAYER,
 )


### PR DESCRIPTION
### Checklist

- [x] [Documentation](https://github.com/ZeitOnline/vivi-deployment/pull/1425)
- [x] Changelog
- [x] Tests
- [ ] ~~Translations~~

### gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2NlbHZ5dDdlY2dwbHo5Z2pjbmthamQ0YzZvMHR3dTJnejhoaG8zeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0CfpudaxhO4CwAITNy/giphy.gif)