### PR TITLE
WCM-1117: Enable lookup of speechbert checksum for animation objects

### DIFF
--- a/core/docs/changelog/WCM-1117.change
+++ b/core/docs/changelog/WCM-1117.change
@@ -1,0 +1,1 @@
+WCM-1117: Enable lookup of speechbert checksum for animation objects

--- a/core/src/zeit/content/animation/animation.py
+++ b/core/src/zeit/content/animation/animation.py
@@ -57,3 +57,9 @@ def animation_images(context):
 @grok.implementer(zeit.content.audio.interfaces.IAudioReferences)
 def animation_audios(context):
     return zeit.content.audio.interfaces.IAudioReferences(context.article)
+
+
+@grok.adapter(zeit.content.animation.interfaces.IAnimation)
+@grok.implementer(zeit.content.article.interfaces.ISpeechbertChecksum)
+def animation_checksum(context):
+    return zeit.content.article.interfaces.ISpeechbertChecksum(context.article)

--- a/core/src/zeit/content/animation/tests/test_animation.py
+++ b/core/src/zeit/content/animation/tests/test_animation.py
@@ -1,6 +1,11 @@
 import pytest
+import transaction
 
+from zeit.cms.checkout.helper import checked_out
 from zeit.cms.interfaces import ICMSContent
+from zeit.content.article.interfaces import ISpeechbertChecksum
+from zeit.content.audio.interfaces import IAudioReferences
+from zeit.content.image.interfaces import IImages
 import zeit.content.animation.animation
 import zeit.content.animation.testing
 import zeit.content.video.testing
@@ -35,3 +40,28 @@ class AnimationTest(zeit.content.animation.testing.FunctionalTestCase):
         animation = zeit.content.animation.animation.Animation()
         animation.article = article
         assert animation.genre == article.genre
+
+    def test_delegates_IImages_to_article(self):
+        image = ICMSContent('http://xml.zeit.de/image1')
+        with checked_out(self.repository['article']) as co:
+            IImages(co).image = image
+        transaction.commit()
+        animation = zeit.content.animation.animation.Animation()
+        animation.article = self.repository['article']
+        self.assertEqual(image, IImages(animation).image)
+
+    def test_delegates_IAudio_to_article(self):
+        self.repository['audio'] = zeit.content.audio.audio.Audio()
+        audio = self.repository['audio']
+        with checked_out(self.repository['article']) as co:
+            IAudioReferences(co).add(audio)
+        transaction.commit()
+        animation = zeit.content.animation.animation.Animation()
+        animation.article = self.repository['article']
+        self.assertEqual((audio,), IAudioReferences(animation).items)
+
+    def test_delegates_ISpeechbert_to_article(self):
+        ISpeechbertChecksum(self.repository['article']).checksum = 'foo'
+        animation = zeit.content.animation.animation.Animation()
+        animation.article = self.repository['article']
+        self.assertEqual('foo', ISpeechbertChecksum(animation).checksum)

--- a/core/src/zeit/content/article/article.py
+++ b/core/src/zeit/content/article/article.py
@@ -503,7 +503,7 @@ class Speechbert(zeit.cms.content.dav.DAVPropertiesAdapter):
         return not self.__eq__(other)
 
     def __str__(self):
-        return self.checksum
+        return self.checksum or ''
 
 
 @grok.subscribe(


### PR DESCRIPTION
### Checklist

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
- [x] ~Translations~