### PR TITLE
WCM-1097: vivi-Pakete Tests auf SQL-Connector umstellen

### DIFF
--- a/core/src/zeit/addcentral/testing.py
+++ b/core/src/zeit/addcentral/testing.py
@@ -2,7 +2,9 @@ import zeit.cms.testing
 import zeit.content.image.testing
 
 
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(bases=zeit.content.image.testing.CONFIG_LAYER)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
+    bases=zeit.content.image.testing.CONFIG_LAYER, features=['zeit.connector.sql.zope']
+)
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 WSGI_LAYER = zeit.cms.testing.WSGILayer(ZOPE_LAYER)
 HTTP_LAYER = zeit.cms.testing.WSGIServerLayer(WSGI_LAYER)

--- a/core/src/zeit/authentication/testing.py
+++ b/core/src/zeit/authentication/testing.py
@@ -13,7 +13,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     },
     bases=zeit.cms.testing.CONFIG_LAYER,
 )
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER, features=['zeit.connector.sql.zope'])
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 
 

--- a/core/src/zeit/brightcove/testing.py
+++ b/core/src/zeit/brightcove/testing.py
@@ -38,7 +38,9 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     patches={'zeit.cms': {'task-queue-brightcove': 'brightcove'}},
     bases=zeit.content.video.testing.CONFIG_LAYER,
 )
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer((CONFIG_LAYER, MOCK_API_LAYER))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
+    (CONFIG_LAYER, MOCK_API_LAYER), features=['zeit.connector.sql.zope']
+)
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 WSGI_LAYER = zeit.cms.testing.WSGILayer(ZOPE_LAYER)
 HTTP_STATIC_LAYER = gocept.httpserverlayer.static.Layer(name='HTTPStaticLayer', bases=(WSGI_LAYER,))

