### PR TITLE
WCM-1089: use filename as fallback name if title is not specified in metadata

### DIFF
--- a/core/docs/changelog/WCM-1089.change
+++ b/core/docs/changelog/WCM-1089.change
@@ -1,0 +1,1 @@
+WCM-1089: use filename as fallback name if title is not specified in metadata

--- a/core/src/zeit/content/image/browser/imageupload.py
+++ b/core/src/zeit/content/image/browser/imageupload.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 import collections
+import os.path
 import urllib.parse
 import uuid
 
@@ -235,6 +236,9 @@ class EditForm(zeit.cms.browser.view.Base):
                 name_base = from_name
             elif meta['title'] is not None:
                 name_base = zeit.cms.interfaces.normalize_filename(meta['title'])
+            else:
+                filename = os.path.splitext(imggroup.master_image)[0]
+                name_base = zeit.cms.interfaces.normalize_filename(filename)
 
             if name_base:
                 name = name_provider.get(name_base)

--- a/core/src/zeit/content/image/browser/tests/test_imageupload.py
+++ b/core/src/zeit/content/image/browser/tests/test_imageupload.py
@@ -310,7 +310,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         )
         b = self.browser
         b.open('/repository/@@edit-images?files=group')
-        assert b.getControl(name='target_name[0]').value == ''
+        assert b.getControl(name='target_name[0]').value == 'master-image-bild'
 
     def test_editimages_correctly_names_image_without_xmp_after_image_with_xmp(self):
         b = self.browser
@@ -329,7 +329,7 @@ class ImageUploadBrowserTest(zeit.content.image.testing.BrowserTestCase):
         )
         b.getForm(name='imageupload').submit()
         assert b.getControl(name='target_name[0]').value == 'cycling-bel-renewi-bild'
-        assert b.getControl(name='target_name[1]').value == ''
+        assert b.getControl(name='target_name[1]').value == 'opernball-bild'
 
     def test_editimages_correctly_names_multiple_images_with_same_xmp(self):
         b = self.browser


### PR DESCRIPTION
### Checklist

- [ ] Documentation
- [x] Changelog
- [x] Tests
- [ ] Translations

### gif
![]()