--- a/core/src/zeit/brightcove/tests/test_convert.py
+++ b/core/src/zeit/brightcove/tests/test_convert.py
@@ -95,13 +95,9 @@ class VideoTest(zeit.brightcove.testing.FunctionalTestCase, zeit.cms.tagging.tes
     def test_converts_related(self):
         cms = CMSVideo()
         related = zeit.cms.related.interfaces.IRelatedContent(cms)
-        related.related = (
-            zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/eta-zapatero'),
-        )
+        related.related = (zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/testcontent'),)
         bc = BCVideo.from_cms(cms)
-        self.assertEqual(
-            'http://xml.zeit.de/online/2007/01/eta-zapatero', bc.data['custom_fields']['ref_link1']
-        )
+        self.assertEqual('http://xml.zeit.de/testcontent', bc.data['custom_fields']['ref_link1'])
 
     def test_converts_advertisement(self):
         cms = CMSVideo()
@@ -147,7 +143,7 @@ class VideoTest(zeit.brightcove.testing.FunctionalTestCase, zeit.cms.tagging.tes
                     sep=zeit.cms.tagging.tag.Tag.SEPARATOR
                 ),
                 'produkt-id': 'TEST',
-                'ref_link1': 'http://xml.zeit.de/online/2007/01/eta-zapatero',
+                'ref_link1': 'http://xml.zeit.de/testcontent',
                 'serie': 'Chefsache',
             },
             'images': {'poster': {'src': 'http://example.com/still'}},
@@ -172,7 +168,7 @@ class VideoTest(zeit.brightcove.testing.FunctionalTestCase, zeit.cms.tagging.tes
         self.assertEqual('TEST', cms.product.id)
         self.assertEqual(True, cms.has_advertisement)
         self.assertEqual(
-            (zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/online/2007/01/eta-zapatero'),),
+            (zeit.cms.interfaces.ICMSContent('http://xml.zeit.de/testcontent'),),
             zeit.cms.related.interfaces.IRelatedContent(cms).related,
         )
         self.assertEqual('Chefsache', cms.serie.serienname)
@@ -182,11 +178,11 @@ class VideoTest(zeit.brightcove.testing.FunctionalTestCase, zeit.cms.tagging.tes
         with mock.patch('zeit.brightcove.connection.CMSAPI.get_video') as get:
             with mock.patch('zeit.brightcove.resolve.query_video_id') as query:
                 get.return_value = None
-                query.return_value = 'http://xml.zeit.de/online/2007/01/Somalia'
+                query.return_value = 'http://xml.zeit.de/testcontent'
                 bc = BCVideo.find_by_id('nonexistent')
         self.assertIsInstance(bc, zeit.brightcove.convert.DeletedVideo)
-        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia', bc.uniqueId)
-        self.assertEqual('http://xml.zeit.de/online/2007/01', bc.__parent__.uniqueId)
+        self.assertEqual('http://xml.zeit.de/testcontent', bc.uniqueId)
+        self.assertEqual('http://xml.zeit.de/', bc.__parent__.uniqueId)
 
     def test_missing_values_use_field_default(self):
         bc = BCVideo()

--- a/core/src/zeit/brightcove/tests/test_resolve.py
+++ b/core/src/zeit/brightcove/tests/test_resolve.py
@@ -7,7 +7,7 @@ import zeit.brightcove.testing
 
 class VideoIdResolverTest(zeit.brightcove.testing.FunctionalTestCase):
     def test_video_id_should_be_resolved_to_unique_id(self):
-        with mock.patch('zeit.connector.mock.Connector.search') as search:
+        with mock.patch('zeit.connector.postgresql.Connector.search') as search:
             search.return_value = iter((('http://xml.zeit.de/video/2010-03/1234',),))
             self.assertEqual(
                 'http://xml.zeit.de/video/2010-03/1234',
@@ -21,7 +21,7 @@ class VideoIdResolverTest(zeit.brightcove.testing.FunctionalTestCase):
 
     def test_should_raise_and_warn_if_multiple_objects_are_found(self):
         log = logging.getLogger('zeit.brightcove.resolve')
-        with mock.patch('zeit.connector.mock.Connector.search') as search:
+        with mock.patch('zeit.connector.postgresql.Connector.search') as search:
             with mock.patch.object(log, 'warning') as log_warning:
                 search.return_value = iter(
                     (

--- a/core/src/zeit/brightcove/tests/test_update.py
+++ b/core/src/zeit/brightcove/tests/test_update.py
@@ -323,6 +323,7 @@ class ExportTest(zeit.brightcove.testing.FunctionalTestCase):
             self.repository['myvid'], semantic_change=True
         ) as co:
             co.title = 'local change'
+            transaction.commit()
         transaction.commit()
         self.assertEqual(1, self.request.call_count)
         self.assertEqual('local change', self.request.call_args[1]['body']['name'])

--- a/core/src/zeit/cmp/testing.py
+++ b/core/src/zeit/cmp/testing.py
@@ -10,7 +10,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     },
     bases=zeit.cms.testing.CONFIG_LAYER,
 )
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER, features=['zeit.connector.sql.zope'])
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 
 

--- a/core/src/zeit/crop/testing.py
+++ b/core/src/zeit/crop/testing.py
@@ -13,7 +13,7 @@ CONFIG_LAYER = zeit.cms.testing.ProductConfigLayer(
     },
     bases=zeit.content.image.testing.CONFIG_LAYER,
 )
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER)
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(CONFIG_LAYER, features=['zeit.connector.sql.zope'])
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 WSGI_LAYER = zeit.cms.testing.WSGILayer(ZOPE_LAYER)
 

--- a/core/src/zeit/push/browser/tests/test_form.py
+++ b/core/src/zeit/push/browser/tests/test_form.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.keys import Keys
 
 import zeit.cms.workingcopy.interfaces
+import zeit.content.image.testing
 import zeit.push.interfaces
 import zeit.push.testing
 import zeit.push.workflow
@@ -109,14 +110,15 @@ class SocialFormTest(zeit.push.testing.BrowserTestCase):
         self.assertEqual('mobile', b.getControl('Mobile text').value)
 
     def test_stores_mobile_image(self):
+        zeit.content.image.testing.create_image_group()
         self.open_form()
         b = self.browser
-        b.getControl('Mobile image').value = 'http://xml.zeit.de/2007/03/group'
+        b.getControl('Mobile image').value = 'http://xml.zeit.de/group'
         b.getControl('Apply').click()
         article = self.get_article()
         push = zeit.push.interfaces.IPushMessages(article)
         service = push.get(type='mobile')
-        self.assertEqual('http://xml.zeit.de/2007/03/group', service['image'])
+        self.assertEqual('http://xml.zeit.de/group', service['image'])
 
         self.open_form()
         b.getControl('Mobile image').value = ''

--- a/core/src/zeit/push/testing.py
+++ b/core/src/zeit/push/testing.py
@@ -54,7 +54,9 @@ class ArticleConfigLayer(zeit.cms.testing.ProductConfigLayer):
 
 
 ARTICLE_CONFIG_LAYER = ArticleConfigLayer({}, package='zeit.content.article')
-ZCML_LAYER = zeit.cms.testing.ZCMLLayer((CONFIG_LAYER, ARTICLE_CONFIG_LAYER))
+ZCML_LAYER = zeit.cms.testing.ZCMLLayer(
+    (CONFIG_LAYER, ARTICLE_CONFIG_LAYER), features=['zeit.connector.sql.zope']
+)
 ZOPE_LAYER = zeit.cms.testing.ZopeLayer(ZCML_LAYER)
 
 

--- a/core/src/zeit/push/tests/test_banner.py
+++ b/core/src/zeit/push/tests/test_banner.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import lxml.etree
+import transaction
 import zope.component
 import zope.security.management
 
@@ -22,11 +23,13 @@ class BannerPublisherTest(zeit.push.testing.TestCase):
 
     def test_banner_xml_is_updated_on_push(self):
         self.publisher.send('foo', 'http://xml.zeit.de/foo')
+        transaction.commit()
         banner = self.repository['banner']
         self.assertIn('http://xml.zeit.de/foo', zeit.cms.testing.xmltotext(banner.xml))
 
     def test_banner_utility_is_updated_on_push(self):
         self.publisher.send('foo', 'http://xml.zeit.de/foo')
+        transaction.commit()
         banner = zope.component.getUtility(zeit.push.interfaces.IBanner)
         self.assertEqual('http://xml.zeit.de/foo', banner.article_id)
         self.assertEqual(self.repository['foo'], zeit.push.banner.get_breaking_news_article())

--- a/core/src/zeit/push/tests/test_urbanairship.py
+++ b/core/src/zeit/push/tests/test_urbanairship.py
@@ -1,3 +1,4 @@
+import transaction
 import zope.component
 import zope.event
 
@@ -82,9 +83,11 @@ class MessageTest(zeit.push.testing.TestCase):
     def test_changes_to_template_are_applied_immediately(self):
         message = zeit.push.urbanairship.Message(self.repository['testcontent'])
         self.create_payload_template('{"messages": {"one": 1}}', 'foo.json')
+        transaction.commit()
         message.config['payload_template'] = 'foo.json'
         self.assertEqual({'one': 1}, message.render())
         self.create_payload_template('{"messages": {"two": 1}}', 'foo.json')
+        transaction.commit()
         self.assertEqual({'two': 1}, message.render())
 
     def test_payload_loads_jinja_payload_variables(self):
@@ -132,10 +135,11 @@ class ChannelsTest(zeit.push.testing.TestCase):
     def test_template_sets_content_channels(self):
         with zeit.cms.checkout.helper.checked_out(self.content) as co:
             co.channels = (('Politik', None),)
+        transaction.commit()
         with zeit.cms.checkout.helper.checked_out(self.content) as co:
             push = zeit.push.interfaces.IPushMessages(co)
             push.message_config = (self.message_config('coffee'),)
-
+        self.content = self.repository['content']
         self.assertIn(('Push', 'coffee'), self.content.channels)
         self.assertIn(('Politik', None), self.content.channels)
 


### PR DESCRIPTION
### Checklist

- [ ] ~~Documentation~~
- [ ] ~~Changelog~~
- [x] Tests
- [ ] ~~Translations~~

### gif
![]()